### PR TITLE
Fix parse of input forms with options required

### DIFF
--- a/Parser/FormTypeParser.php
+++ b/Parser/FormTypeParser.php
@@ -104,7 +104,7 @@ class FormTypeParser implements ParserInterface
                         $bestType = sprintf('array of %ss', $this->mapTypes[$config->getOption('type')]);
                     } else {
                         // Embedded form collection
-                        $subParameters = $this->parseForm($this->formFactory->create($config->getOption('type')), $name . '[]');
+                        $subParameters = $this->parseForm($this->formFactory->create($config->getOption('type'), null, $config->getOption('options', array())), $name . '[]');
                         $parameters = array_merge($parameters, $subParameters);
 
                         continue 2;


### PR DESCRIPTION
When form like model type was parsed this pass the required 'class' option to enable the build of the class
