### PR TITLE
Not all "strict" params should be "Requirements" in the documentation, closes #229

### DIFF
--- a/Extractor/Handler/FosRestHandler.php
+++ b/Extractor/Handler/FosRestHandler.php
@@ -30,7 +30,7 @@ class FosRestHandler implements HandlerInterface
                     'readonly'    => false
                 ));
             } elseif ($annot instanceof QueryParam) {
-                if ($annot->strict && $annot->default === null) {
+                if ($annot->strict && $annot->nullable === false && $annot->default === null) {
                     $annotation->addRequirement($annot->name, array(
                         'requirement'   => $annot->requirements,
                         'dataType'      => '',


### PR DESCRIPTION
If you want to have "strict" QueryParams (for Regex checking for example) with the "nullable=true" option, this FOSRestBundle annotation should still be considered a Filter in the documentation and not a Requirement:

```
@Rest\QueryParam(name="types", requirements="^([a-z_]+,{0,1})+$", strict=true, nullable=true, description="Example"
```

The _types_ QueryParam should still be considered a **Filter** even if we use the "strict=true" annotation, because we are using it just to ensure that the Regex check throws a "400 Bad Request" response when it is necessary.
