### PR TITLE
Make parameters description conform to others

### DIFF
--- a/Parser/JmsMetadataParser.php
+++ b/Parser/JmsMetadataParser.php
@@ -201,7 +201,7 @@ class JmsMetadataParser implements ParserInterface
             $extracted = $this->commentExtractor->getDocCommentText($ref->getProperty($item->name));
         }
 
-        return !empty($extracted) ? $extracted : "No description.";
+        return $extracted;
     }
 
 }

--- a/Tests/Formatter/MarkdownFormatterTest.php
+++ b/Tests/Formatter/MarkdownFormatterTest.php
@@ -200,31 +200,26 @@ foo:
 
   * type: string
   * required: false
-  * description: No description.
 
 number:
 
   * type: double
   * required: false
-  * description: No description.
 
 arr:
 
   * type: array
   * required: false
-  * description: No description.
 
 nested:
 
   * type: object (JmsNested)
   * required: false
-  * description: No description.
 
 nested[bar]:
 
   * type: string
   * required: false
-  * description: No description.
 
 nested[baz][]:
 
@@ -238,49 +233,41 @@ nested[circular]:
 
   * type: object (JmsNested)
   * required: false
-  * description: No description.
 
 nested[parent]:
 
   * type: object (JmsTest)
   * required: false
-  * description: No description.
 
 nested[parent][foo]:
 
   * type: string
   * required: false
-  * description: No description.
 
 nested[parent][number]:
 
   * type: double
   * required: false
-  * description: No description.
 
 nested[parent][arr]:
 
   * type: array
   * required: false
-  * description: No description.
 
 nested[parent][nested]:
 
   * type: object (JmsNested)
   * required: false
-  * description: No description.
 
 nested[parent][nested_array][]:
 
   * type: array of objects (JmsNested)
   * required: false
-  * description: No description.
 
 nested_array[]:
 
   * type: array of objects (JmsNested)
   * required: false
-  * description: No description.
 
 
 ### `GET` /jms-return-test ###

--- a/Tests/Formatter/SimpleFormatterTest.php
+++ b/Tests/Formatter/SimpleFormatterTest.php
@@ -250,35 +250,35 @@ class SimpleFormatterTest extends WebTestCase
                         array(
                             'dataType' => 'string',
                             'required' => false,
-                            'description' => 'No description.',
+                            'description' => '',
                             'readonly' => false,
                         ),
                         'bar' =>
                         array(
                             'dataType' => 'DateTime',
                             'required' => false,
-                            'description' => 'No description.',
+                            'description' => '',
                             'readonly' => true,
                         ),
                         'number' =>
                         array(
                             'dataType' => 'double',
                             'required' => false,
-                            'description' => 'No description.',
+                            'description' => '',
                             'readonly' => false,
                         ),
                         'arr' =>
                         array(
                             'dataType' => 'array',
                             'required' => false,
-                            'description' => 'No description.',
+                            'description' => '',
                             'readonly' => false,
                         ),
                         'nested' =>
                         array(
                             'dataType' => 'object (JmsNested)',
                             'required' => false,
-                            'description' => 'No description.',
+                            'description' => '',
                             'readonly' => false,
                             'children' =>
                             array(
@@ -286,14 +286,14 @@ class SimpleFormatterTest extends WebTestCase
                                 array(
                                     'dataType' => 'DateTime',
                                     'required' => false,
-                                    'description' => 'No description.',
+                                    'description' => '',
                                     'readonly' => true,
                                 ),
                                 'bar' =>
                                 array(
                                     'dataType' => 'string',
                                     'required' => false,
-                                    'description' => 'No description.',
+                                    'description' => '',
                                     'readonly' => false,
                                 ),
                                 'baz' =>
@@ -309,14 +309,14 @@ With multiple lines.',
                                 array(
                                     'dataType' => 'object (JmsNested)',
                                     'required' => false,
-                                    'description' => 'No description.',
+                                    'description' => '',
                                     'readonly' => false,
                                 ),
                                 'parent' =>
                                 array(
                                     'dataType' => 'object (JmsTest)',
                                     'required' => false,
-                                    'description' => 'No description.',
+                                    'description' => '',
                                     'readonly' => false,
                                     'children' =>
                                     array(
@@ -324,42 +324,42 @@ With multiple lines.',
                                         array(
                                             'dataType' => 'string',
                                             'required' => false,
-                                            'description' => 'No description.',
+                                            'description' => '',
                                             'readonly' => false,
                                         ),
                                         'bar' =>
                                         array(
                                             'dataType' => 'DateTime',
                                             'required' => false,
-                                            'description' => 'No description.',
+                                            'description' => '',
                                             'readonly' => true,
                                         ),
                                         'number' =>
                                         array(
                                             'dataType' => 'double',
                                             'required' => false,
-                                            'description' => 'No description.',
+                                            'description' => '',
                                             'readonly' => false,
                                         ),
                                         'arr' =>
                                         array(
                                             'dataType' => 'array',
                                             'required' => false,
-                                            'description' => 'No description.',
+                                            'description' => '',
                                             'readonly' => false,
                                         ),
                                         'nested' =>
                                         array(
                                             'dataType' => 'object (JmsNested)',
                                             'required' => false,
-                                            'description' => 'No description.',
+                                            'description' => '',
                                             'readonly' => false,
                                         ),
                                         'nested_array' =>
                                         array(
                                             'dataType' => 'array of objects (JmsNested)',
                                             'required' => false,
-                                            'description' => 'No description.',
+                                            'description' => '',
                                             'readonly' => false,
                                         ),
                                     ),
@@ -370,7 +370,7 @@ With multiple lines.',
                         array(
                             'dataType' => 'array of objects (JmsNested)',
                             'required' => false,
-                            'description' => 'No description.',
+                            'description' => '',
                             'readonly' => false,
                         ),
                     ),

--- a/Tests/Parser/JmsMetadataParserTest.php
+++ b/Tests/Parser/JmsMetadataParserTest.php
@@ -76,19 +76,19 @@ class JmsMetadataParserTest extends \PHPUnit_Framework_TestCase
             'foo' => array(
                 'dataType' => 'DateTime',
                 'required' => false,
-                'description' => 'No description.',
+                'description' => '',
                 'readonly' => false
             ),
             'bar' => array(
                 'dataType' => 'string',
                 'required' => false,
-                'description' => 'No description.',
+                'description' => '',
                 'readonly' => false
             ),
             'baz' => array(
                 'dataType' => 'array of integers',
                 'required' => false,
-                'description' => 'No description.',
+                'description' => '',
                 'readonly' => false
             )
         ), $output);


### PR DESCRIPTION
Empty description displays as empty string in other places.
