### PR TITLE
api:swagger:dump update

### DIFF
--- a/Resources/doc/swagger-support.md
+++ b/Resources/doc/swagger-support.md
@@ -80,7 +80,7 @@ Et voila!, simply specify http://yourdomain.com/api-docs in your Swagger client 
 The routes registered with the method above will read your `@ApiDoc` annotation during every request. Naturally, this will be slow because the bundle will parse your annotations every single time. For improved performance, you might be better off dumping the JSON output to the file-system and let your web-server serve them directly. If you want that, execute this command:
 
 ```
-php app/console api:swagger:dump --all app/Resources/swagger-docs
+php app/console api:swagger:dump app/Resources/swagger-docs
 ```
 
 The above command will dump JSON files under the `app/Resources/swagger-docs` directory (relative to your project root), and you can now process or server the files however you want. The destination defaults to the project root if not specified.
@@ -89,12 +89,12 @@ The above command will dump JSON files under the `app/Resources/swagger-docs` di
 
 Dump the `api-docs.json` resource list file only:
 ```
-php app/console api:swagger:dump --list-only
+php app/console api:swagger:dump --list-only api-docs.json
 ```
 
 Dump a specific resource API declaration only:
 ```
-php app/console api:swagger:dump --resource=users
+php app/console api:swagger:dump --resource=users users.json
 ```
 The above command will dump the `/users` API declaration in an `users.json` file.
 


### PR DESCRIPTION
I changed the behavior of the `api:swagger:dump` command to be more consistent with most dumping commands.

Currently, the command only supports dumping directly to a file via the required `destination` argument. I realized that it would be more ideal if dumping to a file is optional, and that it should default to just dump the output to the console. This will be helpful for debugging, and will also allow us to pipe the JSON output to other programs.

Here are the changes:
- Removed the `--all` flag. All docs will be dumped if both `--list-only` and `--resource=...` is not provided.
- All calls will default to dump to the console.

To dump to a file:

```
php app/console api:swagger:dump --list-only resources.json
```

will dump the resource list to `resources.json` on the project root.

```
php app/console api:swagger:dump --resource=users web/swagger-docs/user.json
```

will dump the API declaration for the `/users` resource to `web/swagger-docs`.

```
php app/console api:swagger:dump web/swagger-docs
```

will dump the resource list and all API declarations to `web/swagger-docs`.

**This is a BC break, though.** 
