### PR TITLE
Add support for collection type in FormType Parser

### DIFF
--- a/Parser/FormTypeParser.php
+++ b/Parser/FormTypeParser.php
@@ -90,6 +90,8 @@ class FormTypeParser implements ParserInterface
             for ($type = $config->getType(); null !== $type; $type = $type->getParent()) {
                 if (isset($this->mapTypes[$type->getName()])) {
                     $bestType = $this->mapTypes[$type->getName()];
+                } elseif ('collection' === $type->getName() && isset($this->mapTypes[$config->getOption('type')])) {
+                    $bestType = sprintf('array of %ss', $this->mapTypes[$config->getOption('type')]);
                 }
             }
 


### PR DESCRIPTION
This PR adds support for 'collection' type (with simple subtype) in FormType. The rendering is the same as JMS parsed arrays.
