### PR TITLE
Clarify config snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,8 +277,10 @@ input is used, so you can configure their priorities via container tags. Here's 
 You can also define your own motd content (above methods list). All you have to do is add to configuration:
 
     #app/config/config.yml
-    motd:
-        template: AcmeApiBundle::Components/motd.html.twig
+    nelmio_api_doc:
+        # ...
+        motd:
+            template: AcmeApiBundle::Components/motd.html.twig
 
 ## Using Your Own Annotations ##
 


### PR DESCRIPTION
It's not obvious that key `motd` should be under `nelmio_api_doc` in the current doc.
