### PR TITLE
Don't try to call class with custom handlers.

### DIFF
--- a/Parser/JmsMetadataParser.php
+++ b/Parser/JmsMetadataParser.php
@@ -184,6 +184,14 @@ class JmsMetadataParser implements ParserInterface
             );
         }
 
+        // we can use type property also for custom handlers, then we don't have here real class name
+        if (!class_exists($type)) {
+            return array(
+                'normalized' => sprintf("custom handler result for (%s)", $type),
+                'class' => null
+            );
+        }
+
         // if we got this far, it's a general class name
         $exp = explode("\\", $type);
 


### PR DESCRIPTION
With JMS Serializer you can set up own type and use it later with custom handler for this property - Parser allways try to call that custom property type like a class. This fix that.
