### PR TITLE
Fix Bug when looking up base class properties

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 class DumpCommand extends ContainerAwareCommand
 {
@@ -52,8 +53,13 @@ class DumpCommand extends ContainerAwareCommand
             $formatter = $this->getContainer()->get(sprintf('nelmio_api_doc.formatter.%s_formatter', $format));
         }
 
-        if ($input->hasOption('no-sandbox') && 'html' === $format) {
+        if ($input->getOption('no-sandbox') && 'html' === $format) {
             $formatter->setEnableSandbox(false);
+        }
+
+        if ($format == 'html') {
+            $this->getContainer()->enterScope('request');
+            $this->getContainer()->set('request', new Request(), 'request');
         }
 
         $extractedDoc = $this->getContainer()->get('nelmio_api_doc.extractor.api_doc_extractor')->all();


### PR DESCRIPTION
In cases where a property is defined in a base class, the Reflection could be
done on the PropertyMetadata rather than on the Class being introspected. This
helps resolve the variables correctly.
