### PR TITLE
ValidationParser: Blank support

### DIFF
--- a/Parser/ValidationParser.php
+++ b/Parser/ValidationParser.php
@@ -77,6 +77,10 @@ class ValidationParser implements ParserInterface, PostParserInterface
 
                 foreach ($constraints as $constraint) {
                     $vparams = $this->parseConstraint($constraint, $vparams, $className, $visited);
+
+                    if(!$vparams) {
+                        continue 3;
+                    }
                 }
             }
 
@@ -125,6 +129,7 @@ class ValidationParser implements ParserInterface, PostParserInterface
     /**
      * Create a valid documentation parameter based on an individual validation Constraint.
      * Currently supports:
+     *  - Blank
      *  - NotBlank/NotNull
      *  - Type
      *  - Email
@@ -143,6 +148,8 @@ class ValidationParser implements ParserInterface, PostParserInterface
         $class = substr(get_class($constraint), strlen('Symfony\\Component\\Validator\\Constraints\\'));
 
         switch ($class) {
+            case 'Blank':
+                return null;
             case 'NotBlank':
                 $vparams['format'][] = '{not blank}';
             case 'NotNull':

--- a/Tests/Fixtures/Model/ValidatorTest.php
+++ b/Tests/Fixtures/Model/ValidatorTest.php
@@ -26,6 +26,11 @@ class ValidatorTest
     public $length1to10;
 
     /**
+     * @Assert\Blank()
+     */
+    public $blank;
+
+    /**
      * @Assert\NotBlank()
      */
     public $notblank;

--- a/Tests/Parser/ValidationParserTest.php
+++ b/Tests/Parser/ValidationParserTest.php
@@ -34,6 +34,9 @@ class ValidationParserTest extends WebTestCase
             $this->assertArrayHasKey($name, $result[$property]);
             $this->assertEquals($result[$property][$name], $expected[$name]);
         }
+
+        # Test Blank()
+        $this->assertTrue(!isset($result['blank']));
     }
 
     public function dataTestParser()


### PR DESCRIPTION
When you provide Blank() assertion for a property, it should be excluded from docs
