### PR TITLE
Add PostParserInterface to JmsMetadataParser to get ValidatorParser found children parsed

### DIFF
--- a/Extractor/ApiDocExtractor.php
+++ b/Extractor/ApiDocExtractor.php
@@ -293,11 +293,21 @@ class ApiDocExtractor
         // output (populates 'response' for the formatters)
         if (null !== $output = $annotation->getOutput()) {
             $response         = array();
+            $supportedParsers = array();
+
             $normalizedOutput = $this->normalizeClassParameter($output);
 
             foreach ($this->getParsers($normalizedOutput) as $parser) {
                 if ($parser->supports($normalizedOutput)) {
+                    $supportedParsers[] = $parser;
                     $response = $this->mergeParameters($response, $parser->parse($normalizedOutput));
+                }
+            }
+
+            foreach($supportedParsers as $parser) {
+                if($parser instanceof PostParserInterface) {
+                    $mp = $parser->postParse($normalizedOutput, $response);
+                    $response = $this->mergeParameters($response, $mp);
                 }
             }
 

--- a/Parser/JmsMetadataParser.php
+++ b/Parser/JmsMetadataParser.php
@@ -22,7 +22,7 @@ use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
 /**
  * Uses the JMS metadata factory to extract input/output model information
  */
-class JmsMetadataParser implements ParserInterface
+class JmsMetadataParser implements ParserInterface, PostParserInterface
 {
     /**
      * @var \Metadata\MetadataFactoryInterface
@@ -204,6 +204,40 @@ class JmsMetadataParser implements ParserInterface
     protected function isPrimitive($type)
     {
         return in_array($type, array('boolean', 'integer', 'string', 'float', 'double', 'array', 'DateTime'));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function postParse(array $input, array $parameters)
+    {
+        return $this->doPostParse($parameters);
+    }
+
+    /**
+     * Recursive `doPostParse` to avoid circular post parsing.
+     *
+     * @param array $parameters
+     * @param array $visited
+     * @return array
+     */
+    protected function doPostParse (array $parameters, array $visited = array())
+    {
+        foreach($parameters as $param => $data) {
+            if(isset($data['class']) && isset($data['children']) && !in_array($data['class'], $visited)) {
+                $visited[] = $data['class'];
+
+                $input = array('class' => $data['class'], 'groups' => isset($data['groups']) ? $data['groups'] : array());
+                $parameters[$param]['children'] = array_merge(
+                    $parameters[$param]['children'], $this->doPostParse($parameters[$param]['children'], $visited)
+                );
+                $parameters[$param]['children'] = array_merge(
+                    $parameters[$param]['children'], $this->doParse($input['class'], $visited, $input['groups'])
+                );
+            }
+        }
+
+        return $parameters;
     }
 
     /**

--- a/Tests/Fixtures/Model/MultipleTest.php
+++ b/Tests/Fixtures/Model/MultipleTest.php
@@ -21,6 +21,11 @@ class MultipleTest
     public $baz;
 
     /**
+     * @JMS\Type("Nelmio\ApiDocBundle\Tests\Fixtures\Model\Test")
+     */
+    public $related;
+
+    /**
      * @Assert\Type(type="array")
      * @Assert\All({
      *     @Assert\Type(type="Test")

--- a/Tests/Formatter/MarkdownFormatterTest.php
+++ b/Tests/Formatter/MarkdownFormatterTest.php
@@ -489,6 +489,18 @@ number:
 
   * type: DateTime
 
+related:
+
+  * type: object (Test)
+
+related[a]:
+
+  * type: string
+
+related[b]:
+
+  * type: DateTime
+
 
 ### `ANY` /z-return-selected-parsers-input ###
 
@@ -534,6 +546,18 @@ objects[][b]:
   * type: DateTime
 
 number:
+
+  * type: DateTime
+
+related:
+
+  * type: object (Test)
+
+related[a]:
+
+  * type: string
+
+related[b]:
 
   * type: DateTime
 MARKDOWN;

--- a/Tests/Formatter/SimpleFormatterTest.php
+++ b/Tests/Formatter/SimpleFormatterTest.php
@@ -849,6 +849,27 @@ With multiple lines.',
                                     'readonly' => null
                                 )
                             )
+                        ),
+                        'related' => array(
+                            'dataType' => 'object (Test)',
+                            'readonly' => false,
+                            'required' => false,
+                            'description' => '',
+                            'sinceVersion' => null,
+                            'untilVersion' => null,
+                            'children' => array(
+                                'a' => array(
+                                    'dataType' => 'string',
+                                    'format' => '{length: min: foo}, {not blank}',
+                                    'required' => true,
+                                    'readonly' => null
+                                ),
+                                'b' => array(
+                                    'dataType' => 'DateTime',
+                                    'required' => null,
+                                    'readonly' => null
+                                )
+                            )
                         )
                     ),
                     'authenticationRoles' => array(),
@@ -908,6 +929,27 @@ With multiple lines.',
                             'dataType' => 'array of objects (Test)',
                             'readonly' => null,
                             'required' => null,
+                            'children' => array(
+                                'a' => array(
+                                    'dataType' => 'string',
+                                    'format' => '{length: min: foo}, {not blank}',
+                                    'required' => true,
+                                    'readonly' => null
+                                ),
+                                'b' => array(
+                                    'dataType' => 'DateTime',
+                                    'required' => null,
+                                    'readonly' => null
+                                )
+                            )
+                        ),
+                        'related' => array(
+                            'dataType' => 'object (Test)',
+                            'readonly' => false,
+                            'required' => false,
+                            'description' => '',
+                            'sinceVersion' => null,
+                            'untilVersion' => null,
                             'children' => array(
                                 'a' => array(
                                     'dataType' => 'string',


### PR DESCRIPTION
This PR aims to add and implements `PostParserInterface` on `JmsMetadataParser`. 
This way, children found by any other parser will be parsed by JMS parser.
