### PR TITLE
[Fix] Missing handling for DataTypes::COLLECTION in parameters (input)

### DIFF
--- a/Formatter/SwaggerFormatter.php
+++ b/Formatter/SwaggerFormatter.php
@@ -391,6 +391,22 @@ class SwaggerFormatter implements FormatterInterface
                                 $models
                             );
                         break;
+
+                    case DataTypes::COLLECTION:
+                        $type = 'array';
+                        if ($prop['subType'] === DataTypes::MODEL) {
+                            $ref = $this->registerModel(
+                                $prop['subType'],
+                                isset($prop['children']) ? $prop['children'] : null,
+                                $prop['description'] ?: $prop['dataType'],
+                                $models
+                            );
+                        } elseif (isset($this->typeMap[$prop['subType']])) {
+                            $items = $this->typeMap[$prop['subType']];
+                        } else {
+                            $items = 'string';
+                        }
+                        break;
                 }
             }
 


### PR DESCRIPTION
Added missing handling for collection fields in input parameters. Not related to https://github.com/nelmio/NelmioApiDocBundle/pull/469

This is Swagger-specific.
