### PR TITLE
[Fix] 'items' parameter for collections in parameters.

### DIFF
--- a/Formatter/SwaggerFormatter.php
+++ b/Formatter/SwaggerFormatter.php
@@ -417,10 +417,13 @@ class SwaggerFormatter implements FormatterInterface
                                 $prop['description'] ?: $prop['dataType'],
                                 $models
                             );
+                            $items = array(
+                                '$ref' => $ref,
+                            );
                         } elseif (isset($this->typeMap[$prop['subType']])) {
-                            $items = $this->typeMap[$prop['subType']];
+                            $items = array('type' => $this->typeMap[$prop['subType']]);
                         } else {
-                            $items = 'string';
+                            $items = array('type' => 'string');
                         }
                         break;
                 }
@@ -459,6 +462,10 @@ class SwaggerFormatter implements FormatterInterface
 
             if ($prop['default'] !== null) {
                 $parameter['defaultValue'] = $prop['default'];
+            }
+
+            if (isset($items)) {
+                $parameter['items'] = $items;
             }
 
             $parameters[] = $parameter;


### PR DESCRIPTION
A bug was introduced by https://github.com/nelmio/NelmioApiDocBundle/pull/476, wherein `$items` is not even registered in final output.
