### PR TITLE
If a description is not provided use form label

### DIFF
--- a/Parser/FormTypeParser.php
+++ b/Parser/FormTypeParser.php
@@ -187,7 +187,7 @@ class FormTypeParser implements ParserInterface
                                     'default'     => null,
                                     'subType'     => $subType,
                                     'required'    => $config->getRequired(),
-                                    'description' => $config->getAttribute('description'),
+                                    'description' => ($config->getOption('description')) ? $config->getOption('description'):$config->getOption('label'),
                                     'readonly'    => $config->getDisabled(),
                                     'children'    => $children,
                                 );
@@ -205,7 +205,7 @@ class FormTypeParser implements ParserInterface
                                 'actualType'  => 'string',
                                 'default'     => $config->getData(),
                                 'required'    => $config->getRequired(),
-                                'description' => $config->getAttribute('description'),
+                                'description' => ($config->getOption('description')) ? $config->getOption('description'):$config->getOption('label'),
                                 'readonly'    => $config->getDisabled(),
                             );
                         }
@@ -221,7 +221,7 @@ class FormTypeParser implements ParserInterface
                 'subType'     => $subType,
                 'default'     => $config->getData(),
                 'required'    => $config->getRequired(),
-                'description' => $config->getAttribute('description'),
+                'description' => ($config->getOption('description')) ? $config->getOption('description'):$config->getOption('label'),
                 'readonly'    => $config->getDisabled(),
             );
 


### PR DESCRIPTION
It would be nice if there was no description the form label was used instead. In the future I think it would be even better to have the label as an header, and the description as 'additional' instructions.
