### PR TITLE
Form Parser improvements for date, datetime & choice form types (format & types)

### DIFF
--- a/Tests/Fixtures/Form/ImprovedTestType.php
+++ b/Tests/Fixtures/Form/ImprovedTestType.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Maxim_Romanovsky
+ * Date: 4/4/14
+ * Time: 11:00 AM
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Fixtures\Form;
+
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class ImprovedTestType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('dt1', 'datetime', array('widget' => 'single_text', 'description' => 'A nice description'))
+            ->add('dt2', 'datetime', array('date_format' => 'M/d/y'))
+            ->add('dt3', 'datetime', array('widget' => 'single_text', 'format' => 'M/d/y H:i:s'))
+            ->add('dt4', 'datetime', array('date_format' => \IntlDateFormatter::MEDIUM))
+            ->add('dt5', 'datetime', array('format' => 'M/d/y H:i:s'))
+            ->add('d1', 'date', array('format' => \IntlDateFormatter::MEDIUM))
+            ->add('d2', 'date', array('format' => 'd-M-y'))
+            ->add('c1', 'choice', array('choices' => array('m' => 'Male', 'f' => 'Female')))
+            ->add('c2', 'choice', array('choices' => array('m' => 'Male', 'f' => 'Female'), 'multiple' => true))
+            ->add('c3', 'choice', array('choices' => array()))
+            ->add('c4', 'choice', array('choice_list' => new SimpleChoiceList(array('foo' => 'bar', 'bazgroup' => array('baz' => 'Buzz')))))
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\ImprovedTest',
+        ));
+
+        return;
+    }
+
+    public function getName()
+    {
+        return '';
+    }
+}
+

--- a/Tests/Fixtures/Model/ImprovedTest.php
+++ b/Tests/Fixtures/Model/ImprovedTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Fixtures\Model;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class ImprovedTest
+{
+    public $dt1;
+    public $dt2;
+    public $dt3;
+    public $dt4;
+    public $dt5;
+    public $d1;
+    public $d2;
+    public $c1;
+    public $c2;
+    public $c3;
+    public $c4;
+}

--- a/Tests/Parser/FormTypeParserTest.php
+++ b/Tests/Parser/FormTypeParserTest.php
@@ -5,6 +5,7 @@ use Nelmio\ApiDocBundle\Form\Extension\DescriptionFormTypeExtension;
 use Nelmio\ApiDocBundle\Parser\FormTypeParser;
 use Nelmio\ApiDocBundle\Tests\Fixtures;
 use Symfony\Component\Form\Extension\Core\CoreExtension;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\FormFactory;
 use Symfony\Component\Form\FormFactoryBuilder;
 use Symfony\Component\Form\ResolvedFormTypeFactory;
@@ -145,6 +146,84 @@ class FormTypeParserTest extends \PHPUnit_Framework_TestCase
                         'description' => '',
                         'readonly' => false
                     )
+                )
+            ),
+            array(
+                array('class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Form\ImprovedTestType'),
+                array(
+                    'dt1' => array(
+                        'dataType' => 'datetime',
+                        'required' => true,
+                        'description' => 'A nice description',
+                        'readonly' => false,
+                        'format' => DateTimeType::HTML5_FORMAT,
+                    ),
+                    'dt2' => array(
+                        'dataType' => 'datetime',
+                        'required' => true,
+                        'description' => '',
+                        'readonly' => false,
+                        'format' => 'M/d/y',
+                    ),
+                    'dt3' => array(
+                        'dataType' => 'datetime',
+                        'required' => true,
+                        'description' => '',
+                        'readonly' => false,
+                        'format' => 'M/d/y H:i:s',
+                    ),
+                    'dt4' => array(
+                        'dataType' => 'datetime',
+                        'required' => true,
+                        'description' => '',
+                        'readonly' => false,
+                    ),
+                    'dt5' => array(
+                        'dataType' => 'datetime',
+                        'required' => true,
+                        'description' => '',
+                        'readonly' => false,
+                    ),
+                    'd1' => array(
+                        'dataType' => 'date',
+                        'required' => true,
+                        'description' => '',
+                        'readonly' => false,
+                    ),
+                    'd2' => array(
+                        'dataType' => 'date',
+                        'required' => true,
+                        'description' => '',
+                        'readonly' => false,
+                        'format' => 'd-M-y',
+                    ),
+                    'c1' => array(
+                        'dataType' => 'choice',
+                        'required' => true,
+                        'description' => '',
+                        'readonly' => false,
+                        'format' => json_encode(array('m' => 'Male', 'f' => 'Female')),
+                    ),
+                    'c2' => array(
+                        'dataType' => 'array of choices',
+                        'required' => true,
+                        'description' => '',
+                        'readonly' => false,
+                        'format' => json_encode(array('m' => 'Male', 'f' => 'Female')),
+                    ),
+                    'c3' => array(
+                        'dataType' => 'choice',
+                        'required' => true,
+                        'description' => '',
+                        'readonly' => false,
+                    ),
+                    'c4' => array(
+                        'dataType' => 'choice',
+                        'required' => true,
+                        'description' => '',
+                        'readonly' => false,
+                        'format' => json_encode(array('foo' => 'bar', 'baz' => 'Buzz')),
+                    ),
                 )
             ),
         );


### PR DESCRIPTION
Adds `date`, `datetime` & `choice` format support.
For `date` & `datetime` fields it is a date format.
For `choice` it is a list of values formatted as a JSON string.

Partially covers https://github.com/nelmio/NelmioApiDocBundle/pull/297 (date format & add support of collection)
