### PR TITLE
Remove the annoying scroll-jumping on method-click.

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -49,10 +49,13 @@
         </p>
         <script type="text/javascript">
 
-            $(document).ready(function() {
-                var elem = $(window.location.hash);
-                if(elem) {
-                    $('body').scrollTop(elem.top);
+            $(window).load(function() {
+                var id = (window.location.hash || '').substr(1).replace( /([:\.\[\]\{\}])/g, "\\$1");
+                var elem = $('#' + id);
+                if (elem.length) {
+                    setTimeout(function() {
+                        $('body,html').scrollTop(elem.position().top);
+                    });
                     elem.find('a.toggler').click();
                 }
             });
@@ -295,19 +298,26 @@
                     return false;
                 });
 
-                $('.pane.sandbox').delegate('.to-raw', 'click', function(e) {
+                $('.operations').on('click', '.operation > a', function(e) {
+                    if (history.pushState) {
+                        history.pushState(null, null, $(this).attr('href'));
+                        e.preventDefault();
+                    }
+                });
+
+                $('.pane.sandbox').on('click', '.to-raw', function(e) {
                     renderRawBody($(this).parents('.pane').find('.response'));
 
                     e.preventDefault();
                 });
 
-                $('.pane.sandbox').delegate('.to-prettify', 'click', function(e) {
+                $('.pane.sandbox').on('click', '.to-prettify', function(e) {
                     renderPrettifiedBody($(this).parents('.pane').find('.response'));
 
                     e.preventDefault();
                 });
 
-                $('.pane.sandbox').delegate('.to-expand, .to-shrink', 'click', function(e) {
+                $('.pane.sandbox').on('click', '.to-expand, .to-shrink', function(e) {
                     var $headers = $(this).parents('.result').find('.headers');
                     var $label = $(this).parents('.result').find('a.to-expand');
 


### PR DESCRIPTION
Suppressed the auto-scrolling on click and fixed initial-jump issues.

For the initial auto-scrolling to the selected route in location.hash:
- Fixed typo in the calculation of the offset-top position.
- Fixed requesting the selected route that has special chars (e.g. "/content/{page}")
- Fixed for refreshes with F5. It needs a setTimeout workaround to get that working in Webkit.
  It needs also in Firefox a other dom element to fire scrollTop at.

Fixed also some old `.delegation` calls, which are deprecated in jQuery 1.7.

Why suppressing auto-scrolling on click:
When clicking through all methods it's very annoying when the browser always jumps to the clicked method,
especially when you go through all methods from bottom to up. This jump is unexpected and disturbing.
