### PR TITLE
Support multiple descriptions per status code

### DIFF
--- a/Annotation/ApiDoc.php
+++ b/Annotation/ApiDoc.php
@@ -126,7 +126,9 @@ class ApiDoc
         }
 
         if (isset($data['statusCodes'])) {
-            $this->statusCodes = $data['statusCodes'];
+            foreach ($data['statusCodes'] as $statusCode => $description) {
+                $this->addStatusCode($statusCode, $description);
+            }
         }
     }
 
@@ -137,6 +139,15 @@ class ApiDoc
     public function addFilter($name, array $filter)
     {
         $this->filters[$name] = $filter;
+    }
+
+    /**
+     * @param string $statusCode
+     * @param mixed  $description
+     */
+    public function addStatusCode($statusCode, $description)
+    {
+        $this->statusCodes[$statusCode] = !is_array($description) ? array($description) : $description;
     }
 
     /**

--- a/Resources/views/method.html.twig
+++ b/Resources/views/method.html.twig
@@ -136,24 +136,30 @@
                 </table>
             {% endif %}
 
-             {% if data.statusCodes is defined and data.statusCodes is not empty %}
-            <h4>Status Codes</h4>
-            <table class="fullwidth">
-                <thead>
+            {% if data.statusCodes is defined and data.statusCodes is not empty %}
+                <h4>Status Codes</h4>
+                <table class="fullwidth">
+                    <thead>
                     <tr>
                         <th>Status Code</th>
                         <th>Description</th>
                     </tr>
-                </thead>
-                <tbody>
-                    {% for status_code, description in data.statusCodes %}
-                    <tr>
-                        <td><a href="http://en.wikipedia.org/wiki/HTTP_{{ status_code }}" target="_blank">{{ status_code }}<a/></td>
-                        <td>{{ description }}</td>
-                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for status_code, descriptions in data.statusCodes %}
+                        <tr>
+                            <td><a href="http://en.wikipedia.org/wiki/HTTP_{{ status_code }}" target="_blank">{{ status_code }}<a/></td>
+                            <td>
+                                <ul>
+                                    {% for description in descriptions %}
+                                        <li>{{ description }}</li>
+                                    {%  endfor %}
+                                </ul>
+                            </td>
+                        </tr>
                     {% endfor %}
-                </tbody>
-            </table>
+                    </tbody>
+                </table>
             {% endif %}
 
             </div>

--- a/Tests/Annotation/ApiDocTest.php
+++ b/Tests/Annotation/ApiDocTest.php
@@ -174,13 +174,17 @@ class ApiDocTest extends TestCase
         $this->assertEquals($data['input'], $annot->getInput());
     }
 
-    public function testConstructWithHTTPResponseCodes()
+    public function testConstructWithStatusCodes()
     {
         $data = array(
             'description' => 'Heya',
             'statusCodes' => array(
                 200 => "Returned when successful",
-                403 => "Returned when the user is not authorized"
+                403 => "Returned when the user is not authorized",
+                404 => array(
+                    "Returned when the user is not found",
+                    "Returned when when something else is not found"
+                )
             )
         );
 
@@ -190,7 +194,7 @@ class ApiDocTest extends TestCase
         $this->assertTrue(is_array($array));
         $this->assertTrue(is_array($array['statusCodes']));
         foreach ($data['statusCodes'] as $code => $message) {
-            $this->assertEquals($array['statusCodes'][$code], $message);
+            $this->assertEquals($array['statusCodes'][$code], !is_array($message) ? array($message) : $message);
         }
     }
 }


### PR DESCRIPTION
[PR93](https://github.com/nelmio/NelmioApiDocBundle/pull/93) added support for the status codes. This PR just improves it to allow multiple descriptions per status code.

Example:

``` php
@ApiDoc(
   statusCodes={
      200="Returned when successful",
      404={
        "Returned when something does not exist",
        "Returned when something else does not exist"
      }
   }
```
