### PR TITLE
Use only JMS/GroupExclusion if groups are there

### DIFF
--- a/Parser/JmsMetadataParser.php
+++ b/Parser/JmsMetadataParser.php
@@ -98,7 +98,9 @@ class JmsMetadataParser implements ParserInterface
         }
 
         $exclusionStrategies   = array();
-        $exclusionStrategies[] = new GroupsExclusionStrategy($groups);
+        if ($groups) {
+            $exclusionStrategies[] = new GroupsExclusionStrategy($groups);
+        }
 
         $params = array();
 

--- a/Tests/Parser/JmsMetadataParserTest.php
+++ b/Tests/Parser/JmsMetadataParserTest.php
@@ -169,6 +169,14 @@ class JmsMetadataParserTest extends \PHPUnit_Framework_TestCase
                     'sinceVersion' => null,
                     'untilVersion' => null,
                 ),
+                'baz' => array(
+                    'dataType'     => 'string',
+                    'required'     => false,
+                    'description'  => null,
+                    'readonly'     => false,
+                    'sinceVersion' => null,
+                    'untilVersion' => null,
+                ),
             ),
             $output
         );


### PR DESCRIPTION
When no groups are given in the ApiDoc, there should be no GroupExclusion and the Entity should be parsed wihtout exclusions.

Otherwise only the "Default" group of the Entity would be parsed, which may not be used.

The ApiDoc should not enforce the Entity to be grouped with "Default", to generate a "full-view" of it.
