### PR TITLE
Add query parameters in sandbox request URL

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -261,7 +261,12 @@
                     return $('<div>').text(text).html();
                 };
 
-                var displayFinalUrl = function(xhr, method, url, container) {
+                var displayFinalUrl = function(xhr, method, url, data, container) {
+                    if ('GET' == method && jQuery(data).size()) {
+                        var separator = url.indexOf('?') >= 0 ? '&' : '?';
+                        url = url + separator + decodeURIComponent(jQuery.param(data));
+                    }
+
                     container.text(method + ' ' + url);
                 };
 
@@ -294,8 +299,8 @@
                     container.text(text);
                 };
 
-                var displayResponse = function(xhr, method, url, result_container) {
-                    displayFinalUrl(xhr, method, url, $('.url', result_container));
+                var displayResponse = function(xhr, method, url, data, result_container) {
+                    displayFinalUrl(xhr, method, url, data, $('.url', result_container));
                     displayProfilerUrl(xhr, $('.profiler-link', result_container), $('.profiler', result_container));
                     displayResponseData(xhr, $('.response', result_container));
                     displayResponseHeaders(xhr, $('.headers', result_container));
@@ -478,7 +483,7 @@
                             }
                         },
                         complete: function(xhr) {
-                            displayResponse(xhr, method, url, result_container);
+                            displayResponse(xhr, method, url, data, result_container);
 
                             // and enable them back
                             $('input:not(.content-type), button', $(self)).removeAttr('disabled');


### PR DESCRIPTION
This PR adds query parameters to request URL displayed after a sandbox try :

**Before**
![before](https://cloud.githubusercontent.com/assets/663607/4043089/70d51030-2d0c-11e4-9fd9-eead7d43c53e.jpg)

**After**
![after](https://cloud.githubusercontent.com/assets/663607/4043088/70cba9aa-2d0c-11e4-89ce-10f324273f11.jpg)

Query authentication is still working :
![api_key](https://cloud.githubusercontent.com/assets/663607/4043126/099bfffe-2d0d-11e4-8a6c-dc7a7ee04a83.jpg)
