### PR TITLE
Fixed the PHPUnit bootstrap to avoid using a deprecated file

### DIFF
--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -6,7 +6,7 @@ function includeIfExists($file) {
     }
 }
 
-if ((!$loader = includeIfExists(__DIR__.'/../vendor/.composer/autoload.php')) && (!$loader = includeIfExists(__DIR__.'/../../../../../.composer/autoload.php'))) {
+if ((!$loader = includeIfExists(__DIR__.'/../vendor/autoload.php')) && (!$loader = includeIfExists(__DIR__.'/../../../../../autoload.php'))) {
     die('You must set up the project dependencies, run the following commands:'.PHP_EOL.
         'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
         'php composer.phar install'.PHP_EOL);


### PR DESCRIPTION
The old composer autoload file triggers a E_USER_DEPRECATED error now. Due to its error reporting level set to all, PHPUnit will fail before starting the testsuite.
