### PR TITLE
Add possibility to specifiy HTTP verb in annotations

### DIFF
--- a/Annotation/ApiDoc.php
+++ b/Annotation/ApiDoc.php
@@ -105,6 +105,14 @@ class ApiDoc
         if (isset($data['description'])) {
             $this->description = $data['description'];
         }
+		
+        if (isset($data['method'])) {
+		    if (!is_array($data['method'])) {
+			    throw new \InvalidArgumentException('The "method" element must be an array of HTTP verbs');
+			}
+			
+            $this->method = implode('|', $data['method']);
+        }
 
         if (isset($data['input'])) {
             $this->input = $data['input'];
@@ -238,7 +246,9 @@ class ApiDoc
     {
         $this->route  = $route;
         $this->uri    = $route->getPattern();
-        $this->method = $route->getRequirement('_method') ?: 'ANY';
+        if ($this->method === null) {
+            $this->method = $route->getRequirement('_method') ?: 'ANY';
+        }
     }
 
     /**


### PR DESCRIPTION
Add a "method" parameter to the ApiDoc annotation, allowing
to set the HTTP verb of the method.
Useful when you can't use Routing method requirement.
Uses the specified method in the annotation. If none, uses the
requirements of the route. If none, fallback to `'ANY'`
Example:

``` php
<?php
    /*
     * My actions full description
     *
     * @ApiDoc(
     *   method = "POST",
     *   description = "This is a description of your API method",
     *   statusCodes = {
     *      201 = "Returned when successful",
     *      405 = "Returned when HTTP verb isn't supported"
     * })
     *
     * @Route(
     *     name     = "my_route",
     *     pattern  = "/my/url",
     *     defaults = { "_format" = "json" }
     * )
     */
    public function myAction()
```
## Remark

No tests yet, as I can't install the vendors.

```
>php composer.phar update --dev --prefer-dist

Loading composer repositories with package information
Updating dependencies
Nothing to install or update
Loading composer repositories with package information
Updating dev dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for friendsofsymfony/rest-bundle dev-master -> satisfiable by friendsofsymfony/rest-bundle dev-master.
    - jms/serializer-bundle 0.9.0 conflicts with friendsofsymfony/rest-bundle dev-master.
    - Installation request for jms/serializer-bundle 0.9.* -> satisfiable by jms/serializer-bundle 0.9.0.
```
