### PR TITLE
[Formatter] Fixed MarkdownFormatter.

### DIFF
--- a/Formatter/MarkdownFormatter.php
+++ b/Formatter/MarkdownFormatter.php
@@ -123,13 +123,15 @@ class MarkdownFormatter extends AbstractFormatter
     {
         if ('_others' !== $section) {
             $markdown = sprintf("# %s #\n\n", $section);
+        } else {
+            $markdown = '';
         }
 
         foreach ($resources as $resource => $methods) {
             if ('_others' === $section && 'others' !== $resource) {
-                $markdown = sprintf("## %s ##\n\n", $resource);
+                $markdown .= sprintf("## %s ##\n\n", $resource);
             } elseif ('others' !== $resource) {
-                $markdown = sprintf("## %s ##\n\n", $resource);
+                $markdown .= sprintf("## %s ##\n\n", $resource);
             }
 
             foreach ($methods as $method) {

--- a/Tests/Extractor/ApiDocExtratorTest.php
+++ b/Tests/Extractor/ApiDocExtratorTest.php
@@ -24,7 +24,7 @@ class ApiDocExtractorTest extends WebTestCase
         restore_error_handler();
 
         $this->assertTrue(is_array($data));
-        $this->assertCount(15, $data);
+        $this->assertCount(16, $data);
 
         foreach ($data as $d) {
             $this->assertTrue(is_array($d));
@@ -64,7 +64,7 @@ class ApiDocExtractorTest extends WebTestCase
         $this->assertFalse(isset($array2['filters']));
         $this->assertEquals('Nelmio\ApiDocBundle\Tests\Fixtures\Form\TestType', $a2->getInput());
 
-        $a3 = $data['11']['annotation'];
+        $a3 = $data['12']['annotation'];
         $this->assertTrue($a3->getHttps());
     }
 

--- a/Tests/Fixtures/Controller/TestController.php
+++ b/Tests/Fixtures/Controller/TestController.php
@@ -43,6 +43,16 @@ class TestController
     {
     }
 
+    /**
+     * @ApiDoc(
+     *     description="post test 2",
+     *     resource=true
+     * )
+     */
+    public function postTest2Action()
+    {
+    }
+
     public function anotherAction()
     {
     }

--- a/Tests/Fixtures/app/config/routing.yml
+++ b/Tests/Fixtures/app/config/routing.yml
@@ -91,3 +91,9 @@ test_service_route_4:
 NelmioApiDocBundle:
     resource: "@NelmioApiDocBundle/Resources/config/routing.yml"
     prefix:   /
+
+test_route_14:
+    pattern:  /tests2.{_format}
+    defaults: { _controller: NelmioApiDocTestBundle:Test:postTest2, _format: json }
+    requirements:
+        _method: POST

--- a/Tests/Formatter/MarkdownFormatterTest.php
+++ b/Tests/Formatter/MarkdownFormatterTest.php
@@ -126,6 +126,18 @@ c:
   * required: true
 
 
+## /tests2 ##
+
+### `POST` /tests2.{_format} ###
+
+_post test 2_
+
+#### Requirements ####
+
+**_format**
+
+
+
 ### `POST` /another-post ###
 
 _create another test_

--- a/Tests/Formatter/SimpleFormatterTest.php
+++ b/Tests/Formatter/SimpleFormatterTest.php
@@ -477,6 +477,26 @@ And, it supports multilines until the first \'@\' char.',
                     'authentication' => false,
                 ),
             ),
+            '/tests2' =>
+            array (
+                0 =>
+                array (
+                    'method' => 'POST',
+                    'uri' => '/tests2.{_format}',
+                    'description' => 'post test 2',
+                    'requirements' =>
+                    array (
+                        '_format' =>
+                        array (
+                            'requirement' => '',
+                            'dataType' => '',
+                            'description' => '',
+                        ),
+                    ),
+                    'https' => false,
+                    'authentication' => false,
+                ),
+            ),
         );
 
         $this->assertEquals($expected, $result);


### PR DESCRIPTION
Hey there :)

A little PR to fix the Markdown formatter :
When you have two resources other than "others", it will render only the last one because it enters the elseif statement more than once, which erase the previous content of the $markdown variable.

I fixed that and added a testcase of course.

Regards.
