### PR TITLE
Default to DataTypes::STRING when no constraints are found

### DIFF
--- a/Parser/ValidationParser.php
+++ b/Parser/ValidationParser.php
@@ -106,7 +106,7 @@ class ValidationParser implements ParserInterface, PostParserInterface
                 $vparams['format'] = join(', ', $vparams['format']);
             }
 
-            foreach (array('dataType', 'readonly', 'required') as $reqprop) {
+            foreach (array('dataType', 'readonly', 'required', 'subType') as $reqprop) {
                 if (!isset($vparams[$reqprop])) {
                     $vparams[$reqprop] = null;
                 }
@@ -117,6 +117,8 @@ class ValidationParser implements ParserInterface, PostParserInterface
                 $visited[] = $vparams['class'];
                 $vparams['children'] = $this->doParse($vparams['class'], $visited);
             }
+
+            $vparams['actualType'] = isset($vparams['actualType']) ? $vparams['actualType'] : DataTypes::STRING;
 
             $params[$property] = $vparams;
         }


### PR DESCRIPTION
If a property doesn't contain any validation constraints, the parser returns a parameter definition which only contain `null` values. This normally would fly during merging of parameters, but sometimes cause problems when the property names will differ, i.e., when `JMSMetadataParser` uses snake-cased parameters.

All this patch does is ensure that parameters returned by `ValidationParser` has an `actualType` property set.
