### PR TITLE
Modify the `documentation` property inside annotation handlers

### DIFF
--- a/Annotation/ApiDoc.php
+++ b/Annotation/ApiDoc.php
@@ -267,6 +267,14 @@ class ApiDoc
     }
 
     /**
+     * @return string
+     */
+    public function getDocumentation()
+    {
+        return $this->documentation;
+    }
+
+    /**
      * @return Boolean
      */
     public function isResource()

--- a/Extractor/ApiDocExtractor.php
+++ b/Extractor/ApiDocExtractor.php
@@ -239,6 +239,9 @@ class ApiDocExtractor
         // create a new annotation
         $annotation = clone $annotation;
 
+        // doc
+        $annotation->setDocumentation($this->commentExtractor->getDocCommentText($method));
+
         // parse annotations
         $this->parseAnnotations($annotation, $route, $method);
 
@@ -247,7 +250,7 @@ class ApiDocExtractor
 
         // description
         if (null === $annotation->getDescription()) {
-            $comments = explode("\n", $this->commentExtractor->getDocCommentText($method));
+            $comments = explode("\n", $annotation->getDocumentation());
             // just set the first line
             $comment = trim($comments[0]);
             $comment = preg_replace("#\n+#", ' ', $comment);
@@ -258,9 +261,6 @@ class ApiDocExtractor
                 $annotation->setDescription($comment);
             }
         }
-
-        // doc
-        $annotation->setDocumentation($this->commentExtractor->getDocCommentText($method));
 
         // input (populates 'parameters' for the formatters)
         if (null !== $input = $annotation->getInput()) {


### PR DESCRIPTION
Ran into an issue where I have a couple rest controllers using a trait.  In the trait, I have documentation for a method that I wanted to overwrite / manipulate in a custom annotation handler based on the entity the rest controller was for.

There currently is no getter for the `documentation` property and the documentation is extracted from the doc block after the handlers are called, which would overwrite anything assigned using the setter method from a handler.

This changes the order and adds a getter method.
