### PR TITLE
Symfony web profiler integration

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -154,6 +154,17 @@
                     container.text(method + ' ' + url);
                 };
 
+                var displayProfilerUrl = function(xhr, link, container) {
+                    var profilerUrl = xhr.getResponseHeader('X-Debug-Token-Link');
+                    if (profilerUrl) {
+                        link.attr('href', profilerUrl);
+                        container.show();
+                    } else {
+                        link.attr('href', '');
+                        container.hide();
+                    }
+                }
+
                 var displayResponseData = function(xhr, container) {
                     var data = xhr.responseText;
 
@@ -174,6 +185,7 @@
 
                 var displayResponse = function(xhr, method, url, result_container) {
                     displayFinalUrl(xhr, method, url, $('.url', result_container));
+                    displayProfilerUrl(xhr, $('.profiler-link', result_container), $('.profiler', result_container));
                     displayResponseData(xhr, $('.response', result_container));
                     displayResponseHeaders(xhr, $('.headers', result_container));
 

--- a/Resources/views/method.html.twig
+++ b/Resources/views/method.html.twig
@@ -285,7 +285,7 @@
                             <h4>Request URL</h4>
                             <pre class="url"></pre>
 
-                            <h4>Response Headers&nbsp;<small>[<a href="" class="to-expand">Expand</a>]</small></h4>
+                            <h4>Response Headers&nbsp;<small>[<a href="" class="to-expand">Expand</a>]</small>&nbsp;<small class="profiler">[<a href="" class="profiler-link" target="_blank">Profiler</a>]</small></h4>
                             <pre class="headers to-expand"></pre>
 
                             <h4>Response Body&nbsp;<small>[<a href="" class="to-raw">Raw</a>]</small></h4>


### PR DESCRIPTION
Hello.
I bet you know that symfony has a great web profiler tool.
So I think that it would be probably a great idea to integrate the ApiDocBundle sandbox with web profiler. The idea is the following: if sandbox ajax responses contain web profiler headers like these:

```
X-Debug-Token: e3776a
X-Debug-Token-Link: /app_dev.php/_profiler/e3776a
```

Then the sandbox ui should show the corresponding link somewhere near the "Response Body" block.

What do you think?
