### PR TITLE
Update branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     "target-dir": "Nelmio/ApiDocBundle",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.5.x-dev"
+            "dev-master": "2.6.x-dev"
         }
     }
 }


### PR DESCRIPTION
there is a release 2.6.0 and no 2.6 branch so i would assume the alias of master should be on 2.6 now, not 2.5 anymore.
