### PR TITLE
Added 'authorizations` definitions when sandbox authentication is configured

### DIFF
--- a/DependencyInjection/SwaggerConfigCompilerPass.php
+++ b/DependencyInjection/SwaggerConfigCompilerPass.php
@@ -45,5 +45,10 @@ class SwaggerConfigCompilerPass implements CompilerPassInterface
         $formatter->addMethodCall('setSwaggerVersion', array($container->getParameter('nelmio_api_doc.swagger.swagger_version')));
         $formatter->addMethodCall('setInfo', array($container->getParameter('nelmio_api_doc.swagger.info')));
 
+        $authentication = $container->getParameter('nelmio_api_doc.sandbox.authentication');
+
+        if ($authentication !== null) {
+            $formatter->addMethodCall('setAuthenticationConfig', array($authentication));
+        }
     }
 }

--- a/Formatter/SwaggerFormatter.php
+++ b/Formatter/SwaggerFormatter.php
@@ -55,6 +55,16 @@ class SwaggerFormatter implements FormatterInterface
     );
 
     /**
+     * @var array
+     */
+    protected $authConfig = null;
+
+    public function setAuthenticationConfig(array $config)
+    {
+        $this->authConfig = $config;
+    }
+
+    /**
      * Format a collection of documentation data.
      *
      * If resource is provided, an API declaration for that resource is produced. Otherwise, a resource listing is returned.
@@ -115,7 +125,25 @@ class SwaggerFormatter implements FormatterInterface
 
     protected function getAuthorizations()
     {
-        return array();
+        $auth = array();
+
+        if ($this->authConfig === null) {
+            return $auth;
+        }
+
+        $config = $this->authConfig;
+
+        if ($config['delivery'] === 'http') {
+            return $auth;
+        }
+
+        $auth['apiKey'] = array(
+            'type' => 'apiKey',
+            'passAs' => $config['delivery'],
+            'keyname' => $config['name'],
+        );
+
+        return $auth;
     }
 
     /**
@@ -157,7 +185,7 @@ class SwaggerFormatter implements FormatterInterface
             'models' => array(),
             'produces' => array(),
             'consumes' => array(),
-            'authorizations' => array(),
+            'authorizations' => $this->getAuthorizations(),
         );
 
         $main = null;

--- a/Tests/Fixtures/app/config/default.yml
+++ b/Tests/Fixtures/app/config/default.yml
@@ -53,6 +53,10 @@ jms_serializer:
         auto_detection: true
 
 nelmio_api_doc:
+    sandbox:
+        authentication:
+            delivery: header
+            name: access_token
     cache:
         enabled: true
     exclude_sections: ["private", "exclusive"]

--- a/Tests/Formatter/SwaggerFormatterTest.php
+++ b/Tests/Formatter/SwaggerFormatterTest.php
@@ -61,7 +61,13 @@ class SwaggerFormatterTest extends WebTestCase
                     'licenseUrl' => 'http://opensource.org/licenses/MIT',
                 ),
             'authorizations' =>
-                array(),
+                array(
+                    'apiKey' => array(
+                        'type' => 'apiKey',
+                        'passAs' => 'header',
+                        'keyname' => 'access_token',
+                    )
+                ),
             'apis' =>
                 array(
                     array(
@@ -419,7 +425,13 @@ With multiple lines.',
                     'consumes' =>
                         array(),
                     'authorizations' =>
-                        array(),
+                        array(
+                            'apiKey' => array(
+                                'type' => 'apiKey',
+                                'passAs' => 'header',
+                                'keyname' => 'access_token',
+                            )
+                        ),
                 ),
             ),
             array(
@@ -539,7 +551,13 @@ With multiple lines.',
                     'consumes' =>
                         array(),
                     'authorizations' =>
-                        array(),
+                        array(
+                            'apiKey' => array(
+                                'type' => 'apiKey',
+                                'passAs' => 'header',
+                                'keyname' => 'access_token',
+                            )
+                        ),
                 ),
             ),
             array(
@@ -721,7 +739,12 @@ With multiple lines.',
                         array (
                         ),
                     'authorizations' =>
-                        array (
+                        array(
+                            'apiKey' => array(
+                                'type' => 'apiKey',
+                                'passAs' => 'header',
+                                'keyname' => 'access_token',
+                            )
                         ),
                 ),
             ),


### PR DESCRIPTION
Note: `bearer` authentication is not supported in [`swagger-spec`](https://github.com/wordnik/swagger-spec/blob/master/versions/1.2.md#5210-authorizations-object) so it is ignored.
