### PR TITLE
[WIP] Add WADL support

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -21,7 +21,7 @@ class DumpCommand extends ContainerAwareCommand
     /**
      * @var array
      */
-    protected $availableFormats = array('markdown', 'json', 'html');
+    protected $availableFormats = array('markdown', 'json', 'html', 'wadl');
 
     protected function configure()
     {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,6 +23,7 @@ class Configuration implements ConfigurationInterface
             ->root('nelmio_api_doc')
             ->children()
                 ->scalarNode('name')->defaultValue('API documentation')->end()
+                ->scalarNode('base_url')->defaultValue('http://example.com/')->end()
                 ->arrayNode('request_listener')
                     ->beforeNormalization()
                         ->ifTrue(function ($a) { return is_bool($a); })

--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -29,6 +29,7 @@ class NelmioApiDocExtension extends Extension
         $config = $processor->processConfiguration($configuration, $configs);
 
         $container->setParameter('nelmio_api_doc.api_name', $config['name']);
+        $container->setParameter('nelmio_api_doc.base_url', $config['base_url']);
         $container->setParameter('nelmio_api_doc.sandbox.enabled',  $config['sandbox']['enabled']);
         $container->setParameter('nelmio_api_doc.sandbox.endpoint', $config['sandbox']['endpoint']);
         $container->setParameter('nelmio_api_doc.sandbox.request_format.method', $config['sandbox']['request_format']['method']);

--- a/Formatter/HtmlFormatter.php
+++ b/Formatter/HtmlFormatter.php
@@ -21,19 +21,19 @@ class HtmlFormatter extends AbstractFormatter
     protected $apiName;
 
     /**
-     * @var string
-     */
-    protected $endpoint;
-
-    /**
-     * @var string
-     */
-    protected $defaultRequestFormat;
-
-    /**
      * @var EngineInterface
      */
     protected $engine;
+
+    /**
+     * @var string
+     */
+    private $endpoint;
+
+    /**
+     * @var string
+     */
+    private $defaultRequestFormat;
 
     /**
      * @var boolean

--- a/Formatter/WadlFormatter.php
+++ b/Formatter/WadlFormatter.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Formatter;
+
+class WadlFormatter extends HtmlFormatter
+{
+    private $baseUrl;
+
+    public function setBaseUrl($baseUrl)
+    {
+        $this->baseUrl = $baseUrl;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function renderOne(array $data)
+    {
+        return $this->engine->render('NelmioApiDocBundle::resource.wadl.twig', array(
+            'data' => $data,
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function render(array $collection)
+    {
+        return $this->engine->render('NelmioApiDocBundle::resources.wadl.twig', array(
+            'resources' => $collection,
+            'apiName'   => $this->apiName,
+            'baseUrl'   => $this->baseUrl,
+        ));
+    }
+}

--- a/README.md
+++ b/README.md
@@ -220,6 +220,26 @@ input is used, so you can configure their priorities via container tags.  Here's
             tags:
                 - {name: nelmio_api_doc.extractor.parser, priority: 2}
 
+
+## Configuration Reference ##
+
+    nelmio_api_doc:
+        name:                 API documentation
+        base_url:             http://example.com/
+        request_listener:
+            enabled:              true
+            parameter:            _doc
+        sandbox:
+            enabled:              true
+            endpoint:             /app_dev.php
+            request_format:
+                method:               format_param
+                default_format:       json
+            authentication:
+                name:                 ~ # Required
+                delivery:             ~ # Required
+
+
 ## Credits ##
 
 The design is heavily inspired by the [swagger-ui](https://github.com/wordnik/swagger-ui) project.

--- a/Resources/config/formatters.xml
+++ b/Resources/config/formatters.xml
@@ -9,6 +9,7 @@
         <parameter key="nelmio_api_doc.formatter.markdown_formatter.class">Nelmio\ApiDocBundle\Formatter\MarkdownFormatter</parameter>
         <parameter key="nelmio_api_doc.formatter.simple_formatter.class">Nelmio\ApiDocBundle\Formatter\SimpleFormatter</parameter>
         <parameter key="nelmio_api_doc.formatter.html_formatter.class">Nelmio\ApiDocBundle\Formatter\HtmlFormatter</parameter>
+        <parameter key="nelmio_api_doc.formatter.wadl_formatter.class">Nelmio\ApiDocBundle\Formatter\WadlFormatter</parameter>
         <parameter key="nelmio_api_doc.sandbox.authentication">null</parameter>
     </parameters>
 
@@ -47,6 +48,17 @@
                 <argument>%nelmio_api_doc.sandbox.authentication%</argument>
             </call>
         </service>
+        <service id="nelmio_api_doc.formatter.wadl_formatter" class="%nelmio_api_doc.formatter.wadl_formatter.class%"
+            parent="nelmio_api_doc.formatter.abstract_formatter">
+            <call method="setTemplatingEngine">
+                <argument type="service" id="templating" />
+            </call>
+            <call method="setApiName">
+                <argument>%nelmio_api_doc.api_name%</argument>
+            </call>
+            <call method="setBaseUrl">
+                <argument>%nelmio_api_doc.base_url%</argument>
+            </call>
+        </service>
     </services>
-
 </container>

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,5 +1,5 @@
 nelmio_api_doc_index:
-    pattern: /
-    defaults: { _controller: NelmioApiDocBundle:ApiDoc:index }
+    pattern: /{_format}
+    defaults: { _controller: NelmioApiDocBundle:ApiDoc:index, _format: html }
     requirements:
         _method: GET

--- a/Resources/views/layout.wadl.twig
+++ b/Resources/views/layout.wadl.twig
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<application xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://wadl.dev.java.net/2009/02 wadl.xsd"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns="http://wadl.dev.java.net/2009/02">
+    <doc xml:lang="en" title="{{ apiName }}" />
+    {% block content %}{% endblock %}
+</application>

--- a/Resources/views/method.wadl.twig
+++ b/Resources/views/method.wadl.twig
@@ -1,0 +1,29 @@
+<method name="{{ data.method|upper }}">
+{% if data.description is defined %}
+    <doc xml:lang="en" title="{{ data.description }}" />
+{% endif %}
+{% if (data.filters is defined and data.filters is not empty) -%}
+    <request>
+    {% for name, infos in data.filters %}
+        <param name="{{ name }}" style="query" required="false"
+            {%- if infos.dataType is defined %} type="xsd:{{ infos.dataType }}" {% endif -%}
+            {%- if infos.default is defined %} default="{{ infos.default }}" {% endif -%}
+            {%- if infos.description is defined -%}>
+            <doc xml:lang="en" title="{{ infos.description }}" />
+        </param>
+            {%- else -%}
+        />
+            {%- endif -%}
+    {% endfor %}
+    </request>
+{%- endif -%}
+{% if data.statusCodes is defined and data.statusCodes is not empty -%}
+    {% for statusCode, description in data.statusCodes %}
+    <response status="{{ statusCode }}">
+    {% if description is not empty %}
+        <doc xml:lang="en" title="{{ description }}" />
+    {% endif %}
+    </response>
+    {% endfor %}
+{%- endif -%}
+</method>

--- a/Resources/views/resources.wadl.twig
+++ b/Resources/views/resources.wadl.twig
@@ -1,0 +1,43 @@
+{% extends "NelmioApiDocBundle::layout.wadl.twig" %}
+
+{% block content %}
+    <resources base="{{ baseUrl }}">
+    {% for resource, methods in resources %}
+        {%- set resourcePath = resource -%}
+        {%- set nested       = 0 -%}
+        <resource path="{{ resource }}">
+        {% for data in methods %}
+            {% if resourcePath != data.uri %}
+                {% if nested > 0 %}
+            </resource>
+                    {% set nested = nested - 1 %}
+                {% endif %}
+            <resource path="{{ data.uri }}">
+                {% if data.requirements is defined and data.requirements is not empty %}
+                    {% for name, infos in data.requirements %}
+                    <param name="{{ name }}" style="template"{% if infos.dataType %} type="xsd:{{ infos.dataType }}"{% endif %} />
+                    {% endfor %}
+                {% endif %}
+
+                {%- set resourcePath = data.uri -%}
+                {%- set nested       = nested + 1 -%}
+            {% endif %}
+
+            {%- include 'NelmioApiDocBundle::method.wadl.twig' -%}
+
+            {% if resourcePath != data.uri %}
+                {% for i in 0..nested %}
+        </resource>
+                    {% set nested = nested - 1 %}
+                {% endfor %}
+            {% endif %}
+        {% endfor %}
+        {% if resourcePath != resource %}
+            {% for i in 0..nested %}
+        </resource>
+                {% set nested = nested - 1 %}
+            {% endfor %}
+        {% endif %}
+    {% endfor %}
+    </resources>
+{% endblock content %}


### PR DESCRIPTION
This PR adds a [Web Application Description Language](http://www.w3.org/Submission/wadl/) formatter. It's the only language that describes REST services like WSDL for SOAP web services.

It becomes really useful when you want to generate clients, it's a common practice in Java world, and I think it can be great to promote this description language.

Should be mergeable once #98 has been accepted.
