### PR TITLE
Swagger: Ability to specify "paramType" for input

### DIFF
--- a/Formatter/SwaggerFormatter.php
+++ b/Formatter/SwaggerFormatter.php
@@ -200,7 +200,17 @@ class SwaggerFormatter implements FormatterInterface
             /** @var $apiDoc ApiDoc */
             $apiDoc = $item['annotation'];
             $itemResource = $this->stripBasePath($item['resource']);
+            $input = $apiDoc->getInput();
 
+            if (!is_array($input)) {
+                $input = array(
+                    'class' => $input,
+                    'paramType' => 'form',
+                );
+            } elseif (empty($input['paramType'])) {
+                $input['paramType'] = 'form';
+            }
+            
             $route = $apiDoc->getRoute();
 
             $itemResource = $this->normalizeResourcePath($itemResource);
@@ -242,7 +252,10 @@ class SwaggerFormatter implements FormatterInterface
             $data = $apiDoc->toArray();
 
             if (isset($data['parameters'])) {
-                $parameters = array_merge($parameters, $this->deriveParameters($data['parameters'], $models));
+                $parameters = array_merge($parameters, $this->deriveParameters($data['parameters'],
+                        $models,
+                        $input['paramType']
+                    ));
             }
 
             $responseMap = $apiDoc->getParsedResponseMap();
@@ -356,9 +369,12 @@ class SwaggerFormatter implements FormatterInterface
      *
      * @param array $input
      * @param array $models
+     *
+     * @param string $paramType
+     *
      * @return array
      */
-    protected function deriveParameters(array $input, array &$models)
+    protected function deriveParameters(array $input, array &$models, $paramType = 'form')
     {
 
         $parameters = array();
@@ -404,7 +420,7 @@ class SwaggerFormatter implements FormatterInterface
             }
 
             $parameter = array(
-                'paramType' => 'form',
+                'paramType' => $paramType,
                 'name' => $name,
             );
 

--- a/Resources/doc/swagger-support.md
+++ b/Resources/doc/swagger-support.md
@@ -98,6 +98,25 @@ php app/console api:swagger:dump --resource=users
 ```
 The above command will dump the `/users` API declaration in an `users.json` file.
 
+### Defining a form-type as a GET form
+
+If you use forms to capture GET requests, you will have to specify the `paramType` to `query` in the annotation:
+
+```php
+
+<?php
+
+/**
+ * @ApiDoc(
+ *    input = {"class" = "Foo\ContentBundle\Form\SearchType", "paramType" = "query"},
+ *   ...
+ * )
+ */
+ 
+ public function searchAction(Request $request)
+ {
+```
+
 ##Configuration reference
 
 ```yml


### PR DESCRIPTION
This will allow us to do:

```
@ApiDoc(
     "input" = {"class" = "RestBundle\Form\SearchFormType", "paramType" = "query"}
)
```

and the Swagger documentation would understand that the data is to be passed as a query string instead of as form submission.
