### PR TITLE
Testing against HHVM and PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - hhvm
 
 env:
     - SYMFONY_VERSION=2.1.*

--- a/Tests/EventListener/RequestListenerTest.php
+++ b/Tests/EventListener/RequestListenerTest.php
@@ -19,8 +19,10 @@ class RequestListenerTest extends WebTestCase
     {
         $client = $this->createClient();
 
-        $crawler = $client->request('GET', '/tests?_doc=1');
-        $this->assertEquals('/tests.{_format}', trim($crawler->filter(".operation .path:contains('/tests')")->text()), 'Event listener should capture ?_doc=1 requests');
+        $client->request('GET', '/tests?_doc=1');
+        $content = $client->getResponse()->getContent();
+        $this->assertTrue(0 !== strpos($content, '<h1>API documentation</h1>'), 'Event listener should capture ?_doc=1 requests');
+        $this->assertTrue(0 !== strpos($content, '/tests.{_format}'), 'Event listener should capture ?_doc=1 requests');
 
         $client->request('GET', '/tests');
         $this->assertEquals('tests', $client->getResponse()->getContent(), 'Event listener should let normal requests through');


### PR DESCRIPTION
This commit lets the Tests on Travis-CI complete for the HHVM.
For this to achieve, the RequestListenerTest had to be modified, because the used Crawler Component does not work in the 2.3.\* version only.
Also building against the new PHP 5.6 was added.
