### PR TITLE
FormTypeParser: FormType constructor should be called when possible

### DIFF
--- a/Parser/FormTypeParser.php
+++ b/Parser/FormTypeParser.php
@@ -204,7 +204,15 @@ class FormTypeParser implements ParserInterface
 
     private function getTypeInstance($type)
     {
-        return unserialize(sprintf('O:%d:"%s":0:{}', strlen($type), $type));
+        $refl = new \ReflectionClass($type);
+        $constructor = $refl->getConstructor();
+
+        // this fallback may lead to runtime exception, but try hard to generate the docs
+        if ($constructor && $constructor->getNumberOfRequiredParameters() > 0) {
+            return $refl->newInstanceWithoutConstructor();
+        }
+
+        return $refl->newInstance();
     }
 
     private function createForm($item)

--- a/Tests/Fixtures/Form/RequireConstructionType.php
+++ b/Tests/Fixtures/Form/RequireConstructionType.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Fixtures\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class RequireConstructionType extends AbstractType
+{
+    private $noThrow;
+
+    public function __construct($optionalArgs = null)
+    {
+        $this->noThrow = true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        if ($this->noThrow !== true)
+            throw new \RuntimeException(__CLASS__ . " require contruction");
+
+        $builder
+            ->add('a', null, array('description' => 'A nice description'))
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\Test',
+        ));
+
+        return;
+    }
+
+
+    public function getName()
+    {
+        return 'require_construction_type';
+    }
+}

--- a/Tests/Parser/FormTypeParserTest.php
+++ b/Tests/Parser/FormTypeParserTest.php
@@ -226,6 +226,28 @@ class FormTypeParserTest extends \PHPUnit_Framework_TestCase
                     ),
                 )
             ),
+            array(
+                array('class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Form\RequireConstructionType'),
+                array(
+                    'require_construction_type[a]' => array(
+                        'dataType' => 'string',
+                        'required' => true,
+                        'description' => 'A nice description',
+                        'readonly' => false
+                    )
+                )
+            ),
+            array(
+                array('class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Form\DependencyType'),
+                array(
+                    'dependency_type[a]' => array(
+                        'dataType' => 'string',
+                        'required' => true,
+                        'description' => 'A nice description',
+                        'readonly' => false
+                    )
+                )
+            ),
         );
     }
 }


### PR DESCRIPTION
I've found a problem with the FormTypeParser. When generating FormTypes used for the doc generation, the type constructor is not called.

By looking to the code, I've found that the FormType class is created from the outer space with:

``` php
private function getTypeInstance($type)
{
    return unserialize(sprintf('O:%d:"%s":0:{}', strlen($type), $type));
}
```

IMHO, this approach is correct if, and only if, no method of that class are called.
Consider the following simple type, with subscribers support:

``` php
<?php
namespace Acme\AcmeBundle\Form\Type;

use Symfony\Component\Form\AbstractType;
use Symfony\Component\Form\FormBuilderInterface;
use Symfony\Component\OptionsResolver\OptionsResolverInterface;
use Symfony\Component\EventDispatcher\EventSubscriberInterface;

class ATweekableType extends AbstractType
{
    private $subscribers;

    public function __construct()
    {
        $this->subscribers = array();
    }

    public function addSubscriber(EventSubscriberInterface $subscriber)
    {
        $this->subscribers[] = $subscriber;
    }

    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder->add('many_things');
        foreach ($this->subscribers as $subscriber) {
                $builder->addEventSubscriber($subscriber);
        }
    }

    public function setDefaultOptions(OptionsResolverInterface $resolver)
    {
        $resolver->setDefaults(array());
    }

    public function getName()
    {
        return 'acme_atweekabletype';
    }
}
```

By parsing the type a notice is triggered since the foreach loop expects the subscriber array to be initialized. Obviously this is a simple example, but more bugs situation may arise.

With this patch, the constructor is called if available and has no required parameters. Otherwise, it try to fallback and create a new instance without calling the constructor as a fallback (and if it fails, then the developer should really consider using DI).
