### PR TITLE
Fixed the wrong endpoint value check when no endpoint is set in config.

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -396,7 +396,7 @@
                     {% else -%}
                     var endpoint = '{{ endpoint }}';
                     {% endif -%}
-                    if ($('#api_endpoint') && $('#api_endpoint').val() != '') {
+                    if ($('#api_endpoint') && typeof($('#api_endpoint').val()) != 'undefined') {
                         endpoint = $('#api_endpoint').val();
                     }
 


### PR DESCRIPTION
When using a default configuration, the default endpoint should be '/app_dev.php', but because of this small bug, the endpoint in overwritten by "undefined" in javascript. Resulting ajax calls going to '/doc/undefined', not working obviously.

Using the typeof fix the problem and makes the right call.
