### PR TITLE
Add support of `All` constraint

### DIFF
--- a/Tests/Fixtures/Model/MultipleTest.php
+++ b/Tests/Fixtures/Model/MultipleTest.php
@@ -20,4 +20,11 @@ class MultipleTest
      */
     public $baz;
 
+    /**
+     * @Assert\Type(type="array")
+     * @Assert\All({
+     *     @Assert\Type(type="Test")
+     * })
+     */
+    public $objects;
 }

--- a/Tests/Fixtures/Model/Test.php
+++ b/Tests/Fixtures/Model/Test.php
@@ -18,6 +18,7 @@ class Test
     /**
      * @Assert\Length(min="foo");
      * @Assert\NotBlank
+     * @Assert\Type("string")
      */
     public $a;
 

--- a/Tests/Formatter/MarkdownFormatterTest.php
+++ b/Tests/Formatter/MarkdownFormatterTest.php
@@ -479,6 +479,18 @@ bar:
 
   * type: DateTime
 
+objects[]:
+
+  * type: array of objects (Test)
+
+objects[][a]:
+
+  * type: string
+
+objects[][b]:
+
+  * type: DateTime
+
 number:
 
   * type: DateTime

--- a/Tests/Formatter/SimpleFormatterTest.php
+++ b/Tests/Formatter/SimpleFormatterTest.php
@@ -840,6 +840,24 @@ With multiple lines.',
                             'readonly' => false,
                             'sinceVersion' => null,
                             'untilVersion' => null
+                        ),
+                        'objects' => array(
+                            'dataType' => 'array of objects (Test)',
+                            'readonly' => null,
+                            'required' => null,
+                            'children' => array(
+                                'a' => array(
+                                    'dataType' => 'string',
+                                    'format' => '{length: min: foo}, {not blank}',
+                                    'required' => true,
+                                    'readonly' => null
+                                ),
+                                'b' => array(
+                                    'dataType' => 'DateTime',
+                                    'required' => null,
+                                    'readonly' => null
+                                )
+                            )
                         )
                     ),
                     'authenticationRoles' => array(),


### PR DESCRIPTION
This PR aims to add support of [`All` constraint](http://symfony.com/doc/master/reference/constraints/All.html) that allow to validate an array of objects.

For instance, the code bellow validate that `item` field is an array of `Club` objects.

``` php
class ClubListOutput extends ListOutput
{
    /**
     * @Assert\Type(type="array")
     * @Assert\All({
     *     @Assert\Type(type="CoopTilleuls\Geophyle\AgendaBundle\Entity\Club")
     * })
     * @var array
     */
    public $items;
```

With that fix, array type will be displayed and subtype fields.
![nelmio-all-constraint](https://f.cloud.github.com/assets/804625/1491441/c0741530-47ae-11e3-908f-7f6f3b601c25.png)
