### PR TITLE
Fixes the incorrect names of parameters in Sandbox

### DIFF
--- a/Parser/FormTypeParser.php
+++ b/Parser/FormTypeParser.php
@@ -77,7 +77,7 @@ class FormTypeParser implements ParserInterface
 
         $form = $this->formFactory->create($type);
 
-        return $this->parseForm($form, $form->getName());
+        return $this->parseForm($form);
     }
 
     private function parseForm($form, $prefix = null)


### PR DESCRIPTION
Solution to issue #193 -- The parameters appears in format: entityName['fieldName'] in Sandbox when uses FormTypes
