### PR TITLE
Annotation: Specify parameters array directly in `input` option

### DIFF
--- a/Annotation/ApiDoc.php
+++ b/Annotation/ApiDoc.php
@@ -444,7 +444,8 @@ class ApiDoc
      * @param string $name
      * @param array  $parameter
      */
-    public function addParameter($name, array $parameter)
+    public function
+    addParameter($name, array $parameter)
     {
         $this->parameters[$name] = $parameter;
     }
@@ -709,7 +710,7 @@ class ApiDoc
      */
     public function getResponseMap()
     {
-        if (!isset($this->responseMap[200]) && null !== $this->output) {
+        if (!isset($this->responseMap[200]) && null !== $this->output && !$this->output instanceof ApiModelCollection) {
             $this->responseMap[200] = $this->output;
         }
 

--- a/Annotation/ApiModel.php
+++ b/Annotation/ApiModel.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Annotation;
+
+use Nelmio\ApiDocBundle\DataTypes;
+
+/**
+ * @Annotation
+ * @Target({"ANNOTATION"})
+ * @author Bez Hermoso <bezalelhermoso@gmail.com>
+ */
+class ApiModel
+{
+    /**
+     * @var array
+     */
+    protected $parameters;
+
+    /**
+     * @var string
+     */
+    protected $name;
+
+    protected static $acceptableTypes = null;
+
+    /**
+     * @param array $parameters
+     */
+    public function __construct(array $parameters)
+    {
+        $name = null;
+        if (count($parameters) === 1 && isset($parameters['value'])) {
+            if (isset($parameters['value'][0]) && is_scalar($parameters['value'][0])) {
+                $name = $parameters['value'][0];
+                $parameters = $parameters['value'][1];
+            }
+        }
+        $this->name = $name;
+        $this->parameters = $this->normalizeParameters($parameters);
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param $parameters
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function normalizeParameters($parameters)
+    {
+        foreach ($parameters as $name => $value) {
+            if (!empty($value['type'])) {
+                $types = self::getAcceptableTypes();
+                if (!in_array($value['type'], array_keys($types))) {
+                    throw new \InvalidArgumentException(sprintf('Unknown type "%s". Choose among: %s', $value['type'], json_encode(array_keys($types))));
+                }
+                $type = $types[$value['type']];
+                unset($value['type']);
+            } else {
+                $type = DataTypes::STRING;
+            }
+            $value['actualType'] = $type;
+            $parameters[$name] = $value;
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * @return array
+     */
+    protected static function getAcceptableTypes()
+    {
+        if (self::$acceptableTypes === null) {
+            $reflClass = new \ReflectionClass('Nelmio\\ApiDocBundle\\DataTypes');
+            foreach ($reflClass->getConstants() as $name => $value) {
+                self::$acceptableTypes[strtolower($name)] = $value;
+            }
+        }
+
+        return self::$acceptableTypes;
+    }
+}

--- a/Annotation/ApiModel.php
+++ b/Annotation/ApiModel.php
@@ -23,7 +23,7 @@ class ApiModel
     /**
      * @var array
      */
-    protected $parameters;
+    protected $parameters = array();
 
     /**
      * @var string
@@ -33,19 +33,17 @@ class ApiModel
     protected static $acceptableTypes = null;
 
     /**
-     * @param array $parameters
+     * @param array $values
      */
-    public function __construct(array $parameters)
+    public function __construct(array $values)
     {
-        $name = null;
-        if (count($parameters) === 1 && isset($parameters['value'])) {
-            if (isset($parameters['value'][0]) && is_scalar($parameters['value'][0])) {
-                $name = $parameters['value'][0];
-                $parameters = $parameters['value'][1];
-            }
+        if (!empty($values['parameters'])) {
+            $this->parameters = $this->normalizeParameters($values['parameters']);
         }
-        $this->name = $name;
-        $this->parameters = $this->normalizeParameters($parameters);
+
+        if (!empty($values['name'])) {
+            $this->name = $values['name'];
+        }
     }
 
     /**

--- a/Annotation/ApiModelCollection.php
+++ b/Annotation/ApiModelCollection.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Annotation;
+
+/**
+ * @Annotation
+ * @Target({"ANNOTATION"})
+ * @author Bez Hermoso <bez@activelamp.com>
+ */
+class ApiModelCollection extends ApiModel
+{
+
+    /**
+     * @var string
+     */
+    protected $collectionName = '';
+
+    /**
+     * @param array $values
+     */
+    public function __construct(array $values)
+    {
+        parent::__construct($values);
+
+        if (!empty($values['collectionName'])) {
+            $this->collectionName = $values['collectionName'];
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getCollectionName()
+    {
+        return $this->collectionName;
+    }
+}

--- a/Extractor/ApiDocExtractor.php
+++ b/Extractor/ApiDocExtractor.php
@@ -14,15 +14,18 @@ namespace Nelmio\ApiDocBundle\Extractor;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Util\ClassUtils;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
+use Nelmio\ApiDocBundle\Annotation\ApiModel;
 use Nelmio\ApiDocBundle\DataTypes;
 use Nelmio\ApiDocBundle\Parser\ParserInterface;
 use Nelmio\ApiDocBundle\Parser\PostParserInterface;
 use Nelmio\ApiDocBundle\Util\DocCommentExtractor;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 class ApiDocExtractor
 {
@@ -68,6 +71,11 @@ class ApiDocExtractor
      */
     protected $annotationsProviders;
 
+    /**
+     * @var OptionsResolver
+     */
+    protected $resolver;
+
     public function __construct(ContainerInterface $container, RouterInterface $router, Reader $reader, DocCommentExtractor $commentExtractor, ControllerNameParser $controllerNameParser, array $handlers, array $annotationsProviders)
     {
         $this->container            = $container;
@@ -77,6 +85,56 @@ class ApiDocExtractor
         $this->controllerNameParser = $controllerNameParser;
         $this->handlers             = $handlers;
         $this->annotationsProviders = $annotationsProviders;
+        $this->resolver         = new OptionsResolver();
+        $this->configureResolver();
+    }
+
+    private function configureResolver()
+    {
+        $this->resolver->setDefaults(array(
+            'dataType' => null,
+            'subType' => null,
+            'actualType' => DataTypes::STRING,
+            'required' => false,
+            'readonly' => false,
+            'description' => null,
+            'default' => null,
+            'sinceVersion' => null,
+            'untilVersion' => null,
+        ));
+
+        $refClass = new \ReflectionClass('Nelmio\\ApiDocBundle\\DataTypes');
+
+        $this->resolver->setAllowedValues(array(
+            'actualType' => array_values($refClass->getConstants()),
+        ));
+
+        $this->resolver->setOptional(array(
+            'children', 'class', 'type', 'format',
+        ));
+
+        $this->resolver->setAllowedTypes(array(
+            'children' => array('array', 'null'),
+        ));
+
+        $generator = array($this, 'generateHumanReadableType');
+
+        $resolver = $this->resolver;
+
+        $this->resolver->setNormalizers(array(
+            'dataType' => function (Options $options, $value) use ($generator) {
+                if (strlen($value) > 0) {
+                    return $value;
+                }
+                return call_user_func($generator, $options['actualType'], $options['subType']);
+            },
+            'description' => function (Options $options, $value) {
+                return (string) $value;
+            },
+            'readonly' => function (Options $options, $value) {
+                return (boolean) $value;
+            }
+        ));
     }
 
     /**
@@ -286,28 +344,36 @@ class ApiDocExtractor
 
         // input (populates 'parameters' for the formatters)
         if (null !== $input = $annotation->getInput()) {
-            $parameters      = array();
-            $normalizedInput = $this->normalizeClassParameter($input);
+            if ($input instanceof ApiModel) {
+                $parameters = $input->getParameters();
+                $parameters = $this->resolveParameters($parameters);
+            } else {
+                $parameters      = array();
+                $normalizedInput = $this->normalizeClassParameter($input);
 
-            $supportedParsers = array();
-            foreach ($this->getParsers($normalizedInput) as $parser) {
-                if ($parser->supports($normalizedInput)) {
-                    $supportedParsers[] = $parser;
-                    $parameters         = $this->mergeParameters($parameters, $parser->parse($normalizedInput));
+                $supportedParsers = array();
+                foreach ($this->getParsers($normalizedInput) as $parser) {
+                    if ($parser->supports($normalizedInput)) {
+                        $supportedParsers[] = $parser;
+                        $parsed = $parser->parse($normalizedInput);
+                        $parameters = $this->mergeParameters($parameters, $parsed);
+                    }
                 }
+
+                foreach ($supportedParsers as $parser) {
+                    if ($parser instanceof PostParserInterface) {
+                        $postParsed = $parser->postParse($normalizedInput, $parameters);
+                        $parameters = $this->mergeParameters(
+                            $parameters,
+                            $postParsed
+                        );
+                    }
+                }
+
+                $parameters = $this->clearClasses($parameters);
             }
 
-            foreach ($supportedParsers as $parser) {
-                if ($parser instanceof PostParserInterface) {
-                    $parameters = $this->mergeParameters(
-                        $parameters,
-                        $parser->postParse($normalizedInput, $parameters)
-                    );
-                }
-            }
-
-            $parameters = $this->clearClasses($parameters);
-            $parameters = $this->generateHumanReadableTypes($parameters);
+            //$parameters = $this->generateHumanReadableTypes($parameters);
 
             if ('PUT' === $annotation->getMethod()) {
                 // All parameters are optional with PUT (update)
@@ -321,27 +387,39 @@ class ApiDocExtractor
 
         // output (populates 'response' for the formatters)
         if (null !== $output = $annotation->getOutput()) {
-            $response         = array();
-            $supportedParsers = array();
 
-            $normalizedOutput = $this->normalizeClassParameter($output);
+            if ($output instanceof ApiModel) {
 
-            foreach ($this->getParsers($normalizedOutput) as $parser) {
-                if ($parser->supports($normalizedOutput)) {
-                    $supportedParsers[] = $parser;
-                    $response = $this->mergeParameters($response, $parser->parse($normalizedOutput));
+                $response = $output->getParameters();
+                $response = $this->resolveParameters($response);
+                $normalizedOutput = array('class' => $output->getName());
+
+            } else {
+
+                $response         = array();
+                $supportedParsers = array();
+
+                $normalizedOutput = $this->normalizeClassParameter($output);
+
+                foreach ($this->getParsers($normalizedOutput) as $parser) {
+                    if ($parser->supports($normalizedOutput)) {
+                        $supportedParsers[] = $parser;
+                        $parsed   = $parser->parse($normalizedOutput);
+                        $response = $this->mergeParameters($response, $parsed);
+                    }
                 }
+
+                foreach ($supportedParsers as $parser) {
+                    if ($parser instanceof PostParserInterface) {
+                        $postParsed = $parser->postParse($normalizedOutput, $response);
+                        $response = $this->mergeParameters($response, $postParsed);
+                    }
+                }
+
+                $response = $this->clearClasses($response);
             }
 
-            foreach ($supportedParsers as $parser) {
-                if ($parser instanceof PostParserInterface) {
-                    $mp = $parser->postParse($normalizedOutput, $response);
-                    $response = $this->mergeParameters($response, $mp);
-                }
-            }
-
-            $response = $this->clearClasses($response);
-            $response = $this->generateHumanReadableTypes($response);
+            //$response = $this->generateHumanReadableTypes($response);
 
             $annotation->setResponse($response);
             $annotation->setResponseForStatusCode($response, $normalizedOutput, 200);
@@ -365,25 +443,30 @@ class ApiDocExtractor
                 foreach ($this->getParsers($normalizedModel) as $parser) {
                     if ($parser->supports($normalizedModel)) {
                         $supportedParsers[] = $parser;
-                        $parameters = $this->mergeParameters($parameters, $parser->parse($normalizedModel));
+                        $parsed     = $parser->parse($normalizedModel);
+                        $parsed = $this->resolveParameters($parsed);
+                        $parameters = $this->mergeParameters($parameters, $parsed);
                     }
                 }
 
                 foreach ($supportedParsers as $parser) {
                     if ($parser instanceof PostParserInterface) {
-                        $mp = $parser->postParse($normalizedModel, $parameters);
-                        $parameters = $this->mergeParameters($parameters, $mp);
+                        $postParsed = $parser->postParse($normalizedModel, $parameters);
+                        $postParsed = $this->resolveParameters($postParsed);
+                        $parameters = $this->mergeParameters($parameters, $postParsed);
                     }
                 }
 
                 $parameters = $this->clearClasses($parameters);
-                $parameters = $this->generateHumanReadableTypes($parameters);
+                //$parameters = $this->generateHumanReadableTypes($parameters);
 
                 $annotation->setResponseForStatusCode($parameters, $normalizedModel, $code);
 
             }
 
         }
+
+        $annotation->setParameters($this->resolveParameters($annotation->getParameters()));
 
         return $annotation;
     }
@@ -598,5 +681,25 @@ class ApiDocExtractor
         }
 
         return $parsers;
+    }
+
+    /**
+     * Uses the configured OptionsResolver to resolve parameter values.
+     *
+     * @param array $parameters
+     *
+     * @return array
+     */
+    private function resolveParameters(array $parameters)
+    {
+        foreach ($parameters as $name => $params) {
+            $params            = is_array($params) ? $this->resolver->resolve($params) : $params;
+            if (isset($params['children']) && is_array($params['children'])) {
+                $params['children'] = $this->resolveParameters($params['children']);
+            }
+            $parameters[$name] = $params;
+        }
+
+        return $parameters;
     }
 }

--- a/Formatter/AbstractFormatter.php
+++ b/Formatter/AbstractFormatter.php
@@ -69,7 +69,10 @@ abstract class AbstractFormatter implements FormatterInterface
         foreach ($data as $name => $info) {
             $newName = $this->getNewName($name, $info, $parentName);
 
-            $newParams[$newName] = array(
+            $keys = array_keys($info);
+
+
+            /*$newParams[$newName] = array(
                 'dataType'     => $info['dataType'],
                 'readonly'     => array_key_exists('readonly', $info) ? $info['readonly'] : null,
                 'required'     => $info['required'],
@@ -80,7 +83,8 @@ abstract class AbstractFormatter implements FormatterInterface
                 'untilVersion' => array_key_exists('untilVersion', $info) ? $info['untilVersion'] : null,
                 'actualType'   => array_key_exists('actualType', $info) ? $info['actualType'] : null,
                 'subType'      => array_key_exists('subType', $info) ? $info['subType'] : null,
-            );
+            );*/
+            $newParams[$newName] = $info;
 
             if (isset($info['children']) && (!$info['readonly'] || !$ignoreNestedReadOnly)) {
                 foreach ($this->compressNestedParameters($info['children'], $newName, $ignoreNestedReadOnly) as $nestedItemName => $nestedItemData) {

--- a/Formatter/AbstractFormatter.php
+++ b/Formatter/AbstractFormatter.php
@@ -68,22 +68,6 @@ abstract class AbstractFormatter implements FormatterInterface
         $newParams = array();
         foreach ($data as $name => $info) {
             $newName = $this->getNewName($name, $info, $parentName);
-
-            $keys = array_keys($info);
-
-
-            /*$newParams[$newName] = array(
-                'dataType'     => $info['dataType'],
-                'readonly'     => array_key_exists('readonly', $info) ? $info['readonly'] : null,
-                'required'     => $info['required'],
-                'default'      => array_key_exists('default', $info) ? $info['default'] : null,
-                'description'  => array_key_exists('description', $info) ? $info['description'] : null,
-                'format'       => array_key_exists('format', $info) ? $info['format'] : null,
-                'sinceVersion' => array_key_exists('sinceVersion', $info) ? $info['sinceVersion'] : null,
-                'untilVersion' => array_key_exists('untilVersion', $info) ? $info['untilVersion'] : null,
-                'actualType'   => array_key_exists('actualType', $info) ? $info['actualType'] : null,
-                'subType'      => array_key_exists('subType', $info) ? $info['subType'] : null,
-            );*/
             $newParams[$newName] = $info;
 
             if (isset($info['children']) && (!$info['readonly'] || !$ignoreNestedReadOnly)) {

--- a/Tests/Extractor/Handler/FosRestHandlerTest.php
+++ b/Tests/Extractor/Handler/FosRestHandlerTest.php
@@ -128,7 +128,7 @@ class FosRestHandlerTest extends WebTestCase
         $this->assertArrayHasKey('required', $parameter);
         $this->assertEquals($parameter['required'], true);
 
-        $this->assertArrayNotHasKey('default', $parameter);
+        $this->assertNull($parameter['default']);
     }
 
     public function testGetWithRequestParamNullable()
@@ -154,6 +154,6 @@ class FosRestHandlerTest extends WebTestCase
         $this->assertArrayHasKey('required', $parameter);
         $this->assertEquals($parameter['required'], false);
 
-        $this->assertArrayNotHasKey('default', $parameter);
+        $this->assertNull($parameter['default']);
     }
 }

--- a/Tests/Fixtures/Controller/ResourceController.php
+++ b/Tests/Fixtures/Controller/ResourceController.php
@@ -10,7 +10,9 @@
  */
 
 namespace Nelmio\ApiDocBundle\Tests\Fixtures\Controller;
+
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
+use Nelmio\ApiDocBundle\Annotation\ApiModel;
 
 class ResourceController
 {
@@ -18,6 +20,7 @@ class ResourceController
      * @ApiDoc(
      *      resource=true,
      *      views={ "test", "premium", "default" },
+     *      input=@ApiModel("test", {"foo"={"type"="string"}}),
      *      resourceDescription="Operations on resource.",
      *      description="List resources.",
      *      output="array<Nelmio\ApiDocBundle\Tests\Fixtures\Model\Test> as tests",

--- a/Tests/Fixtures/Controller/ResourceController.php
+++ b/Tests/Fixtures/Controller/ResourceController.php
@@ -13,6 +13,7 @@ namespace Nelmio\ApiDocBundle\Tests\Fixtures\Controller;
 
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Nelmio\ApiDocBundle\Annotation\ApiModel;
+use Nelmio\ApiDocBundle\Annotation\ApiModelCollection;
 
 class ResourceController
 {
@@ -20,7 +21,12 @@ class ResourceController
      * @ApiDoc(
      *      resource=true,
      *      views={ "test", "premium", "default" },
-     *      input=@ApiModel("test", {"foo"={"type"="string"}}),
+     *      input=@ApiModel(
+     *          parameters={
+     *              "foo"={"type"="string"}
+     *          },
+     *          name="test"
+     *      ),
      *      resourceDescription="Operations on resource.",
      *      description="List resources.",
      *      output="array<Nelmio\ApiDocBundle\Tests\Fixtures\Model\Test> as tests",
@@ -33,7 +39,13 @@ class ResourceController
     }
 
     /**
-     * @ApiDoc(description="Retrieve a resource by ID.")
+     * @ApiDoc(description="Retrieve a resource by ID.", output=@ApiModelCollection(
+     *      collectionName="bar",
+     *      parameters={
+     *          "price"={"type"="integer", "default"=10, "required"=false}
+     *      },
+     *      name="ResourceCollection"
+     * ))
      */
     public function getResourceAction()
     {

--- a/Tests/Fixtures/Controller/ResourceController.php
+++ b/Tests/Fixtures/Controller/ResourceController.php
@@ -106,3 +106,4 @@ class ResourceController
 
     }
 }
+

--- a/Tests/Formatter/MarkdownFormatterTest.php
+++ b/Tests/Formatter/MarkdownFormatterTest.php
@@ -1367,6 +1367,16 @@ _Retrieve a resource by ID._
 **id**
 
 
+#### Response ####
+
+bar[]:
+
+  * type: array of objects (ResourceCollection)
+
+bar[][price]:
+
+  * type: integer
+
 
 ### `DELETE` /api/resources/{id}.{_format} ###
 

--- a/Tests/Formatter/MarkdownFormatterTest.php
+++ b/Tests/Formatter/MarkdownFormatterTest.php
@@ -1163,6 +1163,13 @@ _List resources._
 
   - Requirement: json|xml|html
 
+#### Parameters ####
+
+foo:
+
+  * type: string
+  * required: false
+
 #### Response ####
 
 tests[]:

--- a/Tests/Formatter/SimpleFormatterTest.php
+++ b/Tests/Formatter/SimpleFormatterTest.php
@@ -3872,15 +3872,6 @@ With multiple lines.',
                                                             array(
                                                                 'foo' =>
                                                                     array(
-                                                                        'dataType' => 'DateTime',
-                                                                        'actualType' => 'datetime',
-                                                                        'subType' => null,
-                                                                        'required' => false,
-                                                                        'default' => null,
-                                                                        'description' => '',
-                                                                        'readonly' => true,
-                                                                        'sinceVersion' => null,
-                                                                        'untilVersion' => null,
                                                                     ),
                                                                 'bar' =>
                                                                     array(

--- a/Tests/Formatter/SwaggerFormatterTest.php
+++ b/Tests/Formatter/SwaggerFormatterTest.php
@@ -320,6 +320,7 @@ class SwaggerFormatterTest extends WebTestCase
                                                             'name'      => 'g',
                                                             'type'      => 'string',
                                                         ),
+                                                    'type' => 'ResourceCollection[bar]',
                                                 ),
                                             'responseMessages' =>
                                                 array(
@@ -627,6 +628,34 @@ With multiple lines.',
                                     ),
                                     'required'    => array(),
                                 ),
+                            'ResourceCollection' => array(
+                                'id' => 'ResourceCollection',
+                                'description' => null,
+                                'properties' => array(
+                                    'price' => array(
+                                        'type' => 'integer',
+                                        'description' => 'integer',
+                                        'format' => 'int32',
+                                    ),
+                                ),
+                                'required' => array(),
+                            ),
+                            'ResourceCollection[bar]' => array(
+                                'id' => 'ResourceCollection[bar]',
+                                'description' => '',
+                                'properties' => array(
+                                    'bar' => array(
+                                        'type' => 'array',
+                                        'description' => null,
+                                        'items' => array(
+                                            '$ref' => 'ResourceCollection',
+                                        ),
+                                    ),
+                                ),
+                                'required' => array(
+                                    'bar'
+                                ),
+                            ),
                         ),
                     'produces'       =>
                         array(),

--- a/Tests/Formatter/SwaggerFormatterTest.php
+++ b/Tests/Formatter/SwaggerFormatterTest.php
@@ -267,6 +267,12 @@ class SwaggerFormatterTest extends WebTestCase
                                                                     1 => 'xml',
                                                                     2 => 'html',
                                                                 ),
+                                                            1 =>
+                                                                array (
+                                                                    'paramType' => 'form',
+                                                                    'type' => 'string',
+                                                                    'name' => 'foo',
+                                                                )
                                                         ),
                                                     1 =>
                                                         array(

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -19,3 +19,4 @@ if (class_exists('Doctrine\Common\Annotations\AnnotationRegistry')) {
 
 // force loading the ApiDoc annotation since the composer target-dir autoloader does not run through $loader::loadClass
 class_exists('Nelmio\ApiDocBundle\Annotation\ApiDoc');
+class_exists('Nelmio\ApiDocBundle\Annotation\ApiModel');

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -20,3 +20,4 @@ if (class_exists('Doctrine\Common\Annotations\AnnotationRegistry')) {
 // force loading the ApiDoc annotation since the composer target-dir autoloader does not run through $loader::loadClass
 class_exists('Nelmio\ApiDocBundle\Annotation\ApiDoc');
 class_exists('Nelmio\ApiDocBundle\Annotation\ApiModel');
+class_exists('Nelmio\ApiDocBundle\Annotation\ApiModelCollection');


### PR DESCRIPTION
Here is a suggestion for implementing this functionality (recently brought up again here: https://github.com/nelmio/NelmioApiDocBundle/issues/474)

We introduce an `@ApiModel` annotation:

```php
@ApiDoc(
     input=@ApiModel({
         "name" = {"type" = "string", "required" = true},
         "age" = {"type" = "integer", "required" = false},
         "group" = { "type" = "integer", "default" = "Users"},
         ...
     })
)
```
Internally we would just normalize the parameters and skip the parsers entirely.

`@ApiModel` can be named, too: 

```php
@ApiDoc(
    output=@ApiModel("User", {"first_name"={ ... }})
)
```
...mainly for use in `output` if it is needed to support that.

The `type` property should be a valid `DataTypes` constant but in lowercase i.e., `DataTypes::INTEGER => integer`

__UPDATE__:

I updated the logic for resolving the parameters by using a the `OptionResolver` component with `ApiDocExtractor`. 

It used to be that the `AbstractFormatter` would ensure that specific parameters are present (`dataType`, `actualType`, `description`, `sinceVersion`, etc.), and all sub-classing formatters would just assume that they are set. But it seems like its the wrong place for this as theoretically not all formatters would need to extend `AbstractFormatter`. 

This is also required for `@ApiModel` parameters to be resolved consistently.

## TODO
* [x] `@ApiModel`
* [x] `@ApiModelCollection` (for collection outputs: https://github.com/nelmio/NelmioApiDocBundle/pull/469)
* [x] Unit tests