### PR TITLE
Option to set requirements and parameters directly from ApiDoc annotation

### DIFF
--- a/Annotation/ApiDoc.php
+++ b/Annotation/ApiDoc.php
@@ -153,6 +153,39 @@ class ApiDoc
             }
         }
 
+        if (isset($data['requirements'])) {
+            foreach ($data['requirements'] as $requirement) {
+                if (!isset($requirement['name'])) {
+                    throw new \InvalidArgumentException('A "requirement" element has to contain a "name" attribute');
+                }
+
+                $name = $requirement['name'];
+                unset($requirement['name']);
+
+                $this->addRequirement($name, $requirement);
+            }
+        }
+
+        if (isset($data['parameters'])) {
+            foreach ($data['parameters'] as $parameter) {
+                if (!isset($parameter['name'])) {
+                    throw new \InvalidArgumentException('A "parameter" element has to contain a "name" attribute');
+                }
+
+                if (!isset($parameter['dataType'])) {
+                    throw new \InvalidArgumentException(sprintf(
+                        '"%s" parameter element has to contain a "dataType" attribute',
+                        $parameter['name']
+                    ));
+                }
+
+                $name = $parameter['name'];
+                unset($parameter['name']);
+
+                $this->addParameter($name, $parameter);
+            }
+        }
+
         if (isset($data['output'])) {
             $this->output = $data['output'];
         }

--- a/README.md
+++ b/README.md
@@ -89,6 +89,26 @@ class YourController extends Controller
     public function postAction()
     {
     }
