### PR TITLE
Replace incorrect jQuery.size() method

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -262,7 +262,7 @@
                 };
 
                 var displayFinalUrl = function(xhr, method, url, data, container) {
-                    if ('GET' == method && jQuery(data).size()) {
+                    if ('GET' == method && !jQuery.isEmptyObject(data)) {
                         var separator = url.indexOf('?') >= 0 ? '&' : '?';
                         url = url + separator + decodeURIComponent(jQuery.param(data));
                     }


### PR DESCRIPTION
`jQuery.size()` does not return the correct parameters count when data is empty (it returns 1).
