### PR TITLE
Select used parsers in input/output

### DIFF
--- a/Extractor/ApiDocExtractor.php
+++ b/Extractor/ApiDocExtractor.php
@@ -273,9 +273,20 @@ class ApiDocExtractor
 
             $normalizedInput = $this->normalizeClassParameter($input);
 
+            $parsers = $this->parsers;
+            if (array_key_exists('parsers', $normalizedInput)) {
+            $parsers = array_filter($parsers, function($parser) use ($normalizedInput) {
+                    if (true === in_array(get_class($parser), $normalizedInput['parsers'])) {
+                        return true;
+                    }
+
+                    return false;
+                });
+            }
+
             $supportedParsers = array();
             $parameters = array();
-            foreach ($this->parsers as $parser) {
+            foreach ($parsers as $parser) {
                 if ($parser->supports($normalizedInput)) {
                     $supportedParsers[] = $parser;
                     $parameters = $this->mergeParameters($parameters, $parser->parse($normalizedInput));
@@ -306,8 +317,19 @@ class ApiDocExtractor
             $response = array();
 
             $normalizedOutput = $this->normalizeClassParameter($output);
+            $parsers = $this->parsers;
 
-            foreach ($this->parsers as $parser) {
+            if (array_key_exists('parsers', $normalizedOutput)) {
+                $parsers = array_filter($parsers, function($parser) use ($normalizedOutput) {
+                    if (true === in_array(get_class($parser), $normalizedOutput['parsers'])) {
+                        return true;
+                    }
+
+                    return false;
+                });
+            }
+
+            foreach ($parsers as $parser) {
                 if ($parser->supports($normalizedOutput)) {
                     $response = $this->mergeParameters($response, $parser->parse($normalizedOutput));
                 }

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -243,6 +243,21 @@ input = {
 }
 ```
 
+#### Used Parsers ####
+
+If you need select which data parser will be used:
+
+ ```
+ output={
+     "class"="Acme\Bundle\Entity\User",
+     "parsers"={"Nelmio\ApiDocBundle\Parser\JmsMetadataParser", "Nelmio\ApiDocBundle\Parser\ValidationParser"}
+ }
+ ```
+
+ In this case the parsers 'JmsMetadataParser' and 'ValidationParser' are used to generate returned data.
+
+ This feature also works for the `input` property.
+
 ### Documentation on-the-fly ###
 
 By calling an URL with the parameter `?_doc=1`, you will get the corresponding documentation if available.

--- a/Tests/Extractor/ApiDocExtractorTest.php
+++ b/Tests/Extractor/ApiDocExtractorTest.php
@@ -15,7 +15,7 @@ use Nelmio\ApiDocBundle\Tests\WebTestCase;
 
 class ApiDocExtractorTest extends WebTestCase
 {
-    const ROUTES_QUANTITY = 22;
+    const ROUTES_QUANTITY = 24;
 
     public function testAll()
     {
@@ -214,5 +214,41 @@ class ApiDocExtractorTest extends WebTestCase
         $this->assertTrue(
             $annotation->getDeprecated()
         );
+    }
+
+    public function testOutputWithSelectedParsers()
+    {
+        $container  = $this->getContainer();
+        $extractor  = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
+        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\TestController::zReturnSelectedParsersOutputAction', 'test_route_19');
+
+        $this->assertNotNull($annotation);
+        $output = $annotation->getOutput();
+        $parsers = $output['parsers'];
+        $this->assertEquals(
+            "Nelmio\\ApiDocBundle\\Parser\\JmsMetadataParser",
+            $parsers[0]
+        );
+        $this->assertEquals(
+            "Nelmio\\ApiDocBundle\\Parser\\ValidationParser",
+            $parsers[1]
+        );
+        $this->assertCount(2, $parsers);
+    }
+
+    public function testInputWithSelectedParsers()
+    {
+        $container  = $this->getContainer();
+        $extractor  = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
+        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\TestController::zReturnSelectedParsersInputAction', 'test_route_20');
+
+        $this->assertNotNull($annotation);
+        $input = $annotation->getInput();
+        $parsers = $input['parsers'];
+        $this->assertEquals(
+            "Nelmio\\ApiDocBundle\\Parser\\FormTypeParser",
+            $parsers[0]
+        );
+        $this->assertCount(1, $parsers);
     }
 }

--- a/Tests/Fixtures/Controller/TestController.php
+++ b/Tests/Fixtures/Controller/TestController.php
@@ -223,4 +223,33 @@ class TestController
     public function cgetAction($id)
     {
     }
+
+    /**
+     * @ApiDoc(
+     *     input={
+     *          "class"="Nelmio\ApiDocBundle\Tests\Fixtures\Form\TestType",
+     *          "parsers"={
+     *              "Nelmio\ApiDocBundle\Parser\FormTypeParser",
+     *          }
+     *     }
+     * )
+     */
+    public function zReturnSelectedParsersInputAction()
+    {
+    }
+
+    /**
+     * @ApiDoc(
+     *     output={
+     *          "class"="Nelmio\ApiDocBundle\Tests\Fixtures\Model\MultipleTest",
+     *          "parsers"={
+     *              "Nelmio\ApiDocBundle\Parser\JmsMetadataParser",
+     *              "Nelmio\ApiDocBundle\Parser\ValidationParser"
+     *          }
+     *     }
+     * )
+     */
+    public function zReturnSelectedParsersOutputAction()
+    {
+    }
 }

--- a/Tests/Fixtures/app/config/routing.yml
+++ b/Tests/Fixtures/app/config/routing.yml
@@ -129,3 +129,11 @@ test_route_18:
 test_route_named_resource:
     pattern:  /named-resource
     defaults: { _controller: NelmioApiDocTestBundle:Test:namedResource }
+
+test_route_19:
+    pattern: /z-return-selected-parsers-output
+    defaults: { _controller: NelmioApiDocTestBundle:Test:zReturnSelectedParsersOutput }
+
+test_route_20:
+    pattern: /z-return-selected-parsers-input
+    defaults: { _controller: NelmioApiDocTestBundle:Test:zReturnSelectedParsersInput }

--- a/Tests/Formatter/MarkdownFormatterTest.php
+++ b/Tests/Formatter/MarkdownFormatterTest.php
@@ -494,6 +494,54 @@ objects[][b]:
 number:
 
   * type: DateTime
+
+
+### `ANY` /z-return-selected-parsers-input ###
+
+
+#### Parameters ####
+
+a:
+
+  * type: string
+  * required: true
+  * description: A nice description
+
+b:
+
+  * type: string
+  * required: false
+
+c:
+
+  * type: boolean
+  * required: true
+
+
+### `ANY` /z-return-selected-parsers-output ###
+
+
+#### Response ####
+
+bar:
+
+  * type: DateTime
+
+objects[]:
+
+  * type: array of objects (Test)
+
+objects[][a]:
+
+  * type: string
+
+objects[][b]:
+
+  * type: DateTime
+
+number:
+
+  * type: DateTime
 MARKDOWN;
 
         $this->assertEquals($expected, $result);

--- a/Tests/Formatter/SimpleFormatterTest.php
+++ b/Tests/Formatter/SimpleFormatterTest.php
@@ -861,6 +861,78 @@ With multiple lines.',
                         )
                     ),
                     'authenticationRoles' => array(),
+                ),
+                16 =>
+                array(
+                    'method' => "ANY",
+                    'uri' => "/z-return-selected-parsers-input",
+                    'https' => false,
+                    'authentication' => false,
+                    'deprecated' => false,
+                    'authenticationRoles' => array(),
+                    'parameters' =>
+                    array(
+                        'a' => array(
+                            'dataType' => 'string',
+                            'required' => true,
+                            'description' => 'A nice description',
+                            'readonly' => false,
+                        ),
+                        'b' => array(
+                            'dataType' => 'string',
+                            'required' => false,
+                            'description' => '',
+                            'readonly' => false,
+                        ),
+                        'c' => array(
+                            'dataType' => 'boolean',
+                            'required' => true,
+                            'description' => '',
+                            'readonly' => false,
+                        ),
+                    )
+                ),
+                17 =>
+                array(
+                    'method' => "ANY",
+                    'uri' => "/z-return-selected-parsers-output",
+                    'https' => false,
+                    'authentication' => false,
+                    'deprecated' => false,
+                    'response' => array (
+                        'bar' => array(
+                            'dataType' => 'DateTime',
+                            'required' => null,
+                            'readonly' => null
+                        ),
+                        'number' => array(
+                            'dataType' => 'DateTime',
+                            'required' => false,
+                            'description' => '',
+                            'readonly' => false,
+                            'sinceVersion' => null,
+                            'untilVersion' => null
+                        ),
+                        'objects' => array(
+                            'dataType' => 'array of objects (Test)',
+                            'readonly' => null,
+                            'required' => null,
+                            'children' => array(
+                                'a' => array(
+                                    'dataType' => 'string',
+                                    'format' => '{length: min: foo}, {not blank}',
+                                    'required' => true,
+                                    'readonly' => null
+                                ),
+                                'b' => array(
+                                    'dataType' => 'DateTime',
+                                    'required' => null,
+                                    'readonly' => null
+                                )
+                            )
+                        )
+                    ),
+                    'authenticationRoles' => array(),
                 )
             ),
             '/tests2' =>


### PR DESCRIPTION
Usage case
It is api endpoint:

``` php
@ApiDoc(output="PathToEntity\EntityWithAssertValidation")
```

NelmioApiDocBundle generated `Return` section:
- `field_1` - parsed by ValidationParser
- `field_2` - parsed by JmsMetadataParser

I expect that section `Return` will contain the actual serialized fields

``` php
@ApiDoc(
     output={
          "class"="PathToEntity\EntityWithAssertValidation",
          "parsers"={"Nelmio\ApiDocBundle\Parser\JmsMetadataParser"}
    }
)
```

and the return section will contain only `field_1` - parsed by JmsMetadataParser
