### PR TITLE
Added caching layer

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -152,6 +152,13 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->arrayNode('cache')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('enabled')->defaultValue(false)->end()
+                        ->scalarNode('file')->defaultValue('%kernel.cache_dir%/api-doc.cache')->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -12,6 +12,7 @@
 namespace Nelmio\ApiDocBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -63,6 +64,14 @@ class NelmioApiDocExtension extends Extension
         $container->setParameter('nelmio_api_doc.swagger.api_version', $config['swagger']['api_version']);
         $container->setParameter('nelmio_api_doc.swagger.info', $config['swagger']['info']);
 
+        if ($config['cache']['enabled'] === true) {
+            $arguments = $container->getDefinition('nelmio_api_doc.extractor.api_doc_extractor')->getArguments();
+            $caching = new Definition('Nelmio\ApiDocBundle\Extractor\CachingApiDocExtractor');
+            $arguments[] = $container->getParameterBag()->resolveValue($config['cache']['file']);
+            $arguments[] = $container->getParameter('kernel.debug');
+            $caching->setArguments($arguments);
+            $container->setDefinition('nelmio_api_doc.extractor.api_doc_extractor', $caching);
+        }
     }
 
     /**

--- a/Extractor/CachingApiDocExtractor.php
+++ b/Extractor/CachingApiDocExtractor.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Extractor;
+
+use Doctrine\Common\Annotations\Reader;
+use Nelmio\ApiDocBundle\Util\DocCommentExtractor;
+use Symfony\Component\Config\ConfigCache;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Class CachingApiDocExtractor
+ *
+ * @author Bez Hermoso <bez@activelamp.com>
+ */
+class CachingApiDocExtractor extends ApiDocExtractor
+{
+    /**
+     * @var \Symfony\Component\Config\ConfigCache
+     */
+    protected $cache;
+
+    protected $cacheFile;
+
+    public function __construct(
+        ContainerInterface $container,
+        RouterInterface $router,
+        Reader $reader,
+        DocCommentExtractor $commentExtractor,
+        array $handlers,
+        $cacheFile,
+        $debug = false
+    ) {
+        parent::__construct($container, $router, $reader, $commentExtractor, $handlers);
+        $this->cacheFile = $cacheFile;
+        $this->cache = new ConfigCache($this->cacheFile, $debug);
+    }
+
+    public function all()
+    {
+        if ($this->cache->isFresh() === false) {
+
+            $resources = array();
+
+            foreach ($this->getRoutes() as $route) {
+                if ( null !== ($method = $this->getReflectionMethod($route->getDefault('_controller')))
+                  && null !== ($annotation = $this->reader->getMethodAnnotation($method, self::ANNOTATION_CLASS))) {
+                    $file = $method->getDeclaringClass()->getFileName();
+                    $resources[] = new FileResource($file);
+                }
+            }
+
+            $resources = array_merge($resources, $this->router->getRouteCollection()->getResources());
+
+            $data = parent::all();
+            $this->cache->write(serialize($data), $resources);
+            
+            return $data;
+        }
+
+        return unserialize(file_get_contents($this->cacheFile));
+
+    }
+} 

--- a/Tests/Extractor/ApiDocExtractorTest.php
+++ b/Tests/Extractor/ApiDocExtractorTest.php
@@ -28,6 +28,10 @@ class ApiDocExtractorTest extends WebTestCase
         $this->assertTrue(is_array($data));
         $this->assertCount(self::ROUTES_QUANTITY, $data);
 
+        $cacheFile = $container->getParameter('kernel.cache_dir') . '/api-doc.cache';
+        $this->assertFileExists($cacheFile);
+        $this->assertEquals(file_get_contents($cacheFile), serialize($data));
+
         foreach ($data as $d) {
             $this->assertTrue(is_array($d));
             $this->assertArrayHasKey('annotation', $d);

--- a/Tests/Fixtures/app/config/default.yml
+++ b/Tests/Fixtures/app/config/default.yml
@@ -53,6 +53,8 @@ jms_serializer:
         auto_detection: true
 
 nelmio_api_doc:
+    cache:
+        enabled: true
     exclude_sections: ["private", "exclusive"]
     swagger:
         api_base_path: /api


### PR DESCRIPTION
To improve performance, the `ApiDoc` metadata is being cached and automatically invalidated when any of the routing files and related controllers are updated.

Added a few tests for this. Please let me know if they are insufficient and how I can improve them.
