### PR TITLE
Remove .{_format} from routes used for resource grouping

### DIFF
--- a/Extractor/ApiDocExtractor.php
+++ b/Extractor/ApiDocExtractor.php
@@ -68,7 +68,8 @@ class ApiDocExtractor
             if ($method = $this->getReflectionMethod($route->getDefault('_controller'))) {
                 if ($annotation = $this->reader->getMethodAnnotation($method, self::ANNOTATION_CLASS)) {
                     if ($annotation->isResource()) {
-                        $resources[] = $route->getPattern();
+                        // remove format from routes used for resource grouping
+                        $resources[] = str_replace('.{_format}', '', $route->getPattern());
                     }
 
                     $array[] = array('annotation' => $this->extractData($annotation, $route, $method));

--- a/Tests/EventListener/RequestListenerTest.php
+++ b/Tests/EventListener/RequestListenerTest.php
@@ -20,7 +20,7 @@ class RequestListenerTest extends WebTestCase
         $client = $this->createClient();
 
         $crawler = $client->request('GET', '/tests?_doc=1');
-        $this->assertEquals('/tests', trim($crawler->filter(".operation .path:contains('/tests')")->text()), 'Event listener should capture ?_doc=1 requests');
+        $this->assertEquals('/tests.{_format}', trim($crawler->filter(".operation .path:contains('/tests')")->text()), 'Event listener should capture ?_doc=1 requests');
 
         $client->request('GET', '/tests');
         $this->assertEquals('tests', $client->getResponse()->getContent(), 'Event listener should let normal requests through');

--- a/Tests/Fixtures/app/config/routing.yml
+++ b/Tests/Fixtures/app/config/routing.yml
@@ -1,11 +1,11 @@
 test_route_1:
-    pattern:  /tests
+    pattern:  /tests.{_format}
     defaults: { _controller: NelmioApiDocTestBundle:Test:index, _format: json }
     requirements:
         _method: GET
 
 test_route_2:
-    pattern:  /tests
+    pattern:  /tests.{_format}
     defaults: { _controller: NelmioApiDocTestBundle:Test:postTest, _format: json }
     requirements:
         _method: POST
@@ -41,13 +41,13 @@ test_route_8:
         _method: GET
 
 test_service_route_1:
-    pattern:  /tests
+    pattern:  /tests.{_format}
     defaults: { _controller: nemlio.test.controller:indexAction, _format: json }
     requirements:
         _method: GET
 
 test_service_route_2:
-    pattern:  /tests
+    pattern:  /tests.{_format}
     defaults: { _controller: nemlio.test.controller:postTestAction, _format: json }
     requirements:
         _method: POST

--- a/Tests/Formatter/MarkdownFormatterTest.php
+++ b/Tests/Formatter/MarkdownFormatterTest.php
@@ -26,9 +26,14 @@ class MarkdownFormatterTest extends WebTestCase
         $expected = <<<MARKDOWN
 # /tests #
 
-### `GET` /tests ###
+### `GET` /tests.{_format} ###
 
 _index action_
+
+#### Requirements ####
+
+**_format**
+
 
 #### Filters ####
 
@@ -42,9 +47,14 @@ b:
   * Arbitrary: ["arg1","arg2"]
 
 
-### `GET` /tests ###
+### `GET` /tests.{_format} ###
 
 _index action_
+
+#### Requirements ####
+
+**_format**
+
 
 #### Filters ####
 
@@ -58,9 +68,14 @@ b:
   * Arbitrary: ["arg1","arg2"]
 
 
-### `POST` /tests ###
+### `POST` /tests.{_format} ###
 
 _create test_
+
+#### Requirements ####
+
+**_format**
+
 
 #### Parameters ####
 
@@ -81,9 +96,14 @@ c:
   * required: true
 
 
-### `POST` /tests ###
+### `POST` /tests.{_format} ###
 
 _create test_
+
+#### Requirements ####
+
+**_format**
+
 
 #### Parameters ####
 
@@ -183,9 +203,14 @@ MARKDOWN;
         $result     = $container->get('nelmio_api_doc.formatter.markdown_formatter')->formatOne($annotation);
 
         $expected = <<<MARKDOWN
-### `GET` /tests ###
+### `GET` /tests.{_format} ###
 
 _index action_
+
+#### Requirements ####
+
+**_format**
+
 
 #### Filters ####
 

--- a/Tests/Formatter/SimpleFormatterTest.php
+++ b/Tests/Formatter/SimpleFormatterTest.php
@@ -29,7 +29,7 @@ class SimpleFormatterTest extends WebTestCase
                 0 =>
                 array(
                     'method' => 'GET',
-                    'uri' => '/tests',
+                    'uri' => '/tests.{_format}',
                     'filters' =>
                     array(
                         'a' =>
@@ -47,11 +47,14 @@ class SimpleFormatterTest extends WebTestCase
                         ),
                     ),
                     'description' => 'index action',
+                    'requirements' => array(
+                        '_format' => array('type' => '', 'description' => '', 'requirement' => ''),
+                    ),
                 ),
                 1 =>
                 array(
                     'method' => 'GET',
-                    'uri' => '/tests',
+                    'uri' => '/tests.{_format}',
                     'filters' =>
                     array(
                         'a' =>
@@ -69,11 +72,14 @@ class SimpleFormatterTest extends WebTestCase
                         ),
                     ),
                     'description' => 'index action',
+                    'requirements' => array(
+                        '_format' => array('type' => '', 'description' => '', 'requirement' => ''),
+                    ),
                 ),
                 2 =>
                 array(
                     'method' => 'POST',
-                    'uri' => '/tests',
+                    'uri' => '/tests.{_format}',
                     'parameters' =>
                     array(
                         'a' =>
@@ -99,11 +105,14 @@ class SimpleFormatterTest extends WebTestCase
                         ),
                     ),
                     'description' => 'create test',
+                    'requirements' => array(
+                        '_format' => array('type' => '', 'description' => '', 'requirement' => ''),
+                    ),
                 ),
                 3 =>
                 array(
                     'method' => 'POST',
-                    'uri' => '/tests',
+                    'uri' => '/tests.{_format}',
                     'parameters' =>
                     array(
                         'a' =>
@@ -129,6 +138,9 @@ class SimpleFormatterTest extends WebTestCase
                         ),
                     ),
                     'description' => 'create test',
+                    'requirements' => array(
+                        '_format' => array('type' => '', 'description' => '', 'requirement' => ''),
+                    ),
                 ),
             ),
             'others' =>
@@ -211,7 +223,7 @@ class SimpleFormatterTest extends WebTestCase
 
         $expected = array(
             'method' => 'GET',
-            'uri' => '/tests',
+            'uri' => '/tests.{_format}',
             'filters' => array(
                 'a' => array(
                     'dataType' => 'integer',
@@ -224,7 +236,10 @@ class SimpleFormatterTest extends WebTestCase
                     ),
                 ),
             ),
-            'description' => 'index action'
+            'description' => 'index action',
+            'requirements' => array(
+                '_format' => array('type' => '', 'description' => '', 'requirement' => ''),
+            ),
         );
 
         $this->assertEquals($expected, $result);


### PR DESCRIPTION
Grouping of resources didn't work if the routes contained `.{_format}` at the end. The FOSRestBundle adds the format parameter by default.

[![Build Status](https://secure.travis-ci.org/asm89/NelmioApiDocBundle.png?branch=master)](http://travis-ci.org/asm89/NelmioApiDocBundle)
