### PR TITLE
fixed JmsMetadataParser::supports

### DIFF
--- a/Parser/JmsMetadataParser.php
+++ b/Parser/JmsMetadataParser.php
@@ -32,10 +32,13 @@ class JmsMetadataParser implements ParserInterface
      */
     public function supports($input)
     {
-        if ($meta = $this->factory->getMetadataForClass($input)) {
-            return true;
+        try {
+            if ($meta = $this->factory->getMetadataForClass($input)) {
+                return true;
+            }            
+        } catch (\ReflectionException $e) {
         }
-
+        
         return false;
     }
 


### PR DESCRIPTION
`JmsMetadataParser` may throw exceptions if it tries to check for support against something that is not an available class name - which could easily happen if it checks before the `FormTypeParser` against something like the string `test_form_type`.

This fixes that to make sure exceptions are caught in `supports()` and false is returned properly
