### PR TITLE
Fix: buildForm() and buildView signatures

### DIFF
--- a/Form/Extension/DescriptionFieldTypeExtension.php
+++ b/Form/Extension/DescriptionFieldTypeExtension.php
@@ -12,16 +12,16 @@
 namespace Nelmio\ApiDocBundle\Form\Extension;
 
 use Symfony\Component\Form\AbstractTypeExtension;
-use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\FormViewInterface;
 
 class DescriptionFieldTypeExtension extends AbstractTypeExtension
 {
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilder $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->setAttribute('description', $options['description']);
     }
@@ -29,7 +29,7 @@ class DescriptionFieldTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form)
+    public function buildView(FormViewInterface $view, FormInterface $form, array $options)
     {
         $view->set('description', $form->getAttribute('description'));
     }


### PR DESCRIPTION
Their signatures changed with the recent modifications done in symfony's
form component.
