### PR TITLE
fixed css for tags output

### DIFF
--- a/Resources/public/css/screen.css
+++ b/Resources/public/css/screen.css
@@ -296,7 +296,7 @@ li.operation .heading h3 span.path {
   padding-left: 5px;
 }
 
-li.operation a.heading h3 span.tag {
+li.operation .heading h3 span.tag {
   color: #FFFFFF;
   font-size: 0.7em;
   vertical-align: baseline;


### PR DESCRIPTION
I updated to master yesterday and noticed the tags feature (#395) is missing the border/background-color. Here is a simple fix for it. Hope i made this pull request right.