+
+    /**
+     * @ApiDoc(
+     *  description="Returns a collection of Object",
+     *  requirements={
+     *      {
+     *          "name"="limit",
+     *          "dataType"="integer",
+     *          "requirement"="\d+",
+     *          "description"="how many objects to return"
+     *      }
+     *  },
+     *  parameters={
+     *      {"name"="categoryId", "dataType"="integer", "required"=true, "description"="category id"}
+     *  }
+     * )
+     */
+    public function cgetAction($id)
+    {
+    }
 }
 ```
 
@@ -103,6 +123,10 @@ The following properties are available:
 * `deprecated`: allow to set method as deprecated (default: `false`);
 
 * `filters`: an array of filters;
+
+* `requirements`: an array of requirements;
+
+* `parameters`: an array of parameters;
 
 * `input`: the input type associated to the method (currently this supports Form Types, classes with JMS Serializer
  metadata, and classes with Validation component metadata) useful for POST|PUT methods, either as FQCN or as form type

--- a/Resources/views/method.html.twig
+++ b/Resources/views/method.html.twig
@@ -123,10 +123,10 @@
                             {% if not infos.readonly %}
                                 <tr>
                                     <td>{{ name }}</td>
-                                    <td>{{ infos.dataType }}</td>
+                                    <td>{{ infos.dataType is defined ? infos.dataType : '' }}</td>
                                     <td>{{ infos.required ? 'true' : 'false' }}</td>
                                     <td>{{ infos.format }}</td>
-                                    <td>{{ infos.description }}</td>
+                                    <td>{{ infos.description is defined ? infos.description : ''  }}</td>
                                 </tr>
                             {% endif %}
                         {% endfor %}

--- a/Tests/Annotation/ApiDocTest.php
+++ b/Tests/Annotation/ApiDocTest.php
@@ -28,6 +28,8 @@ class ApiDocTest extends TestCase
         $this->assertFalse($annot->isResource());
         $this->assertFalse($annot->getDeprecated());
         $this->assertFalse(isset($array['description']));
+        $this->assertFalse(isset($array['requirements']));
+        $this->assertFalse(isset($array['parameters']));
         $this->assertNull($annot->getInput());
         $this->assertFalse($array['authentication']);
     }
@@ -47,6 +49,8 @@ class ApiDocTest extends TestCase
         $this->assertFalse($annot->isResource());
         $this->assertFalse($annot->getDeprecated());
         $this->assertFalse(isset($array['description']));
+        $this->assertFalse(isset($array['requirements']));
+        $this->assertFalse(isset($array['parameters']));
         $this->assertNull($annot->getInput());
     }
 
@@ -64,6 +68,8 @@ class ApiDocTest extends TestCase
         $this->assertFalse($annot->isResource());
         $this->assertFalse($annot->getDeprecated());
         $this->assertEquals($data['description'], $array['description']);
+        $this->assertFalse(isset($array['requirements']));
+        $this->assertFalse(isset($array['parameters']));
         $this->assertNull($annot->getInput());
     }
 
@@ -82,6 +88,8 @@ class ApiDocTest extends TestCase
         $this->assertFalse($annot->isResource());
         $this->assertFalse($annot->getDeprecated());
         $this->assertEquals($data['description'], $array['description']);
+        $this->assertFalse(isset($array['requirements']));
+        $this->assertFalse(isset($array['parameters']));
         $this->assertEquals($data['input'], $annot->getInput());
     }
 
@@ -102,6 +110,8 @@ class ApiDocTest extends TestCase
         $this->assertTrue($annot->isResource());
         $this->assertTrue($annot->getDeprecated());
         $this->assertEquals($data['description'], $array['description']);
+        $this->assertFalse(isset($array['requirements']));
+        $this->assertFalse(isset($array['parameters']));
         $this->assertEquals($data['input'], $annot->getInput());
     }
 
@@ -121,6 +131,8 @@ class ApiDocTest extends TestCase
         $this->assertFalse(isset($array['filters']));
         $this->assertFalse($annot->isResource());
         $this->assertEquals($data['description'], $array['description']);
+        $this->assertFalse(isset($array['requirements']));
+        $this->assertFalse(isset($array['parameters']));
         $this->assertEquals($data['deprecated'], $array['deprecated']);
         $this->assertEquals($data['input'], $annot->getInput());
     }
@@ -145,6 +157,8 @@ class ApiDocTest extends TestCase
         $this->assertEquals(array('a-filter' => array()), $array['filters']);
         $this->assertTrue($annot->isResource());
         $this->assertEquals($data['description'], $array['description']);
+        $this->assertFalse(isset($array['requirements']));
+        $this->assertFalse(isset($array['parameters']));
         $this->assertEquals($data['deprecated'], $array['deprecated']);
         $this->assertNull($annot->getInput());
     }
@@ -231,5 +245,46 @@ class ApiDocTest extends TestCase
         $array = $annot->toArray();
 
         $this->assertEquals($data['cache'], $array['cache']);
+    }
+
+    public function testConstructWithRequirements()
+    {
+        $data = array(
+            'requirements' => array(
+                array(
+                    'name' => 'fooId',
+                    'requirement' => '\d+',
+                    'dataType' => 'integer',
+                    'description' => 'This requirement might be used withing action method directly from Request object'
+                )
+            )
+        );
+
+        $annot = new ApiDoc($data);
+        $array = $annot->toArray();
+
+        $this->assertTrue(is_array($array));
+        $this->assertTrue(isset($array['requirements']['fooId']));
+        $this->assertTrue(isset($array['requirements']['fooId']['dataType']));
+    }
+
+    public function testConstructWithParameters()
+    {
+        $data = array(
+            'parameters' => array(
+                array(
+                    'name' => 'fooId',
+                    'dataType' => 'integer',
+                    'description' => 'Some description'
+                )
+            )
+        );
+
+        $annot = new ApiDoc($data);
+        $array = $annot->toArray();
+
+        $this->assertTrue(is_array($array));
+        $this->assertTrue(isset($array['parameters']['fooId']));
+        $this->assertTrue(isset($array['parameters']['fooId']['dataType']));
     }
 }

--- a/Tests/Fixtures/Controller/TestController.php
+++ b/Tests/Fixtures/Controller/TestController.php
@@ -198,4 +198,19 @@ class TestController
     public function jmsReturnNestedOutputAction()
     {
     }
+
+    /**
+     * @ApiDoc(
+     *  description="Returns a collection of Object",
+     *  requirements={
+     *      {"name"="limit", "dataType"="integer", "requirement"="\d+", "description"="how many objects to return"}
+     *  },
+     *  parameters={
+     *      {"name"="categoryId", "dataType"="integer", "required"=true, "description"="category id"}
+     *  }
+     * )
+     */
+    public function cgetAction($id)
+    {
+    }
 }


### PR DESCRIPTION
Sometimes required parameters are not used through routing but still they are mandatory. I wanted to have API with

resource.json?foo=bar&something=else

format, that was possible through QueryParam annotation or requirements in routing BUT!

There was no way to set dataType or description

This PR solves #135 

Side note: if you want to declare e.g. _format requirement through Annotation or any other required parameter that is used in url ({foo} format) then it won't work. Because Bundle still overrides requirements and parameters after the constructor in ApiDoc is called. This might be solved in separate PR by adding check if given requirements or parameters was already defined. But generally shouldn't be a problem to anyone.
