### PR TITLE
[Parser] Added float in JmsMetadataParser::isPrimitive().

### DIFF
--- a/Parser/JmsMetadataParser.php
+++ b/Parser/JmsMetadataParser.php
@@ -159,7 +159,7 @@ class JmsMetadataParser implements ParserInterface
 
     protected function isPrimitive($type)
     {
-        return in_array($type, array('boolean', 'integer', 'string', 'double', 'array', 'DateTime'));
+        return in_array($type, array('boolean', 'integer', 'string', 'float', 'double', 'array', 'DateTime'));
     }
 
     /**


### PR DESCRIPTION
Hi guys,

I ran into an issue today.

I put an ApiDoc annotation like the following :

``` php
/**
 * @ApiDoc(
 *     resource=true,
 *     output="Acme\Bundle\OrderBundle\Entity\OrderLine",
 *     statusCodes={
 *         200="Returned when successful.",
 *         404="Returned when the order line is not found.",
 *         405="Returned when a wrong HTTP method is used.",
 *         415="Returned when the client does not accept any of the supported formats.",
 *         500="Returned when an error occured."
 *     }
 * )
 */
```

In the `OrderLine` class, I have the following property :

``` php
/**
 * Discounted unit price including taxes.
 *
 * @var string
 *
 * @ORM\Column(name="li_px_ttc_rem", type="decimal", nullable=true)
 * @Assert\Type("numeric")
 */
private $discountedUnitPriceIncludingTaxes;
```

According to the Doctrine2 documentation, a decimal type maps an SQL DECIMAL to a PHP string.

But when I want to see the documentation, I run into this :

```
Class float does not exist
500 Internal Server Error - ReflectionException 

Stack Trace

    in /home/pierreyves/projects/php/project/vendor/jms/metadata/src/Metadata/MetadataFactory.php at line 112  -+
    at ReflectionClass ->__construct ('float')
    in /home/pierreyves/projects/php/project/vendor/jms/metadata/src/Metadata/MetadataFactory.php at line 112  -+
    at MetadataFactory ->getClassHierarchy ('float')
    in /home/pierreyves/projects/php/project/vendor/jms/metadata/src/Metadata/MetadataFactory.php at line 58  -+
    at MetadataFactory ->getMetadataForClass ('float')
    in /home/pierreyves/projects/php/project/vendor/nelmio/api-doc-bundle/Nelmio/ApiDocBundle/Parser/JmsMetadataParser.php at line 105  -+
    at JmsMetadataParser ->doParse ('Project\Bundle\OrderBundle\Entity\OrderLine')
    in /home/pierreyves/projects/php/project/vendor/nelmio/api-doc-bundle/Nelmio/ApiDocBundle/Parser/JmsMetadataParser.php at line 64  -+
    at JmsMetadataParser ->parse ('Project\Bundle\OrderBundle\Entity\OrderLine')
    in /home/pierreyves/projects/php/project/vendor/nelmio/api-doc-bundle/Nelmio/ApiDocBundle/Extractor/ApiDocExtractor.php at line 276  -+
    at ApiDocExtractor ->extractData (object(ApiDoc), object(Route), object(ReflectionMethod))
    in /home/pierreyves/projects/php/project/vendor/nelmio/api-doc-bundle/Nelmio/ApiDocBundle/Extractor/ApiDocExtractor.php at line 98  -+
    at ApiDocExtractor ->all ()
    in /home/pierreyves/projects/php/project/vendor/nelmio/api-doc-bundle/Nelmio/ApiDocBundle/Controller/ApiDocController.php at line 21  -+
    at ApiDocController ->indexAction () 
```

I found two ways to fix this :
- Adding `@Serializer\Type("string")` annotation on the property.
- Adding 'float' to the list of primitive types in `JmsMetadataParser::isPrimitive()`

I don't want to specify the `@Serializer\Type` annotation to all my decimal columns so, that's why I propose to add the 'float' primitive type.
