### PR TITLE
No overwriting a requirements  assigned in the annotations

### DIFF
--- a/Annotation/ApiDoc.php
+++ b/Annotation/ApiDoc.php
@@ -245,7 +245,7 @@ class ApiDoc
      */
     public function setRequirements(array $requirements)
     {
-        $this->requirements = array_merge($this->requirements, $requirements);
+        $this->requirements = array_merge( $requirements, $this->requirements);
     }
 
     /**


### PR DESCRIPTION
When i include a requirements in the annotation, only take a default values.
