### PR TITLE
Fix: BC with symfony 2.1

### DIFF
--- a/Annotation/ApiDoc.php
+++ b/Annotation/ApiDoc.php
@@ -307,7 +307,13 @@ class ApiDoc
     public function setRoute(Route $route)
     {
         $this->route  = $route;
-        $this->host   = $route->getHost() ?: null;
+
+        if (method_exists($route, 'getHost')) {
+            $this->host = $route->getHost() ? : null;
+        } else {
+            $this->host = null;
+        }
+
         $this->uri    = $route->getPattern();
         $this->method = $route->getRequirement('_method') ?: 'ANY';
     }


### PR DESCRIPTION
Commit 5cc7cf212d break compatibility with Symfony 2.1 (or lower),
because only in 2.2 added host support in routing.
