### PR TITLE
Parse JSM\Inline, fixes #372

### DIFF
--- a/Tests/Fixtures/Model/JmsInline.php
+++ b/Tests/Fixtures/Model/JmsInline.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Nelmio\ApiDocBundle\Tests\Fixtures\Model;
+
+use JMS\Serializer\Annotation as JMS;
+
+class JmsInline
+{
+    /**
+     * @JMS\Type("string");
+     */
+    public $foo;
+
+    /**
+     * @JMS\Inline
+     */
+    public $inline;
+}


### PR DESCRIPTION
This properly parses the JMS\Inline property. The inlined item itself is skipped and it's children are included directly. This fixes #372.
