### PR TITLE
Validation parser: validation_groups handling

### DIFF
--- a/Parser/ValidationParser.php
+++ b/Parser/ValidationParser.php
@@ -26,6 +26,8 @@ class ValidationParser implements ParserInterface, PostParserInterface
      */
     protected $factory;
 
+    protected $validationGroups;
+
     /**
      * Requires a validation MetadataFactory.
      *
@@ -53,6 +55,8 @@ class ValidationParser implements ParserInterface, PostParserInterface
     {
         $className = $input['class'];
 
+        $this->validationGroups = isset($input['validation_groups']) ? $input['validation_groups'] : array();
+
         return $this->doParse($className, array());
     }
 
@@ -76,7 +80,17 @@ class ValidationParser implements ParserInterface, PostParserInterface
                 $constraints = $propdata->getConstraints();
 
                 foreach ($constraints as $constraint) {
-                    $vparams = $this->parseConstraint($constraint, $vparams, $className, $visited);
+                    if(empty($this->validationGroups)) {
+                        $vparams = $this->parseConstraint($constraint, $vparams, $className, $visited);
+                    }
+                    else {
+                        if(count(array_intersect($constraint->groups, $this->validationGroups))) {
+                            $vparams = $this->parseConstraint($constraint, $vparams, $className, $visited);
+                        }
+                        else {
+                            continue 3;
+                        }
+                    }
                 }
             }
 

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -151,7 +151,7 @@ class YourController
      *         403="Returned when the user is not authorized to say hello",
      *         404={
      *           "Returned when the user is not found",
-     *           "Returned when somehting else is not found"
+     *           "Returned when something else is not found"
      *         }
      *     }
      * )
@@ -256,6 +256,20 @@ input = {
  "name" = ""
 }
 ```
+
+#### Validation groups
+
+If you use [validation groups from Validation component](http://symfony.com/doc/current/book/validation.html#validation-groups), you can specify additional 'validation_groups' attribute.
+Your documentation will only generate parameters matching given validation groups.
+
+````
+input = {
+ "class" = "Acme\Bundle\Entity\User"
+ "validation_groups" = {"register", "update"}
+}
+````
+
+This feature also works for both the `input` and `output` properties.
 
 #### Used Parsers
 

--- a/Tests/Fixtures/Model/ValidatorTest.php
+++ b/Tests/Fixtures/Model/ValidatorTest.php
@@ -107,4 +107,9 @@ class ValidatorTest
      * @Assert\Length(min=10)
      */
     public $multipleformats;
+
+    /**
+     * @Assert\Length(max=5, groups={"testGroup"})
+     */
+    public $validationgroups;
 }

--- a/Tests/Parser/ValidationParserTest.php
+++ b/Tests/Parser/ValidationParserTest.php
@@ -22,6 +22,19 @@ class ValidationParserTest extends WebTestCase
         }
     }
 
+    public function testValidationGroups() {
+        if (version_compare(Kernel::VERSION, '2.2.0', '<')) {
+            $this->markTestSkipped('Does not work using ValidationParserLegacy');
+        }
+
+        $result = $this->parser->parse(array('class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\ValidatorTest', 'validation_groups' => array('testGroup')));
+
+        $this->assertCount(1, $result);
+        $this->assertTrue(isset($result['validationgroups']));
+
+        $this->assertEquals('{length: max: 5}', $result['validationgroups']['format']);
+    }
+
     /**
      * @dataProvider dataTestParser
      */
@@ -147,6 +160,12 @@ class ValidationParserTest extends WebTestCase
                 'property' => 'multipleformats',
                 'expected' => array(
                     'format' => '{url}, {length: min: 10}'
+                )
+            ),
+            array(
+                'property' => 'validationgroups',
+                'expected' => array(
+                    'format' => '{length: max: 5}'
                 )
             )
         );


### PR DESCRIPTION
Enabled support for validation groups.
If you specify validation_groups attribute, then only annotations with given validation groups will be parsed.
It's also backwards compatible, so if you don't specify any validation group, it'll parse as it used to do.
