### PR TITLE
Increased input field width for sandbox forms to improve readability wit...

### DIFF
--- a/Resources/public/css/screen.css
+++ b/Resources/public/css/screen.css
@@ -538,11 +538,19 @@ li.operation.unlink div.content h4 {
   display: none;
 }
 
-form .parameters,
+form .parameters {
+  float: left;
+  width: 50%;
+}
+
+form .parameters .tuple input {
+	width: 40%;
+}
+
 form .headers,
 form .request-content {
   float: left;
-  width: 33%;
+  width: 25%;
 }
 
 .buttons {


### PR DESCRIPTION
...h long keys. For instance when using a form with subforms, sent parameters may be quite long, hence it's easier if the input fields are wider.
![image](https://f.cloud.github.com/assets/1321977/884660/06a07b60-f9bd-11e2-848c-c6990c31c544.png)
