### PR TITLE
[ApiDocExtractor] Add a little bit more flexibility

### DIFF
--- a/Extractor/ApiDocExtractor.php
+++ b/Extractor/ApiDocExtractor.php
@@ -68,7 +68,7 @@ class ApiDocExtractor
      * You can extend this method if you don't want all the routes
      * to be included.
      *
-     * @return \Traverseable Iterator for a RouteCollection
+     * @return \Traversable Iterator for a RouteCollection
      */
     public function getRoutes()
     {


### PR DESCRIPTION
A proposal for a small refactoring of ApiDocExtractor to allow a little bit more flexibility.
### Use-Case:

I have an application which I like to add an api for. I dont want to add doubled code for every method the Api should use. Therefor I added extra routes per annotation to the actions I want to be available in my api. So far so good.

If I now try to extract the api-doc for those actions, the routes are doubled because of the doubled Routes on those actions. These change allows me to do something like:

``` php
$annotations = $apiDocExtractor->extractAnnotations(
    new ApiRouteFilterIterator(
        $apiDocExtractor->getRoutes()
    )
);
```

Where my ApiRouteFilterIterator looks something like this:

``` php
class ApiRouteFilterIterator extends \FilterIterator 
{
    public function accept()
    {
        return strstr($this->getInnerIterator()->key(), 'api_');
    }
}
```
