### PR TITLE
[Resources] Fixed duplicated h2 titles.

### DIFF
--- a/Resources/views/resources.html.twig
+++ b/Resources/views/resources.html.twig
@@ -12,7 +12,7 @@
                     {% if section == '_others' and resource != 'others' %}
                         <h2>{{ resource }}</h2>
                     {% endif %}
-                    {% if resource != 'others' %}
+                    {% if resource == 'others' %}
                         <h2>{{ resource }}</h2>
                     {% endif %}
                 </div>


### PR DESCRIPTION
Hey,

There is an issue with the html documentation page.
All h2 titles are duplicated.

![html-issue](https://f.cloud.github.com/assets/351471/280286/2c8ae5d4-9150-11e2-929d-0844875053f0.png)

I got a better result by inverting a condition in a template.
