### PR TITLE
Exception handling on unsupported fields types

### DIFF
--- a/Parser/FormTypeParser.php
+++ b/Parser/FormTypeParser.php
@@ -96,6 +96,11 @@ class FormTypeParser implements ParserInterface
             if ('' === $bestType) {
                 if ($type = $config->getType()) {
                     if ($type = $type->getInnerType()) {
+                        /**
+                         * TODO: Implement a better handling of unsupported types
+                         * This is just a temporary workaround for don't breaking docs page in case of unsupported types
+                         * like the entity type https://github.com/nelmio/NelmioApiDocBundle/issues/94
+                         */
                         try {
                             $subForm    = $this->formFactory->create($type);
                             $parameters = array_merge($parameters, $this->parseForm($subForm, $name));


### PR DESCRIPTION
Since the entity (and maybe others) form field type breaks the doc generations, I've added a try{} catch{} exception handler when you try to find a compatible field type in the formParser().

It's a workaround for issue https://github.com/nelmio/NelmioApiDocBundle/issues/94.

Later we can add a better support for unsupported types of fields.

Another way would have been to add the entity to the mapTypes mapping to a string.
