### PR TITLE
Add better support for nested constraints in @All

### DIFF
--- a/Tests/Parser/ValidationParserTest.php
+++ b/Tests/Parser/ValidationParserTest.php
@@ -148,7 +148,27 @@ class ValidationParserTest extends WebTestCase
                 'expected' => array(
                     'format' => '{url}, {length: min: 10}'
                 )
-            )
+            ),
+            array(
+                'property' => 'arrayOfDateTimes',
+                'expected' => array(
+                    'dataType' => 'array of objects (DateTime)',
+                    'class' => 'DateTime',
+                )
+            ),
+            array(
+                'property' => 'arrayOfStrings',
+                'expected' => array(
+                    'dataType' => 'array of type (string)',
+                )
+            ),
+            array(
+                'property' => 'arrayOfIpAddresses',
+                'expected' => array(
+                    'dataType' => 'array',
+                    'format' => '{ip address}'
+                )
+            ),
         );
     }
 }


### PR DESCRIPTION
If I have a constraint along the lines of `@Assert\All( @Assert\Type("string") )` or `@Assert\All( @Assert\Ip )` the bundle doesnt handle this case very well - this is an attempt to make the api doc generated more appropriate in the cases where such annotations are used.

I'm not sure if I've just hacked this to pieces and it needs cleaning up or not and would appreciate a review.
