### PR TITLE
Added fix for doubled parameters

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -269,6 +269,7 @@
                         self = this,
                         params = {},
                         formData = new FormData(),
+                        doubledParams = {},
                         headers = {},
                         content = $(this).find('textarea.content').val(),
                         result_container = $('.result', $(this).parent());
@@ -338,7 +339,12 @@
                         value = $('.value', $(this)).val();
 
                         if (value) {
-                            params[key] = value;
+                            // temporary save all additional/doubled parameters
+                            if (key in params) {
+                                doubledParams[key] = value;
+                            } else {
+                                params[key] = value;
+                            }
                         }
                     });
 
@@ -367,7 +373,12 @@
                         }
                     };
 
-                    // disable all the fields and buttons
+                    // merge additional params back to real params object
+                    if (!$.isEmptyObject(doubledParams)) {
+                        $.extend(params, doubledParams);
+                    }
+
+                    // disable all the fiels and buttons
                     $('input, button', $(this)).attr('disabled', 'disabled');
 
                     // append the query authentication


### PR DESCRIPTION
As explained in #343 it is not possible to have same field in both the request uri and in query string or request body.

This little fix tries to solve this problem. All _doubled_ fields are temporary saved and merged back to the real `params` variable after the request url has been populated.

Want to reproduce the behavior?
Create a resource which takes some route parameter `foo`. The resource could contain in the request body a field which is named equal to this route parameter. This results in a field named `foo` in the _Requirements_ and a field named `foo` in the _Parameters_ list.

Please do not ask why I need those parameters like this. It's a customer requirement :)

What do you think?
