### PR TITLE
Reponse headers are inserted into the DOM as HTML instead of Text

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -120,7 +120,7 @@
                     var text = xhr.status + ' ' + xhr.statusText + "\n\n";
                     text += xhr.getAllResponseHeaders();
 
-                    container.html(text);
+                    container.text(text);
                 };
 
                 var displayResponse = function(xhr, method, url, result_container) {


### PR DESCRIPTION
Use text() instead of html() when inserting headers in the DOM
