### PR TITLE
Don't parse custom properties as classes.

### DIFF
--- a/Parser/JmsMetadataParser.php
+++ b/Parser/JmsMetadataParser.php
@@ -150,6 +150,11 @@ class JmsMetadataParser implements ParserInterface, PostParserInterface
                     }
                 }
 
+                // we can use type property also for custom handlers, then we don't have here real class name
+                if (!class_exists($dataType['class'])) {
+                    continue;
+                }
+
                 // if class already parsed, continue, to avoid infinite recursion
                 if (in_array($dataType['class'], $visited)) {
                     continue;


### PR DESCRIPTION
Sometimes instead real class name we can use custom handler name. Then this class can't be initialized and we will get this exception `ReflectionException: Class custom_handler_name does not exist`
