### PR TITLE
Pressing enter in the sandbox mode will now lead to submit the form.

### DIFF
--- a/Resources/views/method.html.twig
+++ b/Resources/views/method.html.twig
@@ -230,7 +230,7 @@
                                         </p>
                                     {% endif %}
                                     {% endfor %}
-                                    <button class="add">New parameter</button>
+                                    <button type="button" class="add">New parameter</button>
                                 {% endif %}
 
                             </fieldset>
@@ -252,7 +252,7 @@
                                     <input type="text" class="value" placeholder="Value" /> <span class="remove">-</span>
                                 </p>
 
-                                <button class="add">New header</button>
+                                <button type="button" class="add">New header</button>
                             </fieldset>
 
                             <fieldset class="request-content">
@@ -264,7 +264,7 @@
                                     <input type="text" class="key content-type" value="Content-Type" disabled="disabled" />
                                     <span>=</span>
                                     <input type="text" class="value" placeholder="Value" />
-                                    <button class="set-content-type">Set header</button> <small>Replaces header if set</small>
+                                    <button  type="button" class="set-content-type">Set header</button> <small>Replaces header if set</small>
                                 </p>
                             </fieldset>
 


### PR DESCRIPTION
From other tools like DHC or POSTMAN I was used to it, that pressing the enter key, the request was submitted. In the sandbox mode, when you clicked enter, there always was added a new header, as the button was the first appearing in the html markup and if a button has no type, the type is submit by default. Thus, I just added a type attribute to avoid that. 
Hope this is fine :)
