### PR TITLE
Sandbox should not be disabled in https whenever a method is not marked as https explictly

### DIFF
--- a/Resources/views/method.html.twig
+++ b/Resources/views/method.html.twig
@@ -193,7 +193,7 @@
 
             {% if enableSandbox %}
                 <div class="pane sandbox">
-                    {% if app.request is not null and app.request.secure != data.https %}
+                    {% if app.request is not null and data.https and app.request.secure != data.https %}
                     Please reload the documentation using the scheme {% if data.https %}HTTPS{% else %}HTTP{% endif %} if you want to use the sandbox.
                     {% else %}
                         <form method="{{ data.method|upper }}" action="{% if data.host is defined %}{{ data.https ? 'https://' : 'http://' }}{{ data.host }}{% endif %}{{ data.uri }}">


### PR DESCRIPTION
This PR is to enhance issue #283 and fixes issue #330.

What I did is to only disable the sandbox whenever a method has been explicitly marked as https and accessed through http. But whenever you access through https a method not explicitly marked it will allow it too!

@SimonSimCity does that break something for you?
