### PR TITLE
Add support for nullable option in RequestParam annotation

### DIFF
--- a/Annotation/ApiDoc.php
+++ b/Annotation/ApiDoc.php
@@ -525,6 +525,13 @@ class ApiDoc
     /**
      * @return array
      */
+    public function getParameters() {
+        return $this->parameters;
+    }
+
+    /**
+     * @return array
+     */
     public function getTags()
     {
         return $this->tags;

--- a/Extractor/Handler/FosRestHandler.php
+++ b/Extractor/Handler/FosRestHandler.php
@@ -29,7 +29,7 @@ class FosRestHandler implements HandlerInterface
         foreach ($annotations as $annot) {
             if ($annot instanceof RequestParam) {
                 $annotation->addParameter($annot->name, array(
-                    'required'    => $annot->strict && $annot->default === null,
+                    'required'    => $annot->strict && $annot->nullable === false && $annot->default === null,
                     'dataType'    => $this->handleRequirements($annot->requirements),
                     'description' => $annot->description,
                     'readonly'    => false

--- a/Tests/Extractor/ApiDocExtractorTest.php
+++ b/Tests/Extractor/ApiDocExtractorTest.php
@@ -15,7 +15,7 @@ use Nelmio\ApiDocBundle\Tests\WebTestCase;
 
 class ApiDocExtractorTest extends WebTestCase
 {
-    const ROUTES_QUANTITY = 24;
+    const ROUTES_QUANTITY = 25;
 
     public function testAll()
     {

--- a/Tests/Extractor/Handler/FosRestHandlerTest.php
+++ b/Tests/Extractor/Handler/FosRestHandlerTest.php
@@ -105,4 +105,55 @@ class FosRestHandlerTest extends WebTestCase
         $this->assertEquals($filter['requirement'], 'Email');
     }
 
+    public function testGetWithRequestParam()
+    {
+        $container  = $this->getContainer();
+        $extractor  = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
+        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\TestController::zActionWithRequestParamAction', 'test_route_11');
+
+        $this->assertNotNull($annotation);
+
+        $parameters = $annotation->getParameters();
+        $this->assertCount(1, $parameters);
+        $this->assertArrayHasKey('param1', $parameters);
+
+        $parameter = $parameters['param1'];
+
+        $this->assertArrayHasKey('dataType', $parameter);
+        $this->assertEquals($parameter['dataType'], 'string');
+
+        $this->assertArrayHasKey('description', $parameter);
+        $this->assertEquals($parameter['description'], 'Param1 description.');
+
+        $this->assertArrayHasKey('required', $parameter);
+        $this->assertEquals($parameter['required'], true);
+
+        $this->assertArrayNotHasKey('default', $parameter);
+    }
+
+    public function testGetWithRequestParamNullable()
+    {
+        $container  = $this->getContainer();
+        $extractor  = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
+        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\TestController::zActionWithNullableRequestParamAction', 'test_route_22');
+
+        $this->assertNotNull($annotation);
+
+        $parameters = $annotation->getParameters();
+        $this->assertCount(1, $parameters);
+        $this->assertArrayHasKey('param1', $parameters);
+
+        $parameter = $parameters['param1'];
+
+        $this->assertArrayHasKey('dataType', $parameter);
+        $this->assertEquals($parameter['dataType'], 'string');
+
+        $this->assertArrayHasKey('description', $parameter);
+        $this->assertEquals($parameter['description'], 'Param1 description.');
+
+        $this->assertArrayHasKey('required', $parameter);
+        $this->assertEquals($parameter['required'], false);
+
+        $this->assertArrayNotHasKey('default', $parameter);
+    }
 }

--- a/Tests/Fixtures/Controller/TestController.php
+++ b/Tests/Fixtures/Controller/TestController.php
@@ -169,6 +169,14 @@ class TestController
 
     /**
      * @ApiDoc()
+     * @RequestParam(name="param1", requirements="string", description="Param1 description.", nullable=true)
+     */
+    public function zActionWithNullableRequestParamAction()
+    {
+    }
+
+    /**
+     * @ApiDoc()
      */
     public function secureRouteAction()
     {

--- a/Tests/Fixtures/app/config/routing.yml
+++ b/Tests/Fixtures/app/config/routing.yml
@@ -155,3 +155,9 @@ test_route_21:
     defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithConstraintAsRequirements }
     requirements:
         _method: GET
+
+test_route_22:
+    pattern:  /z-action-with-nullable-request-param
+    defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithNullableRequestParam }
+    requirements:
+        _method: POST

--- a/Tests/Formatter/MarkdownFormatterTest.php
+++ b/Tests/Formatter/MarkdownFormatterTest.php
@@ -418,6 +418,18 @@ nested_array[]:
 
 
 
+### `POST` /z-action-with-nullable-request-param ###
+
+
+#### Parameters ####
+
+param1:
+
+  * type: string
+  * required: false
+  * description: Param1 description.
+
+
 ### `GET` /z-action-with-query-param ###
 
 

--- a/Tests/Formatter/SimpleFormatterTest.php
+++ b/Tests/Formatter/SimpleFormatterTest.php
@@ -741,6 +741,25 @@ With multiple lines.',
                 ),
                 11 =>
                 array(
+                    'method' => 'POST',
+                    'uri' => '/z-action-with-nullable-request-param',
+                    'parameters' =>
+                    array(
+                        'param1' =>
+                        array(
+                            'required' => false,
+                            'dataType' => 'string',
+                            'description' => 'Param1 description.',
+                            'readonly' => false,
+                        ),
+                    ),
+                    'https' => false,
+                    'authentication' => false,
+                    'authenticationRoles' => array(),
+                    'deprecated' => false,
+                ),
+                12 =>
+                array(
                     'method' => 'GET',
                     'uri' => '/z-action-with-query-param',
                     'filters' =>
@@ -757,7 +776,7 @@ With multiple lines.',
                     'authenticationRoles' => array(),
                     'deprecated' => false,
                 ),
-                12 =>
+                13 =>
                 array(
                     'method' => 'GET',
                     'uri' => '/z-action-with-query-param-no-default',
@@ -774,7 +793,7 @@ With multiple lines.',
                     'authenticationRoles' => array(),
                     'deprecated' => false,
                 ),
-                13 =>
+                14 =>
                 array(
                     'method' => 'GET',
                     'uri' => '/z-action-with-query-param-strict',
@@ -792,7 +811,7 @@ With multiple lines.',
                     'authenticationRoles' => array(),
                     'deprecated' => false,
                 ),
-                14 =>
+                15 =>
                 array(
                     'method' => 'POST',
                     'uri' => '/z-action-with-request-param',
@@ -811,7 +830,7 @@ With multiple lines.',
                     'authenticationRoles' => array(),
                     'deprecated' => false,
                 ),
-                15 =>
+                16 =>
                 array(
                     'method' => 'ANY',
                     'uri' => '/z-return-jms-and-validator-output',
@@ -853,7 +872,7 @@ With multiple lines.',
                     ),
                     'authenticationRoles' => array(),
                 ),
-                16 =>
+                17 =>
                 array(
                     'method' => "ANY",
                     'uri' => "/z-return-selected-parsers-input",
@@ -883,7 +902,7 @@ With multiple lines.',
                         ),
                     )
                 ),
-                17 =>
+                18 =>
                 array(
                     'method' => "ANY",
                     'uri' => "/z-return-selected-parsers-output",


### PR DESCRIPTION
I have a use case where I have validation requirements on `RequestParam` but still allow the parameter not to be set in requests (through the `nullable=true` Annotation option). The problem is that the API documentation generated show these as required parameters.
Thia feature is already supported in NelmioApiDocBundle on `QueryParam`, but not `RequestParam`, though both annotations supports the option.

My usage is like this:

```
@RequestParam(name="company", requirements=".{0,255}", description="Optional Company name on the receipt (max 255 char)", nullable=true)
```

I think it would be nice if the documentation reflected that the parameter is indeed not required. 
The issue is also related to #360, but supported through the right property (`nullable`) in RequestParam annotation.
