### PR TITLE
Disable usage of endpoint if host is defined

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -273,9 +273,12 @@
                     }
                     var data = content.length ? content : body;
 
+
+                    url = ($(this).data('use-endpoint') ? endpoint : '') + url;
+
                     // and trigger the API call
                     $.ajax({
-                        url: endpoint + url,
+                        url: url,
                         type: method,
                         data: data,
                         headers: headers,

--- a/Resources/views/method.html.twig
+++ b/Resources/views/method.html.twig
@@ -196,7 +196,7 @@
                     {% if app.request is not null and data.https and app.request.secure != data.https %}
                     Please reload the documentation using the scheme {% if data.https %}HTTPS{% else %}HTTP{% endif %} if you want to use the sandbox.
                     {% else %}
-                        <form method="{{ data.method|upper }}" action="{% if data.host is defined %}{{ data.https ? 'https://' : 'http://' }}{{ data.host }}{% endif %}{{ data.uri }}">
+                        <form method="{{ data.method|upper }}" action="{% if data.host is defined %}{{ data.https ? 'https://' : 'http://' }}{{ data.host }}{% endif %}{{ data.uri }}" data-use-endpoint="{{ data.host is defined ? 'false' : 'true' }}">
                             <fieldset class="parameters">
                                 <legend>Input</legend>
                                 {% if data.requirements is defined %}


### PR DESCRIPTION
If host is defined for api doc routes, the generated url is wrong. I used this this to fix the issue.

```
app/console router:debug
[...]
backend_dashboard                   ANY      ANY    back.local.com /
nelmio_api_doc_index                GET      ANY    api.local.com  /doc/ 
```
