### PR TITLE
Fix and properly document the https option

### DIFF
--- a/Annotation/ApiDoc.php
+++ b/Annotation/ApiDoc.php
@@ -222,6 +222,10 @@ class ApiDoc
         if (isset($data['deprecated'])) {
             $this->deprecated = $data['deprecated'];
         }
+
+        if (isset($data['https'])) {
+            $this->https = $data['https'];
+        }
     }
 
     /**

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -123,6 +123,8 @@ The following properties are available:
 
 * `description`: a description of the API method;
 
+* `https`: whether the method described requires the https protocol (default: `false`);
+
 * `deprecated`: allow to set method as deprecated (default: `false`);
 
 * `filters`: an array of filters;


### PR DESCRIPTION
The annotation `https` exists but isn't parsed and isn't documented.  Fix that!

The sandbox will insist that the `https` option exist if you're trying to use it with HTTPS, otherwise, it forces you to reload it as HTTP.
