### PR TITLE
Added support for Security annotation

### DIFF
--- a/Extractor/Handler/SensioFrameworkExtraHandler.php
+++ b/Extractor/Handler/SensioFrameworkExtraHandler.php
@@ -15,6 +15,7 @@ use Nelmio\ApiDocBundle\Extractor\HandlerInterface;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Symfony\Component\Routing\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
 class SensioFrameworkExtraHandler implements HandlerInterface
 {
@@ -23,6 +24,8 @@ class SensioFrameworkExtraHandler implements HandlerInterface
         foreach ($annotations as $annot) {
             if ($annot instanceof Cache) {
                 $annotation->setCache($annot->getMaxAge());
+            } elseif ($annot instanceof Security) {
+                $annotation->setAuthentication(true);
             }
         }
     }

--- a/Tests/Extractor/ApiDocExtractorTest.php
+++ b/Tests/Extractor/ApiDocExtractorTest.php
@@ -15,7 +15,7 @@ use Nelmio\ApiDocBundle\Tests\WebTestCase;
 
 class ApiDocExtractorTest extends WebTestCase
 {
-    const ROUTES_QUANTITY = 31;
+    const ROUTES_QUANTITY = 33;
 
     public function testAll()
     {
@@ -199,7 +199,7 @@ class ApiDocExtractorTest extends WebTestCase
     {
         $container  = $this->getContainer();
         $extractor  = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
-        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\TestController::CachedAction', 'test_route_14');
+        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\TestController::zCachedAction', 'test_route_23');
 
         $this->assertNotNull($annotation);
         $this->assertEquals(

--- a/Tests/Extractor/Handler/SensioFrameworkExtraHandlerTest.php
+++ b/Tests/Extractor/Handler/SensioFrameworkExtraHandlerTest.php
@@ -1,0 +1,38 @@
+<?php
+/*
+* This file is part of the NelmioApiDocBundle.
+*
+* (c) Nelmio <hello@nelm.io>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+namespace Nelmio\ApiDocBundle\Tests\Extractor;
+
+use Nelmio\ApiDocBundle\Tests\WebTestCase;
+
+class SensioFrameworkExtraHandlerTest extends WebTestCase
+{
+    public function testCacheAnnotation()
+    {
+        $container  = $this->getContainer();
+        $extractor  = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
+        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\TestController::zCachedAction', 'test_route_23');
+
+        $this->assertNotNull($annotation);
+
+        $this->assertSame(60, $annotation->getCache());
+    }
+
+    public function testSecurityAnnotation()
+    {
+        $container  = $this->getContainer();
+        $extractor  = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
+        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\TestController::zSecuredAction', 'test_route_24');
+
+        $this->assertNotNull($annotation);
+
+        $this->assertTrue($annotation->getAuthentication());
+    }
+}

--- a/Tests/Fixtures/Controller/TestController.php
+++ b/Tests/Fixtures/Controller/TestController.php
@@ -17,6 +17,7 @@ use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Constraints\Email;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
 class TestController
 {
@@ -196,7 +197,15 @@ class TestController
      * @ApiDoc()
      * @Cache(maxage=60, public=1)
      */
-    public function cachedAction()
+    public function zCachedAction()
+    {
+    }
+
+    /**
+     * @ApiDoc()
+     * @Security("has_role('ROLE_USER')")
+     */
+    public function zSecuredAction()
     {
     }
 

--- a/Tests/Fixtures/app/config/routing.yml
+++ b/Tests/Fixtures/app/config/routing.yml
@@ -207,3 +207,15 @@ test_route_update_another_resource:
 swagger_doc:
     resource: @NelmioApiDocBundle/Resources/config/swagger_routing.yml
     prefix: /api-docs
+
+test_route_23:
+    pattern:  /zcached
+    defaults: { _controller: NelmioApiDocTestBundle:Test:zCached }
+    requirements:
+        _method: POST
+
+test_route_24:
+    pattern:  /zsecured
+    defaults: { _controller: NelmioApiDocTestBundle:Test:zSecured }
+    requirements:
+        _method: POST

--- a/Tests/Formatter/MarkdownFormatterTest.php
+++ b/Tests/Formatter/MarkdownFormatterTest.php
@@ -835,6 +835,13 @@ related[a]:
 related[b]:
 
   * type: DateTime
+
+
+### `POST` /zcached ###
+
+
+
+### `POST` /zsecured ###
 MARKDOWN;
 
         $this->assertEquals($expected, $result);

--- a/Tests/Formatter/SimpleFormatterTest.php
+++ b/Tests/Formatter/SimpleFormatterTest.php
@@ -1237,6 +1237,25 @@ With multiple lines.',
                         )
                     ),
                     'authenticationRoles' => array(),
+                ),
+                19 =>
+                array(
+                    'cache' => 60,
+                    'method' => 'POST',
+                    'uri' => '/zcached',
+                    'https' => false,
+                    'authentication' => false,
+                    'authenticationRoles' => array(),
+                    'deprecated' => false
+                ),
+                20 =>
+                array(
+                    'authentication' => true,
+                    'method' => 'POST',
+                    'uri' => '/zsecured',
+                    'https' => false,
+                    'authenticationRoles' => array(),
+                    'deprecated' => false
                 )
             ),
             '/tests2' =>

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/form": "~2.1",
         "friendsofsymfony/rest-bundle": "~1.0",
         "jms/serializer-bundle": ">=0.11",
-        "sensio/framework-extra-bundle": "~2.1"
+        "sensio/framework-extra-bundle": "~3.0"
     },
     "suggest": {
         "symfony/form": "For using form definitions as input.",


### PR DESCRIPTION
Fixes #494 
- Bumped the required dev version of SensioFrameworkExtraBundle from ~2.1 to ~3.0 because the annotation is not available before
- Added test for `SensioFrameworkExtraHandler` (for `Security` annotation but also for `Cache`)
