### PR TITLE
Support for collections to output

### DIFF
--- a/DependencyInjection/LoadExtractorParsersPass.php
+++ b/DependencyInjection/LoadExtractorParsersPass.php
@@ -26,12 +26,12 @@ class LoadExtractorParsersPass implements CompilerPassInterface
         // validation may not be installed/enabled, if it is, load that config as well
         if ($container->hasDefinition('validator.mapping.class_metadata_factory')) {
             $loader->load('services.validation.xml');
-            $loader->load('services.output.array.xml');
         }
 
         // JMS may or may not be installed, if it is, load that config as well
         if ($container->hasDefinition('jms_serializer.serializer')) {
             $loader->load('services.jms.xml');
+            $loader->load('services.output.array.xml');
         }
     }
 }

--- a/DependencyInjection/LoadExtractorParsersPass.php
+++ b/DependencyInjection/LoadExtractorParsersPass.php
@@ -26,6 +26,7 @@ class LoadExtractorParsersPass implements CompilerPassInterface
         // validation may not be installed/enabled, if it is, load that config as well
         if ($container->hasDefinition('validator.mapping.class_metadata_factory')) {
             $loader->load('services.validation.xml');
+            $loader->load('services.output.array.xml');
         }
 
         // JMS may or may not be installed, if it is, load that config as well

