### PR TITLE
Add support for embedded forms

### DIFF
--- a/Parser/FormTypeParser.php
+++ b/Parser/FormTypeParser.php
@@ -102,6 +102,12 @@ class FormTypeParser implements ParserInterface
                 } elseif ('collection' === $type->getName()) {
                     if (is_string($config->getOption('type')) && isset($this->mapTypes[$config->getOption('type')])) {
                         $bestType = sprintf('array of %ss', $this->mapTypes[$config->getOption('type')]);
+                    } else {
+                        // Embedded form collection
+                        $subParameters = $this->parseForm($this->formFactory->create($config->getOption('type')), $name . '[]');
+                        $parameters = array_merge($parameters, $subParameters);
+
+                        continue 2;
                     }
                 }
             }

--- a/Tests/Parser/FormTypeParserTest.php
+++ b/Tests/Parser/FormTypeParserTest.php
@@ -64,8 +64,20 @@ class FormTypeParserTest extends \PHPUnit_Framework_TestCase
                         'description' => '',
                         'readonly' => false
                     ),
-                    'collection_type[b]' => array(
+                    'collection_type[b][][a]' => array(
                         'dataType' => 'string',
+                        'required' => true,
+                        'description' => 'A nice description',
+                        'readonly' => false
+                    ),
+                    'collection_type[b][][b]' => array(
+                        'dataType' => 'string',
+                        'required' => true,
+                        'description' => '',
+                        'readonly' => false
+                    ),
+                    'collection_type[b][][c]' => array(
+                        'dataType' => 'boolean',
                         'required' => true,
                         'description' => '',
                         'readonly' => false
@@ -84,8 +96,20 @@ class FormTypeParserTest extends \PHPUnit_Framework_TestCase
                         'description' => '',
                         'readonly' => false
                     ),
-                    'b' => array(
+                    'b[][a]' => array(
                         'dataType' => 'string',
+                        'required' => true,
+                        'description' => 'A nice description',
+                        'readonly' => false
+                    ),
+                    'b[][b]' => array(
+                        'dataType' => 'string',
+                        'required' => true,
+                        'description' => '',
+                        'readonly' => false
+                    ),
+                    'b[][c]' => array(
+                        'dataType' => 'boolean',
                         'required' => true,
                         'description' => '',
                         'readonly' => false
@@ -104,8 +128,20 @@ class FormTypeParserTest extends \PHPUnit_Framework_TestCase
                         'description' => '',
                         'readonly' => false
                     ),
-                    'b' => array(
+                    'b[][a]' => array(
                         'dataType' => 'string',
+                        'required' => true,
+                        'description' => 'A nice description',
+                        'readonly' => false
+                    ),
+                    'b[][b]' => array(
+                        'dataType' => 'string',
+                        'required' => true,
+                        'description' => '',
+                        'readonly' => false
+                    ),
+                    'b[][c]' => array(
+                        'dataType' => 'boolean',
                         'required' => true,
                         'description' => '',
                         'readonly' => false


### PR DESCRIPTION
Currently, embedded forms are shown as:

| Parameter | Type | Required? | Format | Description |
| --- | --- | --- | --- | --- |
| main[sub_forms] | string | true |  |  |

This PR renders them as:

| Parameter | Type | Required? | Format | Description |
| --- | --- | --- | --- | --- |
| main[subs][][id] | string | true |  |  |
| main[subs][][type] | string | true |  |  |
| main[subs][][token] | string | false |  |  |
| main[subs][][refreshToken] | string | false |  |  |
| main[subs][][expiresIn] | string | true |  |  |
