### PR TITLE
Update FormTypeParser.php

### DIFF
--- a/Parser/FormTypeParser.php
+++ b/Parser/FormTypeParser.php
@@ -104,7 +104,7 @@ class FormTypeParser implements ParserInterface
                         $bestType = sprintf('array of %ss', $this->mapTypes[$config->getOption('type')]);
                     } else {
                         // Embedded form collection
-                        $subParameters = $this->parseForm($this->formFactory->create($config->getOption('type')), $name . '[]');
+                        $subParameters = $this->parseForm($this->formFactory->create($config->getOption('type')), $name . '[0]');
                         $parameters = array_merge($parameters, $subParameters);
 
                         continue 2;


### PR DESCRIPTION
only [] isn't good enough because 

if form type has more that 1 field as example:

ROOT
- FIELD
- SUB
  -- SUB_FIELD
  -- SUB_FIELD_2

It will be 
root[field]
root[sub][][sub_field]
root[sub][][sub_field_2]

And it will be submitted as 2 collections instead of 1 
And if we will force to use equal key for array it will be 1 collection as supposed
