### PR TITLE
fix enpoint bug

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -396,7 +396,7 @@
                     {% else -%}
                     var endpoint = '{{ endpoint }}';
                     {% endif -%}
-                    if ($('#api_endpoint') && $('#api_endpoint').val() != null) {
+                    if ($('#api_endpoint') && $('#api_endpoint').val() != '') {
                         endpoint = $('#api_endpoint').val();
                     }
 


### PR DESCRIPTION
When enable endpoint, default URL It doesn't work, because conditional JavaScript is wrong, NULL is unlike empty.