--- a/Parser/OutputArrayParser.php
+++ b/Parser/OutputArrayParser.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Nelmio\ApiDocBundle\Parser;
+
+class OutputArrayParser implements ParserInterface
+{
+
+    /**
+     * @var ParserInterface
+     */
+    private $parser;
+
+    /**
+     * @param ParserInterface $parser
+     */
+    public function __construct(ParserInterface $parser)
+    {
+        $this->parser = $parser;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(array $item)
+    {
+        list($className, $type) = $this->getClassType($item);
+
+        if (empty($className) || empty($type)) {
+            return false;
+        }
+
+        $item['class'] = $className;
+
+        return $this->parser->supports($item);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parse(array $item)
+    {
+        list($classNameWithNamespace, $type) = $this->getClassType($item);
+
+        if (empty($classNameWithNamespace) || empty($type)) {
+            return false;
+        }
+
+        $className = explode("\\", $classNameWithNamespace);
+
+        $item['class'] = $classNameWithNamespace;
+
+        $returnData = array(
+            'dataType' => $type,
+            'required' => true,
+            'description' => sprintf("%s of objects (%s)", $type, end($className)),
+            'readonly' => false,
+            'children' => $this->parser->parse($item)
+        );
+
+        return array('[]' => $returnData);
+    }
+
+    /**
+     * @param array $item
+     *
+     * @return array
+     */
+    private function getClassType(array $item)
+    {
+        $className = $type = '';
+
+        if (preg_match('/(.+)\<(.+)\>/', $item['class'], $match)) {
+            $className = $match[2];
+            $type = $match[1];
+        }
+
+        return array($className, $type);
+    }
+
+}

--- a/Resources/config/services.output.array.xml
+++ b/Resources/config/services.output.array.xml
@@ -9,7 +9,7 @@
 
     <services>
         <service id="nelmio_api_doc.parser.output_array_parser" class="%nelmio_api_doc.parser.output_array_parser.class%">
-            <argument type="service" id="nelmio_api_doc.parser.validation_parser" />
+            <argument type="service" id="nelmio_api_doc.parser.jms_metadata_parser" />
             <tag name="nelmio_api_doc.extractor.parser" />
         </service>
     </services>

--- a/Resources/config/services.output.array.xml
+++ b/Resources/config/services.output.array.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="nelmio_api_doc.parser.output_array_parser.class">Nelmio\ApiDocBundle\Parser\OutputArrayParser</parameter>
+    </parameters>
+
+    <services>
+        <service id="nelmio_api_doc.parser.output_array_parser" class="%nelmio_api_doc.parser.output_array_parser.class%">
+            <argument type="service" id="nelmio_api_doc.parser.validation_parser" />
+            <tag name="nelmio_api_doc.extractor.parser" />
+        </service>
+    </services>
+
+</container>

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -96,6 +96,7 @@ class YourController extends Controller
     /**
      * @ApiDoc(
      *  description="Returns a collection of Object",
+     *  output="array<Your\Namespace\Class>"
      *  requirements={
      *      {
      *          "name"="limit",

--- a/Tests/Parser/OutputArrayParserTest.php
+++ b/Tests/Parser/OutputArrayParserTest.php
@@ -55,14 +55,10 @@ class OutputArrayParserTest extends WebTestCase
      */
     private function mockService()
     {
-        $serviceName = 'nelmio_api_doc.parser.validation_parser';
 
-        $service = $this->getContainer()->get($serviceName);
-
-        $mockedService = $this->getMockBuilder(get_class($service))
+        $mockedService = $this->getMockBuilder('Nelmio\ApiDocBundle\Parser\ValidationParser')
             ->disableOriginalConstructor()
             ->getMock();
-
 
         $mockMethods = array('supports', 'parse');
 

--- a/Tests/Parser/OutputArrayParserTest.php
+++ b/Tests/Parser/OutputArrayParserTest.php
@@ -55,7 +55,7 @@ class OutputArrayParserTest extends WebTestCase
      */
     private function mockService()
     {
-        $mockedService = $this->getMockBuilder('Nelmio\ApiDocBundle\Parser\ValidationParser')
+        $mockedService = $this->getMockBuilder('Nelmio\ApiDocBundle\Parser\JmsMetadataParser')
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/Tests/Parser/OutputArrayParserTest.php
+++ b/Tests/Parser/OutputArrayParserTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace NelmioApiDocBundle\Tests\Parser;
+
+use Nelmio\ApiDocBundle\Parser\OutputArrayParser;
+use Nelmio\ApiDocBundle\Tests\WebTestCase;
+
+class OutputArrayParserTest extends WebTestCase
+{
+
+    /**
+     * @var OutputArrayParser
+     */
+    private $objectUnderTest;
+
+    private $parseClassDefinition = array('class' => 'array<Nelmio\ApiDocBundle\Tests\Fixtures\Model\Test>');
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->objectUnderTest = new OutputArrayParser($this->mockService());
+    }
+
+    public function tearDown()
+    {
+        unset($this->objectUnderTest);
+    }
+
+    public function testReturnsTrueWhenClassAnnotationIsSupported()
+    {
+        $this->assertTrue($this->objectUnderTest->supports($this->parseClassDefinition));
+    }
+
+    public function testReturnsArrayWhenClassAnnotationHasArray()
+    {
+        $result = $this->objectUnderTest->parse($this->parseClassDefinition);
+        $this->assertArrayHasKey('[]', $result);
+        $this->assertArrayHasKey('dataType', $result['[]']);
+        $this->assertEquals('array', $result['[]']['dataType']);
+        $this->assertEquals('array of objects (Test)', $result['[]']['description']);
+    }
+
+    public function testReturnsFalseWhenClassAnnotationHasNoArray()
+    {
+        $result = $this->objectUnderTest->parse(
+            array('class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\Test')
+        );
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @return mixed
+     */
+    private function mockService()
+    {
+        $serviceName = 'nelmio_api_doc.parser.validation_parser';
+
+        $service = $this->getContainer()->get($serviceName);
+
+        $mockedService = $this->getMockBuilder(get_class($service))
+            ->disableOriginalConstructor()
+            ->getMock();
+
+
+        $mockMethods = array('supports', 'parse');
+
+        foreach ($mockMethods as $mockMethod) {
+
+            $mockedService->expects($this->any())
+                ->method($mockMethod)
+                ->will($this->returnValue(true));
+        }
+
+        return $mockedService;
+    }
+
+}

--- a/Tests/Parser/OutputArrayParserTest.php
+++ b/Tests/Parser/OutputArrayParserTest.php
@@ -55,7 +55,6 @@ class OutputArrayParserTest extends WebTestCase
      */
     private function mockService()
     {
-
         $mockedService = $this->getMockBuilder('Nelmio\ApiDocBundle\Parser\ValidationParser')
             ->disableOriginalConstructor()
             ->getMock();


### PR DESCRIPTION
I made changes to allows api output parameter to accept "array" of object 

```
    /**
     * @ApiDoc(
     *  description="Returns a collection of Object",
     *  output="array<Your\Namespace\Class>"
     * )
     */
```

Details are in issue https://github.com/nelmio/NelmioApiDocBundle/issues/306.