### PR TITLE
Fix toggler click event

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -95,7 +95,7 @@
                 if(contentContainer.is(':visible')) {
                     clearHash();
                 } else {
-                    setHash($(this).attr('href'));
+                    setHash($(this).data('href'));
                 }
 
                 contentContainer.slideToggle('fast');


### PR DESCRIPTION
On the master branch the .toggle div (https://github.com/EmmanuelVella/NelmioApiDocBundle/blob/master/Resources/views/method.html.twig#L2) has a data-href attribute since https://github.com/nelmio/NelmioApiDocBundle/commit/0a42d1773cbad7fffda9b07ef0714e1092fc6060#diff-d54056867729d3fa16536eed2bdd1715R2

BTW, why the 2.6.0 tag doesn't have this commit ?
