### PR TITLE
Fixed endpoint is undefined in sandbox when custom_endpoint is disabled

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -396,9 +396,11 @@
                     {% else -%}
                     var endpoint = '{{ endpoint }}';
                     {% endif -%}
+                    {% if authentication.custom_endpoint %}
                     if ($('#api_endpoint') && typeof($('#api_endpoint').val()) != 'undefined') {
                         endpoint = $('#api_endpoint').val();
                     }
+                    {% endif %}
 
                     // Workaround for Firefox bug and a thereby resulting nginx incompatibility
                     if (method == "LINK") {


### PR DESCRIPTION
I have custom_endpoint setting disabled in my environment, which results in endpoint variable in the sandbox is overriden by string 'undefined', which results in 404 requests.
See attached patch to fix this.
