### PR TITLE
Optional requirements fields: requirement, dataType and description

### DIFF
--- a/Resources/views/method.html.twig
+++ b/Resources/views/method.html.twig
@@ -68,9 +68,9 @@
                         {% for name, infos in data.requirements %}
                             <tr>
                                 <td>{{ name }}</td>
-                                <td>{{ infos.requirement }}</td>
-                                <td>{{ infos.dataType }}</td>
-                                <td>{{ infos.description }}</td>
+                                <td>{{ infos.requirement is defined ? infos.requirement : ''}}</td>
+                                <td>{{ infos.dataType is defined ? infos.dataType : ''}}</td>
+                                <td>{{ infos.description is defined ? infos.description : ''}}</td>
                             </tr>
                         {% endfor %}
                     </tbody>


### PR DESCRIPTION
Not providing one of the fields from requirements (in this case "requirement")

```
/**
 * Promote user with given role(s)
 *
 * @param Request $request
 * @param $workspaceId
 * @param $userId
 * @ApiDoc(
 *   requirements={
 *      {
 *          "name"="roles",
 *          "dataType"="string|array",
 *          "description"="role name you wish to add."
 *      }
 *  }
 * )
 * @Route(pattern="/workspaces/{workspaceId}/users/{userId}/promote")
 * @return \Symfony\Component\HttpFoundation\Response
 */
public function postPromoteAction(Request $request, $workspaceId, $userId)
{
...
```

is causing an error

```
Key "requirement" for array with keys "dataType, description" does not exist in NelmioApiDocBundle::method.html.twig at line 71
```
