### PR TITLE
Fix PHPDoc

### DIFF
--- a/Extractor/ApiDocExtractor.php
+++ b/Extractor/ApiDocExtractor.php
@@ -205,7 +205,7 @@ class ApiDocExtractor
      * Returns an ApiDoc annotation.
      *
      * @param string $controller
-     * @param Route  $route
+     * @param string $route
      * @return ApiDoc|null
      */
     public function get($controller, $route)


### PR DESCRIPTION
$route parameter of ApiDocExtractor::get is a string. Passing a Route object throw an error.
