### PR TITLE
Honor body format before uploading file type parameters

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -357,6 +357,11 @@
                         return false;
                     }
 
+                    if (hasFileTypes && bodyFormat != 'form') {
+                        alert("Body Format must be set to 'Form Data' when utilizing file upload type parameters.\nYour current bodyFormat is '" + bodyFormat + "'. Change your BodyFormat or do not use file type\nparameters.");
+                        return false;
+                    }
+
                     if (hasFileTypes) {
                         // retrieve all the parameters to send for file upload
                         $('.parameters .tuple', $(this)).each(function() {


### PR DESCRIPTION
Current behavior is that if a file upload type parameter is added, the body format is ignored. This PR checks the body format and throws an error message if the body format is incorrect delegating it to the user to set the correct body format instead of assuming that the user wants to use body format "form data" when a file upload type parameter is added.
