### PR TITLE
Fixed rendering issue when used with FOSRestBundle

### DIFF
--- a/Controller/ApiDocController.php
+++ b/Controller/ApiDocController.php
@@ -21,6 +21,6 @@ class ApiDocController extends Controller
         $extractedDoc = $this->get('nelmio_api_doc.extractor.api_doc_extractor')->all();
         $htmlContent  = $this->get('nelmio_api_doc.formatter.html_formatter')->format($extractedDoc);
 
-        return new Response($htmlContent);
+        return new Response($htmlContent, 200, array('Content-Type' => 'text/html'));
     }
 }


### PR DESCRIPTION
When using FOSRestBundle with following config:

```
fos_rest:
  format_listener:
    default_priorities:
        - json
        - xml
    fallback_format: xml
```

NelmioApiDocBundle will return the documentation with xml content type, and thus not viewable in a browser (at least not on my chrome browser).

Forcing the response to html in the ApiDocController fixes this.
