### PR TITLE
Apply JMS naming strategy consistenly if available

### DIFF
--- a/Annotation/ApiDoc.php
+++ b/Annotation/ApiDoc.php
@@ -548,15 +548,15 @@ class ApiDoc
         }
 
         if ($parameters = $this->parameters) {
-            $data['parameters'] = $parameters;
+            $data['parameters'] = $this->applyAliases($parameters);
         }
 
         if ($requirements = $this->requirements) {
-            $data['requirements'] = $requirements;
+            $data['requirements'] = $this->applyAliases($requirements);
         }
 
         if ($response = $this->response) {
-            $data['response'] = $response;
+            $data['response'] = $this->applyAliases($response);
         }
 
         if ($statusCodes = $this->statusCodes) {
@@ -577,5 +577,25 @@ class ApiDoc
         $data['deprecated'] = $this->deprecated;
 
         return $data;
+    }
+
+    private function applyAliases(array $items)
+    {
+        $aliasedItems = array();
+
+        foreach ($items as $name => $data) {
+            if (isset($data['alias'])) {
+                $name = $data['alias'];
+                unset($data['alias']);
+            }
+
+            if (isset($data['children'])) {
+                $data['children'] = $this->applyAliases($data['children']);
+            }
+
+            $aliasedItems[$name] = $data;
+        }
+
+        return $aliasedItems;
     }
 }

--- a/Parser/JmsMetadataParser.php
+++ b/Parser/JmsMetadataParser.php
@@ -107,7 +107,8 @@ class JmsMetadataParser implements ParserInterface
         // iterate over property metadata
         foreach ($meta->propertyMetadata as $item) {
             if (!is_null($item->type)) {
-                $name = $this->namingStrategy->translateName($item);
+                $name = $item->name;
+                $serializedName = $this->namingStrategy->translateName($item);
 
                 $dataType = $this->processDataType($item);
 
@@ -127,6 +128,10 @@ class JmsMetadataParser implements ParserInterface
                     'sinceVersion' => $item->sinceVersion,
                     'untilVersion' => $item->untilVersion,
                 );
+
+                if ($name !== $serializedName) {
+                    $params[$name]['alias'] = $serializedName;
+                }
 
                 if (!is_null($dataType['class'])) {
                     $params[$name]['class'] = $dataType['class'];


### PR DESCRIPTION
This commit makes sure that if the JMS parser is used, it properly uses
the naming strategy and applies a possibly different name to all parameters, requirements and filters if applicable.

Changes:
- The JMS parser no longer replaces the property name, because
  that will cause duplicate property keys (e.g. camelCase and with
  underscores)
- if the serialized name differs form the property name, it is saved
  with the key 'alias' in the property data
- The ApiDoc::toArray() method now applies aliases to any property name
  if an alias exists in the property data.
