### PR TITLE
Add a getRoutes method and change property privacy

### DIFF
--- a/Extractor/ApiDocExtractor.php
+++ b/Extractor/ApiDocExtractor.php
@@ -28,28 +28,40 @@ class ApiDocExtractor
     /**
      * @var \Symfony\Component\DependencyInjection\ContainerInterface
      */
-    private $container;
+    protected $container;
 
     /**
      * @var \Symfony\Component\Routing\RouterInterface
      */
-    private $router;
+    protected $router;
 
     /**
      * @var \Doctrine\Common\Annotations\Reader
      */
-    private $reader;
+    protected $reader;
 
     /**
      * @var array \Nelmio\ApiDocBundle\Parser\ParserInterface
      */
-    private $parsers = array();
+    protected $parsers = array();
 
     public function __construct(ContainerInterface $container, RouterInterface $router, Reader $reader)
     {
         $this->container = $container;
         $this->router    = $router;
         $this->reader    = $reader;
+    }
+
+    /**
+     * Return a list of route to inspect for ApiDoc annotation
+     * You can extend this method if you don't want all the routes
+     * to be included.
+     *
+     * @return array of Route
+     */
+    public function getRoutes()
+    {
+        return $this->router->getRouteCollection()->all();
     }
 
     /**
@@ -64,7 +76,7 @@ class ApiDocExtractor
         $array = array();
         $resources = array();
 
-        foreach ($this->router->getRouteCollection()->all() as $route) {
+        foreach ($this->getRoutes() as $route) {
             if ($method = $this->getReflectionMethod($route->getDefault('_controller'))) {
                 if ($annotation = $this->reader->getMethodAnnotation($method, self::ANNOTATION_CLASS)) {
                     if ($annotation->isResource()) {


### PR DESCRIPTION
Overwriting this class for route filtering is not possible / easy 
at the moment. This commit allow to use our own getRoutes method.

For example I may be in a case where I want to hide some routes (old API, or other external factor) or add one (a fake one you want in the doc but not in the code). 

Overwriting this class is simple: 

```
parameters:
    nelmio_api_doc.extractor.api_doc_extractor.class: Toto\Bundle\AdminBundle\Extractor\MyCleanedExtractor
```

And then simply extend `ApiDocExtractor::getRoutes()` :metal:
