### PR TITLE
2.0

### DIFF
--- a/Extractor/ApiDocExtractor.php
+++ b/Extractor/ApiDocExtractor.php
@@ -200,7 +200,7 @@ class ApiDocExtractor
             }
         }
 
-        $route->addOptions(array('_paramDocs' => $paramDocs));
+        $route->setOptions(array_merge($route->getOptions(), array('_paramDocs' => $paramDocs)));
 
         return array('annotation' => $annotation, 'route' => $route);
     }

--- a/Form/Extension/DescriptionFieldTypeExtension.php
+++ b/Form/Extension/DescriptionFieldTypeExtension.php
@@ -37,7 +37,7 @@ class DescriptionFieldTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions()
+    public function getDefaultOptions(array $options)
     {
         return array(
             'description' => '',

--- a/Parser/FormTypeParser.php
+++ b/Parser/FormTypeParser.php
@@ -54,8 +54,12 @@ class FormTypeParser
     {
         $builder = $this->formFactory->createBuilder($type);
 
+        $refl = new \ReflectionProperty('Symfony\Component\Form\FormBuilder', 'children');
+        $refl->setAccessible(true);
+        $children = $refl->getValue($builder);
+
         $parameters = array();
-        foreach ($builder->all() as $name => $child) {
+        foreach ($children as $name => $child) {
             if ($child instanceof FormBuilder) {
                 $childBuilder = $child;
             } else {

--- a/Tests/Fixtures/Form/TestType.php
+++ b/Tests/Fixtures/Form/TestType.php
@@ -29,7 +29,7 @@ class TestType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions()
+    public function getDefaultOptions(array $options)
     {
         return array(
             'data_class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\Test',
@@ -38,6 +38,6 @@ class TestType extends AbstractType
 
     public function getName()
     {
-        return '';
+        return 'foobar';
     }
 }

--- a/Tests/Fixtures/app/config/default.yml
+++ b/Tests/Fixtures/app/config/default.yml
@@ -7,11 +7,11 @@ framework:
     validation:    { enabled: true, enable_annotations: true }
     form: ~
     test: ~
-    default_locale: en
     session:
+        default_locale: en
         auto_start:     true
-        storage_id:     session.storage.mock_file
-    profiler: { only_exceptions: false }
+        storage_id:     session.storage.filesystem
+    profiler: false
     templating:    { engines: ['twig'] }
 
 # Twig Configuration

--- a/Tests/WebTestCase.php
+++ b/Tests/WebTestCase.php
@@ -12,7 +12,7 @@
 namespace Nelmio\ApiDocBundle\Tests;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
-use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Util\Filesystem;
 use Symfony\Component\HttpKernel\Kernel;
 
 abstract class WebTestCase extends BaseWebTestCase

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -12,3 +12,7 @@ if ((!$loader = includeIfExists(__DIR__.'/../vendor/autoload.php')) && (!$loader
         'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
         'php composer.phar install'.PHP_EOL);
 }
+
+if (class_exists('Doctrine\Common\Annotations\AnnotationRegistry')) {
+    \Doctrine\Common\Annotations\AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
+}

--- a/composer.json
+++ b/composer.json
@@ -15,15 +15,16 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "2.1.*",
-        "symfony/twig-bundle": "2.1.*",
-        "symfony/form": "2.1.*"
+        "symfony/symfony": "2.0.*",
+        "symfony/framework-bundle": "2.0.*",
+        "symfony/twig-bundle": "2.0.*",
+        "symfony/form": "2.0.*"
     },
     "require-dev": {
-        "symfony/css-selector": "2.1.*",
-        "symfony/browser-kit": "2.1.*",
-        "symfony/validator": "2.1.*",
-        "symfony/yaml": "2.1.*"
+        "symfony/css-selector": "2.0.*",
+        "symfony/browser-kit": "2.0.*",
+        "symfony/validator": "2.0.*",
+        "symfony/yaml": "2.0.*"
     },
     "autoload": {
         "psr-0": { "Nelmio\\ApiDocBundle": "" }


### PR DESCRIPTION
**Don't merge this into master**

This creates a branch compatible with Symfony 2.0. I will let you figure its name according to the version you want to give it for composer (2.0 is a bad name IMO as starting to version a bundle from 2.0 seems a crappy idea).
If you want to see the diff concerned by the backport, it is [here](https://github.com/stof/NelmioApiDocBundle/compare/fix_form_parser...2.0)

It is built on top of #15 (so that you don't have to port CS fixes and the bug fix)
