### PR TITLE
Can now specifiy form name

### DIFF
--- a/Parser/FormTypeParser.php
+++ b/Parser/FormTypeParser.php
@@ -82,7 +82,7 @@ class FormTypeParser implements ParserInterface
 
         $form = $this->formFactory->create($type);
 
-        return $this->parseForm($form, $form->getName());
+        return $this->parseForm($form, array_key_exists('name', $item) ? $item['name'] : $form->getName());
     }
 
     private function parseForm($form, $prefix = null)

--- a/README.md
+++ b/README.md
@@ -209,6 +209,20 @@ you can specify which groups to use when generating the documentation by using t
 If your `output` classes use [versioning capabilities of JMS Serializer](http://jmsyst.com/libs/serializer/master/cookbook/exclusion_strategies#versioning-objects),
 the versioning information will be automatically used when generating the documentation.
 
+#### Form Types features ####
+
+If you use `FormFactoryInterface::createdNamed('', 'your_form_type'`, then by default the documentation will use
+the form type name as the prefix (`your_form_type[param]` ... instead of just `param`).
+
+You can specify which prefix to use with the `name` key:
+
+```
+input = {
+ "class" = "your_form_type",
+ "name" = ""
+}
+```
+
 ### Documentation on-the-fly ###
 
 By calling an URL with the parameter `?_doc=1`, you will get the corresponding documentation if available.

--- a/Tests/Parser/FormTypeParserTest.php
+++ b/Tests/Parser/FormTypeParserTest.php
@@ -72,6 +72,46 @@ class FormTypeParserTest extends \PHPUnit_Framework_TestCase
                     )
                 )
             ),
+            array(
+                array(
+                    'class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Form\CollectionType',
+                    'name' => '',
+                ),
+                array(
+                    'a' => array(
+                        'dataType' => 'array of strings',
+                        'required' => true,
+                        'description' => '',
+                        'readonly' => false
+                    ),
+                    'b' => array(
+                        'dataType' => 'string',
+                        'required' => true,
+                        'description' => '',
+                        'readonly' => false
+                    )
+                )
+            ),
+            array(
+                array(
+                    'class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Form\CollectionType',
+                    'name' => null,
+                ),
+                array(
+                    'a' => array(
+                        'dataType' => 'array of strings',
+                        'required' => true,
+                        'description' => '',
+                        'readonly' => false
+                    ),
+                    'b' => array(
+                        'dataType' => 'string',
+                        'required' => true,
+                        'description' => '',
+                        'readonly' => false
+                    )
+                )
+            ),
         );
     }
 }


### PR DESCRIPTION
If you create you forms using FormFactoryInterface::createNamed, then you should now be able to tell the ApiDocBundle the correct form prefix.
