### PR TITLE
FOSRest integration: Form errors format

### DIFF
--- a/Formatter/SwaggerFormatter.php
+++ b/Formatter/SwaggerFormatter.php
@@ -275,6 +275,8 @@ class SwaggerFormatter implements FormatterInterface
                     $message = sprintf('See standard HTTP status code reason for %s', $statusCode);
                 }
 
+                $className = !empty($prop['type']['form_errors']) ? $prop['type']['class'] . '.ErrorResponse' : $prop['type']['class'];
+
                 if (isset($prop['type']['collection']) && $prop['type']['collection'] === true) {
 
                     /*
@@ -283,14 +285,14 @@ class SwaggerFormatter implements FormatterInterface
                      */
                     $alias = $prop['type']['collectionName'];
 
-                    $newName = sprintf('%s[%s]', $prop['type']['class'], $alias);
+                    $newName = sprintf('%s[%s]', $className, $alias);
                     $collId =
                         $this->registerModel(
                             $newName,
                             array(
                                 $alias => array(
                                     'dataType'    => null,
-                                    'subType'     => $prop['type']['class'],
+                                    'subType'     => $className,
                                     'actualType'  => DataTypes::COLLECTION,
                                     'required'    => true,
                                     'readonly'    => true,
@@ -307,10 +309,11 @@ class SwaggerFormatter implements FormatterInterface
                         'responseModel' => $collId
                     );
                 } else {
+
                     $responseModel = array(
                         'code' => $statusCode,
                         'message' => $message,
-                        'responseModel' => $this->registerModel($prop['type']['class'], $prop['model'], ''),
+                        'responseModel' => $this->registerModel($className, $prop['model'], ''),
                     );
                 }
                 $responseMessages[$statusCode] = $responseModel;

--- a/Parser/FormErrorsParser.php
+++ b/Parser/FormErrorsParser.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Parser;
+
+use Nelmio\ApiDocBundle\DataTypes;
+
+/**
+ * @author Bez Hermoso <bezalelhermoso@gmail.com>
+ */
+class FormErrorsParser implements ParserInterface, PostParserInterface
+{
+    /**
+     * Return true/false whether this class supports parsing the given class.
+     *
+     * @param  array $item containing the following fields: class, groups. Of which groups is optional
+     *
+     * @return boolean
+     */
+    public function supports(array $item)
+    {
+        return isset($item['form_errors']) && $item['form_errors'] === true;
+    }
+
+    public function parse(array $item)
+    {
+        return array();
+    }
+
+    /**
+     * Overrides the root parameters to contain these parameters instead:
+     *      - status_code: 400
+     *      - message: "Validation failed"
+     *      - errors: contains the original parameters, but all types are changed to array of strings (array of errors for each field)
+     *
+     * @param array $item
+     * @param array $parameters
+     *
+     * @return array
+     */
+    public function postParse(array $item, array $parameters)
+    {
+        $params = $parameters;
+
+        foreach ($params as $name => $data) {
+            $params[$name] = null;
+        }
+
+        $params['status_code'] = array(
+            'dataType' => 'integer',
+            'actualType' => DataTypes::INTEGER,
+            'subType' => null,
+            'required' => false,
+            'description' => 'The status code',
+            'readonly' => true,
+            'default' => 400,
+        );
+
+        $params['message'] = array(
+            'dataType' => 'string',
+            'actualType' => DataTypes::STRING,
+            'subType' => null,
+            'required' => false,
+            'description' => 'The error message',
+            'default' => 'Validation failed.',
+        );
+
+        $params['errors'] = array(
+            'dataType' => 'errors',
+            'actualType' => DataTypes::MODEL,
+            'subType' => sprintf('%s.FormErrors', $item['class']),
+            'required' => false,
+            'description' => 'Errors',
+            'readonly' => true,
+            'children' => $this->doPostParse($parameters),
+        );
+
+        return $params;
+    }
+
+    protected function doPostParse(array $parameters, $attachFieldErrors = true, array $propertyPath = array())
+    {
+        $data = array();
+
+        foreach ($parameters as $name => $parameter) {
+
+            $data[$name] = array(
+                'dataType' => 'parameter errors',
+                'actualType' => DataTypes::MODEL,
+                'subType' => 'FieldErrors',
+                'required' => false,
+                'description' => 'Errors on the parameter',
+                'readonly' => true,
+                'children' => array(
+                    'errors' => array(
+                        'dataType' => 'array of errors',
+                        'actualType' => DataTypes::COLLECTION,
+                        'subType' => 'string',
+                        'required' => false,
+                        'dscription' => '',
+                        'readonly' => true,
+                    ),
+                ),
+            );
+
+            if ($parameter['actualType'] === DataTypes::MODEL) {
+                $propertyPath[] = $name;
+                $data[$name]['subType'] = sprintf('%s.FieldErrors[%s]', $parameter['subType'], implode('.', $propertyPath));
+                $data[$name]['children'] = $this->doPostParse($parameter['children'], $attachFieldErrors, $propertyPath);
+            } else {
+                if ($attachFieldErrors === false) {
+                    unset($data[$name]['children']);
+                }
+                $attachFieldErrors = false;
+            }
+        }
+
+        return $data;
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -15,6 +15,7 @@
         <parameter key="nelmio_api_doc.extractor.handler.phpdoc.class">Nelmio\ApiDocBundle\Extractor\Handler\PhpDocHandler</parameter>
 
         <parameter key="nelmio_api_doc.parser.collection_parser.class">Nelmio\ApiDocBundle\Parser\CollectionParser</parameter>
+        <parameter key="nelmio_api_doc.parser.form_errors_parser.class">Nelmio\ApiDocBundle\Parser\FormErrorsParser</parameter>
     </parameters>
 
     <services>
@@ -56,6 +57,9 @@
         </service>
 
         <service id="nelmio_api_doc.parser.collection_parser" class="%nelmio_api_doc.parser.collection_parser.class%">
+            <tag name="nelmio_api_doc.extractor.parser" />
+        </service>
+        <service id="nelmio_api_doc.parser.form_errors_parser" class="%nelmio_api_doc.parser.form_errors_parser.class%">
             <tag name="nelmio_api_doc.extractor.parser" />
         </service>
     </services>

--- a/Tests/Fixtures/Controller/ResourceController.php
+++ b/Tests/Fixtures/Controller/ResourceController.php
@@ -48,7 +48,10 @@ class ResourceController
      * @ApiDoc(
      *      description="Create a new resource.",
      *      input={"class" = "Nelmio\ApiDocBundle\Tests\Fixtures\Form\SimpleType", "name" = ""},
-     *      output="Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested"
+     *      output="Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested",
+     *      responseMap={
+     *          400 = {"class" = "Nelmio\ApiDocBundle\Tests\Fixtures\Form\SimpleType", "form_errors" = true}
+     *      }
      * )
      */
     public function createResourceAction()

--- a/Tests/Formatter/SwaggerFormatterTest.php
+++ b/Tests/Formatter/SwaggerFormatterTest.php
@@ -12,10 +12,11 @@ use Nelmio\ApiDocBundle\Tests\WebTestCase;
  * Class SwaggerFormatterTest
  *
  * @package Nelmio\ApiDocBundle\Tests\Formatter
- * @author Bez Hermoso <bez@activelamp.com>
+ * @author  Bez Hermoso <bez@activelamp.com>
  */
 class SwaggerFormatterTest extends WebTestCase
 {
+
     /**
      * @var ApiDocExtractor
      */
@@ -30,7 +31,7 @@ class SwaggerFormatterTest extends WebTestCase
     {
         parent::setUp();
 
-        $container = $this->getContainer();
+        $container       = $this->getContainer();
         $this->extractor = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
         $this->formatter = $container->get('nelmio_api_doc.formatter.swagger_formatter');
     }
@@ -49,49 +50,49 @@ class SwaggerFormatterTest extends WebTestCase
 
         $expected = array(
             'swaggerVersion' => '1.2',
-            'apiVersion' => '3.14',
-            'info' =>
+            'apiVersion'     => '3.14',
+            'info'           =>
                 array(
-                    'title' => 'Nelmio Swagger',
-                    'description' => 'Testing Swagger integration.',
+                    'title'             => 'Nelmio Swagger',
+                    'description'       => 'Testing Swagger integration.',
                     'TermsOfServiceUrl' => 'https://github.com',
-                    'contact' => 'user@domain.tld',
-                    'license' => 'MIT',
-                    'licenseUrl' => 'http://opensource.org/licenses/MIT',
+                    'contact'           => 'user@domain.tld',
+                    'license'           => 'MIT',
+                    'licenseUrl'        => 'http://opensource.org/licenses/MIT',
                 ),
             'authorizations' =>
                 array(
                     'apiKey' => array(
-                        'type' => 'apiKey',
-                        'passAs' => 'header',
+                        'type'    => 'apiKey',
+                        'passAs'  => 'header',
                         'keyname' => 'access_token',
                     )
                 ),
-            'apis' =>
+            'apis'           =>
                 array(
                     array(
-                        'path' => '/other-resources',
+                        'path'        => '/other-resources',
                         'description' => 'Operations on another resource.',
                     ),
                     array(
-                        'path' => '/resources',
+                        'path'        => '/resources',
                         'description' => 'Operations on resource.',
                     ),
                     array(
-                        'path' => '/tests',
-                        'description' => NULL,
+                        'path'        => '/tests',
+                        'description' => null,
                     ),
                     array(
-                        'path' => '/tests',
-                        'description' => NULL,
+                        'path'        => '/tests',
+                        'description' => null,
                     ),
                     array(
-                        'path' => '/tests2',
-                        'description' => NULL,
+                        'path'        => '/tests2',
+                        'description' => null,
                     ),
                     array(
-                        'path' => '/TestResource',
-                        'description' => NULL,
+                        'path'        => '/TestResource',
+                        'description' => null,
                     ),
                 ),
         );
@@ -121,372 +122,437 @@ class SwaggerFormatterTest extends WebTestCase
         return array(
             array(
                 '/resources',
-                array (
+                array(
                     'swaggerVersion' => '1.2',
-                    'apiVersion' => '3.14',
-                    'basePath' => '/api',
-                    'resourcePath' => '/resources',
-                    'apis' =>
-                        array (
-                            0 =>
-                                array (
-                                    'path' => '/resources.{_format}',
-                                    'operations' =>
-                                        array (
-                                            0 =>
-                                                array (
-                                                    'method' => 'GET',
-                                                    'summary' => 'List resources.',
-                                                    'nickname' => 'get_resources',
-                                                    'parameters' =>
-                                                        array (
-                                                            0 =>
-                                                                array (
-                                                                    'paramType' => 'path',
-                                                                    'name' => '_format',
-                                                                    'type' => 'string',
-                                                                    'required' => true,
-                                                                    'enum' =>
-                                                                        array (
-                                                                            0 => 'json',
-                                                                            1 => 'xml',
-                                                                            2 => 'html',
-                                                                        ),
-                                                                ),
-                                                        ),
-                                                    'responseMessages' =>
-                                                        array (
-                                                            0 =>
-                                                                array (
-                                                                    'code' => 200,
-                                                                    'message' => 'Returned on success.',
-                                                                    'responseModel' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.Test[tests]',
-                                                                ),
-                                                            1 =>
-                                                                array (
-                                                                    'code' => 404,
-                                                                    'message' => 'Returned if resource cannot be found.',
-                                                                ),
-                                                        ),
-                                                    'type' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.Test[tests]',
+                    'apiVersion'     => '3.14',
+                    'basePath'       => '/api',
+                    'resourcePath'   => '/resources',
+                    'apis'           =>
+                        array(
+
+                            array(
+                                'path'       => '/resources.{_format}',
+                                'operations' =>
+                                    array(
+
+                                        array(
+                                            'method'           => 'GET',
+                                            'summary'          => 'List resources.',
+                                            'nickname'         => 'get_resources',
+                                            'parameters'       =>
+                                                array(
+
+                                                    array(
+                                                        'paramType' => 'path',
+                                                        'name'      => '_format',
+                                                        'type'      => 'string',
+                                                        'required'  => true,
+                                                        'enum'      =>
+                                                            array(
+                                                                'json',
+                                                                'xml',
+                                                                'html',
+                                                            ),
+                                                    ),
                                                 ),
-                                            1 =>
-                                                array (
-                                                    'method' => 'POST',
-                                                    'summary' => 'Create a new resource.',
-                                                    'nickname' => 'post_resources',
-                                                    'parameters' =>
-                                                        array (
-                                                            0 =>
-                                                                array (
-                                                                    'paramType' => 'path',
-                                                                    'name' => '_format',
-                                                                    'type' => 'string',
-                                                                    'required' => true,
-                                                                    'enum' =>
-                                                                        array (
-                                                                            0 => 'json',
-                                                                            1 => 'xml',
-                                                                            2 => 'html',
-                                                                        ),
-                                                                ),
-                                                            1 =>
-                                                                array (
-                                                                    'paramType' => 'form',
-                                                                    'name' => 'a',
-                                                                    'type' => 'string',
-                                                                    'description' => 'Something that describes A.',
-                                                                ),
-                                                            2 =>
-                                                                array (
-                                                                    'paramType' => 'form',
-                                                                    'name' => 'b',
-                                                                    'type' => 'number',
-                                                                    'format' => 'float',
-                                                                ),
-                                                            3 =>
-                                                                array (
-                                                                    'paramType' => 'form',
-                                                                    'name' => 'c',
-                                                                    'type' => 'string',
-                                                                    'enum' =>
-                                                                        array (
-                                                                            0 => 'x',
-                                                                            1 => 'y',
-                                                                            2 => 'z',
-                                                                        ),
-                                                                ),
-                                                            4 =>
-                                                                array (
-                                                                    'paramType' => 'form',
-                                                                    'name' => 'd',
-                                                                    'type' => 'string',
-                                                                    'format' => 'date-time',
-                                                                ),
-                                                            5 =>
-                                                                array (
-                                                                    'paramType' => 'form',
-                                                                    'name' => 'e',
-                                                                    'type' => 'string',
-                                                                    'format' => 'date',
-                                                                ),
-                                                            6 =>
-                                                                array (
-                                                                    'paramType' => 'form',
-                                                                    'name' => 'g',
-                                                                    'type' => 'string',
-                                                                ),
-                                                        ),
-                                                    'responseMessages' =>
-                                                        array (
-                                                            0 =>
-                                                                array (
-                                                                    'code' => 200,
-                                                                    'message' => 'See standard HTTP status code reason for 200',
-                                                                    'responseModel' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsNested',
-                                                                ),
-                                                        ),
-                                                    'type' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsNested',
+                                            'responseMessages' =>
+                                                array(
+
+                                                    array(
+                                                        'code'          => 200,
+                                                        'message'       => 'Returned on success.',
+                                                        'responseModel' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.Test[tests]',
+                                                    ),
+                                                    array(
+                                                        'code'    => 404,
+                                                        'message' => 'Returned if resource cannot be found.',
+                                                    ),
                                                 ),
+                                            'type'             => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.Test[tests]',
                                         ),
-                                ),
-                            1 =>
-                                array (
-                                    'path' => '/resources/{id}.{_format}',
-                                    'operations' =>
-                                        array (
-                                            0 =>
-                                                array (
-                                                    'method' => 'GET',
-                                                    'summary' => 'Retrieve a resource by ID.',
-                                                    'nickname' => 'get_resources',
-                                                    'parameters' =>
-                                                        array (
-                                                            0 =>
-                                                                array (
-                                                                    'paramType' => 'path',
-                                                                    'name' => 'id',
-                                                                    'type' => 'string',
-                                                                    'required' => true,
-                                                                ),
-                                                            1 =>
-                                                                array (
-                                                                    'paramType' => 'path',
-                                                                    'name' => '_format',
-                                                                    'type' => 'string',
-                                                                    'required' => true,
-                                                                    'enum' =>
-                                                                        array (
-                                                                            0 => 'json',
-                                                                            1 => 'xml',
-                                                                            2 => 'html',
-                                                                        ),
+                                        array(
+                                            'method'           => 'POST',
+                                            'summary'          => 'Create a new resource.',
+                                            'nickname'         => 'post_resources',
+                                            'parameters'       =>
+                                                array(
+                                                    0 =>
+                                                        array(
+                                                            'paramType' => 'path',
+                                                            'name'      => '_format',
+                                                            'type'      => 'string',
+                                                            'required'  => true,
+                                                            'enum'      =>
+                                                                array(
+                                                                    0 => 'json',
+                                                                    1 => 'xml',
+                                                                    2 => 'html',
                                                                 ),
                                                         ),
-                                                    'responseMessages' =>
-                                                        array (
+                                                    1 =>
+                                                        array(
+                                                            'paramType'   => 'form',
+                                                            'name'        => 'a',
+                                                            'type'        => 'string',
+                                                            'description' => 'Something that describes A.',
                                                         ),
-                                                ),
-                                            1 =>
-                                                array (
-                                                    'method' => 'DELETE',
-                                                    'summary' => 'Delete a resource by ID.',
-                                                    'nickname' => 'delete_resources',
-                                                    'parameters' =>
-                                                        array (
-                                                            0 =>
-                                                                array (
-                                                                    'paramType' => 'path',
-                                                                    'name' => 'id',
-                                                                    'type' => 'string',
-                                                                    'required' => true,
-                                                                ),
-                                                            1 =>
-                                                                array (
-                                                                    'paramType' => 'path',
-                                                                    'name' => '_format',
-                                                                    'type' => 'string',
-                                                                    'required' => true,
-                                                                    'enum' =>
-                                                                        array (
-                                                                            0 => 'json',
-                                                                            1 => 'xml',
-                                                                            2 => 'html',
-                                                                        ),
+                                                    2 =>
+                                                        array(
+                                                            'paramType' => 'form',
+                                                            'name'      => 'b',
+                                                            'type'      => 'number',
+                                                            'format'    => 'float',
+                                                        ),
+                                                    3 =>
+                                                        array(
+                                                            'paramType' => 'form',
+                                                            'name'      => 'c',
+                                                            'type'      => 'string',
+                                                            'enum'      =>
+                                                                array(
+                                                                    0 => 'x',
+                                                                    1 => 'y',
+                                                                    2 => 'z',
                                                                 ),
                                                         ),
-                                                    'responseMessages' =>
-                                                        array (
+                                                    4 =>
+                                                        array(
+                                                            'paramType' => 'form',
+                                                            'name'      => 'd',
+                                                            'type'      => 'string',
+                                                            'format'    => 'date-time',
+                                                        ),
+                                                    5 =>
+                                                        array(
+                                                            'paramType' => 'form',
+                                                            'name'      => 'e',
+                                                            'type'      => 'string',
+                                                            'format'    => 'date',
+                                                        ),
+                                                    6 =>
+                                                        array(
+                                                            'paramType' => 'form',
+                                                            'name'      => 'g',
+                                                            'type'      => 'string',
                                                         ),
                                                 ),
+                                            'responseMessages' =>
+                                                array(
+                                                    0 =>
+                                                        array(
+                                                            'code'          => 200,
+                                                            'message'       => 'See standard HTTP status code reason for 200',
+                                                            'responseModel' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsNested',
+                                                        ),
+                                                    1 =>
+                                                        array(
+                                                            'code'          => 400,
+                                                            'message'       => 'See standard HTTP status code reason for 400',
+                                                            'responseModel' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Form.SimpleType.ErrorResponse'
+                                                        ),
+                                                ),
+                                            'type'             => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsNested',
                                         ),
-                                ),
+                                    ),
+                            ),
+                            array(
+                                'path'       => '/resources/{id}.{_format}',
+                                'operations' =>
+                                    array(
+
+                                        array(
+                                            'method'           => 'GET',
+                                            'summary'          => 'Retrieve a resource by ID.',
+                                            'nickname'         => 'get_resources',
+                                            'parameters'       =>
+                                                array(
+
+                                                    array(
+                                                        'paramType' => 'path',
+                                                        'name'      => 'id',
+                                                        'type'      => 'string',
+                                                        'required'  => true,
+                                                    ),
+                                                    array(
+                                                        'paramType' => 'path',
+                                                        'name'      => '_format',
+                                                        'type'      => 'string',
+                                                        'required'  => true,
+                                                        'enum'      =>
+                                                            array(
+                                                                'json',
+                                                                'xml',
+                                                                'html',
+                                                            ),
+                                                    ),
+                                                ),
+                                            'responseMessages' =>
+                                                array(),
+                                        ),
+                                        array(
+                                            'method'           => 'DELETE',
+                                            'summary'          => 'Delete a resource by ID.',
+                                            'nickname'         => 'delete_resources',
+                                            'parameters'       =>
+                                                array(
+
+                                                    array(
+                                                        'paramType' => 'path',
+                                                        'name'      => 'id',
+                                                        'type'      => 'string',
+                                                        'required'  => true,
+                                                    ),
+                                                    array(
+                                                        'paramType' => 'path',
+                                                        'name'      => '_format',
+                                                        'type'      => 'string',
+                                                        'required'  => true,
+                                                        'enum'      =>
+                                                            array(
+                                                                'json',
+                                                                'xml',
+                                                                'html',
+                                                            ),
+                                                    ),
+                                                ),
+                                            'responseMessages' =>
+                                                array(),
+                                        ),
+                                    ),
+                            ),
                         ),
-                    'models' =>
-                        array (
-                            'Nelmio.ApiDocBundle.Tests.Fixtures.Model.Test' =>
-                                array (
-                                    'id' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.Test',
-                                    'description' => NULL,
-                                    'properties' =>
-                                        array (
+                    'models'         =>
+                        array(
+                            'Nelmio.ApiDocBundle.Tests.Fixtures.Model.Test'                          =>
+                                array(
+                                    'id'          => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.Test',
+                                    'description' => null,
+                                    'properties'  =>
+                                        array(
                                             'a' =>
-                                                array (
-                                                    'type' => 'string',
+                                                array(
+                                                    'type'        => 'string',
                                                     'description' => 'string',
                                                 ),
                                             'b' =>
-                                                array (
-                                                    'type' => 'string',
+                                                array(
+                                                    'type'        => 'string',
                                                     'description' => 'DateTime',
-                                                    'format' => 'date-time',
+                                                    'format'      => 'date-time',
                                                 ),
                                         ),
-                                    'required' =>
-                                        array (
-                                            0 => 'a',
+                                    'required'    =>
+                                        array(
+                                            'a',
                                         ),
                                 ),
-                            'Nelmio.ApiDocBundle.Tests.Fixtures.Model.Test[tests]' =>
-                                array (
-                                    'id' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.Test[tests]',
+                            'Nelmio.ApiDocBundle.Tests.Fixtures.Model.Test[tests]'                   =>
+                                array(
+                                    'id'          => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.Test[tests]',
                                     'description' => '',
-                                    'properties' =>
-                                        array (
+                                    'properties'  =>
+                                        array(
                                             'tests' =>
-                                                array (
-                                                    'type' => 'array',
-                                                    'description' => NULL,
-                                                    'items' =>
-                                                        array (
+                                                array(
+                                                    'type'        => 'array',
+                                                    'description' => null,
+                                                    'items'       =>
+                                                        array(
                                                             '$ref' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.Test',
                                                         ),
                                                 ),
                                         ),
-                                    'required' =>
-                                        array (
-                                            0 => 'tests',
+                                    'required'    =>
+                                        array(
+                                            'tests',
                                         ),
                                 ),
-                            'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsTest' =>
-                                array (
-                                    'id' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsTest',
+                            'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsTest'                       =>
+                                array(
+                                    'id'          => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsTest',
                                     'description' => 'object (JmsTest)',
-                                    'properties' =>
-                                        array (
-                                            'foo' =>
-                                                array (
-                                                    'type' => 'string',
+                                    'properties'  =>
+                                        array(
+                                            'foo'          =>
+                                                array(
+                                                    'type'        => 'string',
                                                     'description' => 'string',
                                                 ),
-                                            'bar' =>
-                                                array (
-                                                    'type' => 'string',
+                                            'bar'          =>
+                                                array(
+                                                    'type'        => 'string',
                                                     'description' => 'DateTime',
-                                                    'format' => 'date-time',
+                                                    'format'      => 'date-time',
                                                 ),
-                                            'number' =>
-                                                array (
-                                                    'type' => 'number',
+                                            'number'       =>
+                                                array(
+                                                    'type'        => 'number',
                                                     'description' => 'double',
-                                                    'format' => 'float',
+                                                    'format'      => 'float',
                                                 ),
-                                            'arr' =>
-                                                array (
-                                                    'type' => 'array',
+                                            'arr'          =>
+                                                array(
+                                                    'type'        => 'array',
                                                     'description' => 'array',
-                                                    'items' =>
-                                                        array (
+                                                    'items'       =>
+                                                        array(
                                                             'type' => 'string',
                                                         ),
                                                 ),
-                                            'nested' =>
-                                                array (
+                                            'nested'       =>
+                                                array(
                                                     '$ref' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsNested',
                                                 ),
                                             'nested_array' =>
-                                                array (
-                                                    'type' => 'array',
+                                                array(
+                                                    'type'        => 'array',
                                                     'description' => 'array of objects (JmsNested)',
-                                                    'items' =>
-                                                        array (
+                                                    'items'       =>
+                                                        array(
                                                             '$ref' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsNested',
                                                         ),
                                                 ),
                                         ),
-                                    'required' =>
-                                        array (
-                                        ),
+                                    'required'    =>
+                                        array(),
                                 ),
-                            'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsNested' =>
-                                array (
-                                    'id' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsNested',
+                            'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsNested'                     =>
+                                array(
+                                    'id'          => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsNested',
                                     'description' => '',
-                                    'properties' =>
-                                        array (
-                                            'foo' =>
-                                                array (
-                                                    'type' => 'string',
+                                    'properties'  =>
+                                        array(
+                                            'foo'             =>
+                                                array(
+                                                    'type'        => 'string',
                                                     'description' => 'DateTime',
-                                                    'format' => 'date-time',
+                                                    'format'      => 'date-time',
                                                 ),
-                                            'bar' =>
-                                                array (
-                                                    'type' => 'string',
+                                            'bar'             =>
+                                                array(
+                                                    'type'        => 'string',
                                                     'description' => 'string',
                                                 ),
-                                            'baz' =>
-                                                array (
-                                                    'type' => 'array',
+                                            'baz'             =>
+                                                array(
+                                                    'type'        => 'array',
                                                     'description' => 'Epic description.
 
 With multiple lines.',
-                                                    'items' =>
-                                                        array (
-                                                                'type' => 'integer',
+                                                    'items'       =>
+                                                        array(
+                                                            'type' => 'integer',
                                                         ),
                                                 ),
-                                            'circular' =>
-                                                array (
+                                            'circular'        =>
+                                                array(
                                                     '$ref' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsNested',
                                                 ),
-                                            'parent' =>
-                                                array (
+                                            'parent'          =>
+                                                array(
                                                     '$ref' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsTest',
                                                 ),
-                                            'since' =>
-                                                array (
-                                                    'type' => 'string',
+                                            'since'           =>
+                                                array(
+                                                    'type'        => 'string',
                                                     'description' => 'string',
                                                 ),
-                                            'until' =>
-                                                array (
-                                                    'type' => 'string',
+                                            'until'           =>
+                                                array(
+                                                    'type'        => 'string',
                                                     'description' => 'string',
                                                 ),
                                             'since_and_until' =>
-                                                array (
-                                                    'type' => 'string',
+                                                array(
+                                                    'type'        => 'string',
                                                     'description' => 'string',
                                                 ),
                                         ),
-                                    'required' =>
-                                        array (
+                                    'required'    =>
+                                        array(),
+                                ),
+                            'FieldErrors'                                                            =>
+                                array(
+                                    'id'          => 'FieldErrors',
+                                    'description' => 'Errors on the parameter',
+                                    'properties'  => array(
+                                        'errors' => array(
+                                            'type'        => 'array',
+                                            'description' => 'array of errors',
+                                            'items'       => array(
+                                                'type' => 'string',
+                                            ),
                                         ),
+                                    ),
+                                    'required'    => array()
+                                ),
+                            'Nelmio.ApiDocBundle.Tests.Fixtures.Form.SimpleType.FormErrors'          =>
+                                array(
+                                    'id'          => 'Nelmio.ApiDocBundle.Tests.Fixtures.Form.SimpleType.FormErrors',
+                                    'description' => 'Errors',
+                                    'properties'  => array(
+                                        'simple' => array(
+                                            '$ref' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Form.SimpleType.FieldErrors[simple]',
+                                        )
+                                    ),
+                                    'required'    => array()
+                                ),
+                            'Nelmio.ApiDocBundle.Tests.Fixtures.Form.SimpleType.ErrorResponse'       => array(
+                                'id'          => 'Nelmio.ApiDocBundle.Tests.Fixtures.Form.SimpleType.ErrorResponse',
+                                'description' => '',
+                                'properties'  => array(
+                                    'status_code' => array(
+                                        'type'        => 'integer',
+                                        'description' => 'The status code',
+                                        'format'      => 'int32',
+                                    ),
+                                    'message'     => array(
+                                        'type'        => 'string',
+                                        'description' => 'The error message',
+                                    ),
+                                    'errors'      => array(
+                                        '$ref' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Form.SimpleType.FormErrors',
+                                    ),
+                                ),
+                                'required'    => array(),
+                            ),
+                            'Nelmio.ApiDocBundle.Tests.Fixtures.Form.SimpleType.FieldErrors[simple]' =>
+                                array(
+                                    'id'          => 'Nelmio.ApiDocBundle.Tests.Fixtures.Form.SimpleType.FieldErrors[simple]',
+                                    'description' => 'Errors on the parameter',
+                                    'properties'  => array(
+                                        'a' => array(
+                                            '$ref' => 'FieldErrors',
+                                        ),
+                                        'b' => array(
+                                            '$ref' => 'FieldErrors',
+                                        ),
+                                        'c' => array(
+                                            '$ref' => 'FieldErrors',
+                                        ),
+                                        'd' => array(
+                                            '$ref' => 'FieldErrors',
+                                        ),
+                                        'e' => array(
+                                            '$ref' => 'FieldErrors',
+                                        ),
+                                        'g' => array(
+                                            '$ref' => 'FieldErrors',
+                                        ),
+                                    ),
+                                    'required'    => array(),
                                 ),
                         ),
-                    'produces' =>
-                        array (
-                        ),
-                    'consumes' =>
-                        array (
-                        ),
+                    'produces'       =>
+                        array(),
+                    'consumes'       =>
+                        array(),
                     'authorizations' =>
-                        array (
+                        array(
                             'apiKey' =>
-                                array (
-                                    'type' => 'apiKey',
-                                    'passAs' => 'header',
+                                array(
+                                    'type'    => 'apiKey',
+                                    'passAs'  => 'header',
                                     'keyname' => 'access_token',
                                 ),
                         ),
@@ -494,266 +560,256 @@ With multiple lines.',
             ),
             array(
                 '/other-resources',
-                array (
+                array(
                     'swaggerVersion' => '1.2',
-                    'apiVersion' => '3.14',
-                    'basePath' => '/api',
-                    'resourcePath' => '/other-resources',
-                    'apis' =>
-                        array (
-                            0 =>
-                                array (
-                                    'path' => '/other-resources.{_format}',
-                                    'operations' =>
-                                        array (
-                                            0 =>
-                                                array (
-                                                    'method' => 'GET',
-                                                    'summary' => 'List another resource.',
-                                                    'nickname' => 'get_other-resources',
-                                                    'parameters' =>
-                                                        array (
-                                                            0 =>
-                                                                array (
-                                                                    'paramType' => 'path',
-                                                                    'name' => '_format',
-                                                                    'type' => 'string',
-                                                                    'required' => true,
-                                                                    'enum' =>
-                                                                        array (
-                                                                            0 => 'json',
-                                                                            1 => 'xml',
-                                                                            2 => 'html',
-                                                                        ),
-                                                                ),
-                                                        ),
-                                                    'responseMessages' =>
-                                                        array (
-                                                            0 =>
-                                                                array (
-                                                                    'code' => 200,
-                                                                    'message' => 'See standard HTTP status code reason for 200',
-                                                                    'responseModel' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsTest[]',
-                                                                ),
-                                                        ),
-                                                    'type' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsTest[]',
+                    'apiVersion'     => '3.14',
+                    'basePath'       => '/api',
+                    'resourcePath'   => '/other-resources',
+                    'apis'           =>
+                        array(
+
+                            array(
+                                'path'       => '/other-resources.{_format}',
+                                'operations' =>
+                                    array(
+
+                                        array(
+                                            'method'           => 'GET',
+                                            'summary'          => 'List another resource.',
+                                            'nickname'         => 'get_other-resources',
+                                            'parameters'       =>
+                                                array(
+
+                                                    array(
+                                                        'paramType' => 'path',
+                                                        'name'      => '_format',
+                                                        'type'      => 'string',
+                                                        'required'  => true,
+                                                        'enum'      =>
+                                                            array(
+                                                                'json',
+                                                                'xml',
+                                                                'html',
+                                                            ),
+                                                    ),
                                                 ),
+                                            'responseMessages' =>
+                                                array(
+
+                                                    array(
+                                                        'code'          => 200,
+                                                        'message'       => 'See standard HTTP status code reason for 200',
+                                                        'responseModel' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsTest[]',
+                                                    ),
+                                                ),
+                                            'type'             => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsTest[]',
                                         ),
-                                ),
-                            1 =>
-                                array (
-                                    'path' => '/other-resources/{id}.{_format}',
-                                    'operations' =>
-                                        array (
-                                            0 =>
-                                                array (
-                                                    'method' => 'PUT',
-                                                    'summary' => 'Update a resource bu ID.',
-                                                    'nickname' => 'put_other-resources',
-                                                    'parameters' =>
-                                                        array (
-                                                            0 =>
-                                                                array (
-                                                                    'paramType' => 'path',
-                                                                    'name' => 'id',
-                                                                    'type' => 'string',
-                                                                    'required' => true,
-                                                                ),
-                                                            1 =>
-                                                                array (
-                                                                    'paramType' => 'path',
-                                                                    'name' => '_format',
-                                                                    'type' => 'string',
-                                                                    'required' => true,
-                                                                    'enum' =>
-                                                                        array (
-                                                                            0 => 'json',
-                                                                            1 => 'xml',
-                                                                            2 => 'html',
-                                                                        ),
-                                                                ),
-                                                        ),
-                                                    'responseMessages' =>
-                                                        array (
-                                                        ),
+                                    ),
+                            ),
+                            array(
+                                'path'       => '/other-resources/{id}.{_format}',
+                                'operations' =>
+                                    array(
+
+                                        array(
+                                            'method'           => 'PUT',
+                                            'summary'          => 'Update a resource bu ID.',
+                                            'nickname'         => 'put_other-resources',
+                                            'parameters'       =>
+                                                array(
+
+                                                    array(
+                                                        'paramType' => 'path',
+                                                        'name'      => 'id',
+                                                        'type'      => 'string',
+                                                        'required'  => true,
+                                                    ),
+                                                    array(
+                                                        'paramType' => 'path',
+                                                        'name'      => '_format',
+                                                        'type'      => 'string',
+                                                        'required'  => true,
+                                                        'enum'      =>
+                                                            array(
+                                                                'json',
+                                                                'xml',
+                                                                'html',
+                                                            ),
+                                                    ),
                                                 ),
-                                            1 =>
-                                                array (
-                                                    'method' => 'PATCH',
-                                                    'summary' => 'Update a resource bu ID.',
-                                                    'nickname' => 'patch_other-resources',
-                                                    'parameters' =>
-                                                        array (
-                                                            0 =>
-                                                                array (
-                                                                    'paramType' => 'path',
-                                                                    'name' => 'id',
-                                                                    'type' => 'string',
-                                                                    'required' => true,
-                                                                ),
-                                                            1 =>
-                                                                array (
-                                                                    'paramType' => 'path',
-                                                                    'name' => '_format',
-                                                                    'type' => 'string',
-                                                                    'required' => true,
-                                                                    'enum' =>
-                                                                        array (
-                                                                            0 => 'json',
-                                                                            1 => 'xml',
-                                                                            2 => 'html',
-                                                                        ),
-                                                                ),
-                                                        ),
-                                                    'responseMessages' =>
-                                                        array (
-                                                        ),
-                                                ),
+                                            'responseMessages' =>
+                                                array(),
                                         ),
-                                ),
+                                        array(
+                                            'method'           => 'PATCH',
+                                            'summary'          => 'Update a resource bu ID.',
+                                            'nickname'         => 'patch_other-resources',
+                                            'parameters'       =>
+                                                array(
+
+                                                    array(
+                                                        'paramType' => 'path',
+                                                        'name'      => 'id',
+                                                        'type'      => 'string',
+                                                        'required'  => true,
+                                                    ),
+                                                    array(
+                                                        'paramType' => 'path',
+                                                        'name'      => '_format',
+                                                        'type'      => 'string',
+                                                        'required'  => true,
+                                                        'enum'      =>
+                                                            array(
+                                                                'json',
+                                                                'xml',
+                                                                'html',
+                                                            ),
+                                                    ),
+                                                ),
+                                            'responseMessages' =>
+                                                array(),
+                                        ),
+                                    ),
+                            ),
                         ),
-                    'models' =>
-                        array (
-                            'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsTest' =>
-                                array (
-                                    'id' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsTest',
-                                    'description' => NULL,
-                                    'properties' =>
-                                        array (
-                                            'foo' =>
-                                                array (
-                                                    'type' => 'string',
+                    'models'         =>
+                        array(
+                            'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsTest'   =>
+                                array(
+                                    'id'          => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsTest',
+                                    'description' => null,
+                                    'properties'  =>
+                                        array(
+                                            'foo'          =>
+                                                array(
+                                                    'type'        => 'string',
                                                     'description' => 'string',
                                                 ),
-                                            'bar' =>
-                                                array (
-                                                    'type' => 'string',
+                                            'bar'          =>
+                                                array(
+                                                    'type'        => 'string',
                                                     'description' => 'DateTime',
-                                                    'format' => 'date-time',
+                                                    'format'      => 'date-time',
                                                 ),
-                                            'number' =>
-                                                array (
-                                                    'type' => 'number',
+                                            'number'       =>
+                                                array(
+                                                    'type'        => 'number',
                                                     'description' => 'double',
-                                                    'format' => 'float',
+                                                    'format'      => 'float',
                                                 ),
-                                            'arr' =>
-                                                array (
-                                                    'type' => 'array',
+                                            'arr'          =>
+                                                array(
+                                                    'type'        => 'array',
                                                     'description' => 'array',
-                                                    'items' =>
-                                                        array (
+                                                    'items'       =>
+                                                        array(
                                                             'type' => 'string',
                                                         ),
                                                 ),
-                                            'nested' =>
-                                                array (
+                                            'nested'       =>
+                                                array(
                                                     '$ref' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsNested',
                                                 ),
                                             'nested_array' =>
-                                                array (
-                                                    'type' => 'array',
+                                                array(
+                                                    'type'        => 'array',
                                                     'description' => 'array of objects (JmsNested)',
-                                                    'items' =>
-                                                        array (
+                                                    'items'       =>
+                                                        array(
                                                             '$ref' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsNested',
                                                         ),
                                                 ),
                                         ),
-                                    'required' =>
-                                        array (
-                                        ),
+                                    'required'    =>
+                                        array(),
                                 ),
                             'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsNested' =>
-                                array (
-                                    'id' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsNested',
+                                array(
+                                    'id'          => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsNested',
                                     'description' => 'object (JmsNested)',
-                                    'properties' =>
-                                        array (
-                                            'foo' =>
-                                                array (
-                                                    'type' => 'string',
+                                    'properties'  =>
+                                        array(
+                                            'foo'             =>
+                                                array(
+                                                    'type'        => 'string',
                                                     'description' => 'DateTime',
-                                                    'format' => 'date-time',
+                                                    'format'      => 'date-time',
                                                 ),
-                                            'bar' =>
-                                                array (
-                                                    'type' => 'string',
+                                            'bar'             =>
+                                                array(
+                                                    'type'        => 'string',
                                                     'description' => 'string',
                                                 ),
-                                            'baz' =>
-                                                array (
-                                                    'type' => 'array',
+                                            'baz'             =>
+                                                array(
+                                                    'type'        => 'array',
                                                     'description' => 'Epic description.
 
 With multiple lines.',
-                                                    'items' =>
-                                                        array (
+                                                    'items'       =>
+                                                        array(
                                                             'type' => 'integer',
                                                         ),
                                                 ),
-                                            'circular' =>
-                                                array (
+                                            'circular'        =>
+                                                array(
                                                     '$ref' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsNested',
                                                 ),
-                                            'parent' =>
-                                                array (
+                                            'parent'          =>
+                                                array(
                                                     '$ref' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsTest',
                                                 ),
-                                            'since' =>
-                                                array (
-                                                    'type' => 'string',
+                                            'since'           =>
+                                                array(
+                                                    'type'        => 'string',
                                                     'description' => 'string',
                                                 ),
-                                            'until' =>
-                                                array (
-                                                    'type' => 'string',
+                                            'until'           =>
+                                                array(
+                                                    'type'        => 'string',
                                                     'description' => 'string',
                                                 ),
                                             'since_and_until' =>
-                                                array (
-                                                    'type' => 'string',
+                                                array(
+                                                    'type'        => 'string',
                                                     'description' => 'string',
                                                 ),
                                         ),
-                                    'required' =>
-                                        array (
-                                        ),
+                                    'required'    =>
+                                        array(),
                                 ),
                             'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsTest[]' =>
-                                array (
-                                    'id' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsTest[]',
+                                array(
+                                    'id'          => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsTest[]',
                                     'description' => '',
-                                    'properties' =>
-                                        array (
+                                    'properties'  =>
+                                        array(
                                             '' =>
-                                                array (
-                                                    'type' => 'array',
-                                                    'description' => NULL,
-                                                    'items' =>
-                                                        array (
+                                                array(
+                                                    'type'        => 'array',
+                                                    'description' => null,
+                                                    'items'       =>
+                                                        array(
                                                             '$ref' => 'Nelmio.ApiDocBundle.Tests.Fixtures.Model.JmsTest',
                                                         ),
                                                 ),
                                         ),
-                                    'required' =>
-                                        array (
-                                            0 => '',
+                                    'required'    =>
+                                        array(
+                                            '',
                                         ),
                                 ),
                         ),
-                    'produces' =>
-                        array (
-                        ),
-                    'consumes' =>
-                        array (
-                        ),
+                    'produces'       =>
+                        array(),
+                    'consumes'       =>
+                        array(),
                     'authorizations' =>
-                        array (
+                        array(
                             'apiKey' =>
-                                array (
-                                    'type' => 'apiKey',
-                                    'passAs' => 'header',
+                                array(
+                                    'type'    => 'apiKey',
+                                    'passAs'  => 'header',
                                     'keyname' => 'access_token',
                                 ),
                         ),
@@ -761,191 +817,170 @@ With multiple lines.',
             ),
             array(
                 '/tests',
-                array (
+                array(
                     'swaggerVersion' => '1.2',
-                    'apiVersion' => '3.14',
-                    'basePath' => '/api',
-                    'resourcePath' => '/tests',
-                    'apis' =>
-                        array (
+                    'apiVersion'     => '3.14',
+                    'basePath'       => '/api',
+                    'resourcePath'   => '/tests',
+                    'apis'           =>
+                        array(
 
-                                array (
-                                    'path' => '/tests.{_format}',
-                                    'operations' =>
-                                        array (
+                            array(
+                                'path'       => '/tests.{_format}',
+                                'operations' =>
+                                    array(
 
-                                                array (
-                                                    'method' => 'GET',
-                                                    'summary' => 'index action',
-                                                    'nickname' => 'get_tests',
-                                                    'parameters' =>
-                                                        array (
+                                        array(
+                                            'method'           => 'GET',
+                                            'summary'          => 'index action',
+                                            'nickname'         => 'get_tests',
+                                            'parameters'       =>
+                                                array(
 
-                                                                array (
-                                                                    'paramType' => 'path',
-                                                                    'name' => '_format',
-                                                                    'type' => 'string',
-                                                                    'required' => true,
-                                                                ),
-                                                                array (
-                                                                    'paramType' => 'query',
-                                                                    'name' => 'a',
-                                                                    'type' => 'integer',
-                                                                    'description' => null,
-                                                                ),
-                                                                array (
-                                                                    'paramType' => 'query',
-                                                                    'name' => 'b',
-                                                                    'type' => 'string',
-                                                                    'description' => null,
-                                                                ),
-                                                        ),
-                                                    'responseMessages' =>
-                                                        array (
-                                                        ),
+                                                    array(
+                                                        'paramType' => 'path',
+                                                        'name'      => '_format',
+                                                        'type'      => 'string',
+                                                        'required'  => true,
+                                                    ),
+                                                    array(
+                                                        'paramType'   => 'query',
+                                                        'name'        => 'a',
+                                                        'type'        => 'integer',
+                                                        'description' => null,
+                                                    ),
+                                                    array(
+                                                        'paramType'   => 'query',
+                                                        'name'        => 'b',
+                                                        'type'        => 'string',
+                                                        'description' => null,
+                                                    ),
                                                 ),
-
-                                                array (
-                                                    'method' => 'GET',
-                                                    'summary' => 'index action',
-                                                    'nickname' => 'get_tests',
-                                                    'parameters' =>
-                                                        array (
-
-                                                                array (
-                                                                    'paramType' => 'path',
-                                                                    'name' => '_format',
-                                                                    'type' => 'string',
-                                                                    'required' => true,
-                                                                ),
-
-                                                                array (
-                                                                    'paramType' => 'query',
-                                                                    'name' => 'a',
-                                                                    'type' => 'integer',
-                                                                    'description' => null,
-                                                                ),
-
-                                                                array (
-                                                                    'paramType' => 'query',
-                                                                    'name' => 'b',
-                                                                    'type' => 'string',
-                                                                    'description' => null,
-                                                                ),
-                                                        ),
-                                                    'responseMessages' =>
-                                                        array (
-                                                        ),
-                                                ),
-
-                                                array (
-                                                    'method' => 'POST',
-                                                    'summary' => 'create test',
-                                                    'nickname' => 'post_tests',
-                                                    'parameters' =>
-                                                        array (
-
-                                                                array (
-                                                                    'paramType' => 'path',
-                                                                    'name' => '_format',
-                                                                    'type' => 'string',
-                                                                    'required' => true,
-                                                                ),
-
-                                                                array (
-                                                                    'paramType' => 'form',
-                                                                    'name' => 'a',
-                                                                    'type' => 'string',
-                                                                    'description' => 'A nice description',
-                                                                ),
-
-                                                                array (
-                                                                    'paramType' => 'form',
-                                                                    'name' => 'b',
-                                                                    'type' => 'string',
-                                                                ),
-
-                                                                array (
-                                                                    'paramType' => 'form',
-                                                                    'name' => 'c',
-                                                                    'type' => 'boolean',
-                                                                    'defaultValue' => false,
-                                                                ),
-
-                                                                array (
-                                                                    'paramType' => 'form',
-                                                                    'name' => 'd',
-                                                                    'type' => 'string',
-                                                                    'defaultValue' => 'DefaultTest',
-                                                                ),
-                                                        ),
-                                                    'responseMessages' =>
-                                                        array (
-                                                        ),
-                                                ),
-
-                                                array (
-                                                    'method' => 'POST',
-                                                    'summary' => 'create test',
-                                                    'nickname' => 'post_tests',
-                                                    'parameters' =>
-                                                        array (
-
-                                                                array (
-                                                                    'paramType' => 'path',
-                                                                    'name' => '_format',
-                                                                    'type' => 'string',
-                                                                    'required' => true,
-                                                                ),
-
-                                                                array (
-                                                                    'paramType' => 'form',
-                                                                    'name' => 'a',
-                                                                    'type' => 'string',
-                                                                    'description' => 'A nice description',
-                                                                ),
-
-                                                                array (
-                                                                    'paramType' => 'form',
-                                                                    'name' => 'b',
-                                                                    'type' => 'string',
-                                                                ),
-
-                                                                array (
-                                                                    'paramType' => 'form',
-                                                                    'name' => 'c',
-                                                                    'type' => 'boolean',
-                                                                    'defaultValue' => false,
-                                                                ),
-
-                                                                array (
-                                                                    'paramType' => 'form',
-                                                                    'name' => 'd',
-                                                                    'type' => 'string',
-                                                                    'defaultValue' => 'DefaultTest',
-                                                                ),
-                                                        ),
-                                                    'responseMessages' =>
-                                                        array (
-                                                        ),
-                                                ),
+                                            'responseMessages' =>
+                                                array(),
                                         ),
-                                ),
+                                        array(
+                                            'method'           => 'GET',
+                                            'summary'          => 'index action',
+                                            'nickname'         => 'get_tests',
+                                            'parameters'       =>
+                                                array(
+
+                                                    array(
+                                                        'paramType' => 'path',
+                                                        'name'      => '_format',
+                                                        'type'      => 'string',
+                                                        'required'  => true,
+                                                    ),
+                                                    array(
+                                                        'paramType'   => 'query',
+                                                        'name'        => 'a',
+                                                        'type'        => 'integer',
+                                                        'description' => null,
+                                                    ),
+                                                    array(
+                                                        'paramType'   => 'query',
+                                                        'name'        => 'b',
+                                                        'type'        => 'string',
+                                                        'description' => null,
+                                                    ),
+                                                ),
+                                            'responseMessages' =>
+                                                array(),
+                                        ),
+                                        array(
+                                            'method'           => 'POST',
+                                            'summary'          => 'create test',
+                                            'nickname'         => 'post_tests',
+                                            'parameters'       =>
+                                                array(
+
+                                                    array(
+                                                        'paramType' => 'path',
+                                                        'name'      => '_format',
+                                                        'type'      => 'string',
+                                                        'required'  => true,
+                                                    ),
+                                                    array(
+                                                        'paramType'   => 'form',
+                                                        'name'        => 'a',
+                                                        'type'        => 'string',
+                                                        'description' => 'A nice description',
+                                                    ),
+                                                    array(
+                                                        'paramType' => 'form',
+                                                        'name'      => 'b',
+                                                        'type'      => 'string',
+                                                    ),
+                                                    array(
+                                                        'paramType'    => 'form',
+                                                        'name'         => 'c',
+                                                        'type'         => 'boolean',
+                                                        'defaultValue' => false,
+                                                    ),
+                                                    array(
+                                                        'paramType'    => 'form',
+                                                        'name'         => 'd',
+                                                        'type'         => 'string',
+                                                        'defaultValue' => 'DefaultTest',
+                                                    ),
+                                                ),
+                                            'responseMessages' =>
+                                                array(),
+                                        ),
+                                        array(
+                                            'method'           => 'POST',
+                                            'summary'          => 'create test',
+                                            'nickname'         => 'post_tests',
+                                            'parameters'       =>
+                                                array(
+                                                    array(
+                                                        'paramType' => 'path',
+                                                        'name'      => '_format',
+                                                        'type'      => 'string',
+                                                        'required'  => true,
+                                                    ),
+                                                    array(
+                                                        'paramType'   => 'form',
+                                                        'name'        => 'a',
+                                                        'type'        => 'string',
+                                                        'description' => 'A nice description',
+                                                    ),
+                                                    array(
+                                                        'paramType' => 'form',
+                                                        'name'      => 'b',
+                                                        'type'      => 'string',
+                                                    ),
+                                                    array(
+                                                        'paramType'    => 'form',
+                                                        'name'         => 'c',
+                                                        'type'         => 'boolean',
+                                                        'defaultValue' => false,
+                                                    ),
+                                                    array(
+                                                        'paramType'    => 'form',
+                                                        'name'         => 'd',
+                                                        'type'         => 'string',
+                                                        'defaultValue' => 'DefaultTest',
+                                                    ),
+                                                ),
+                                            'responseMessages' =>
+                                                array(),
+                                        ),
+                                    ),
+                            ),
                         ),
-                    'models' =>
-                        array (
-                        ),
-                    'produces' =>
-                        array (
-                        ),
-                    'consumes' =>
-                        array (
-                        ),
+                    'models'         =>
+                        array(),
+                    'produces'       =>
+                        array(),
+                    'consumes'       =>
+                        array(),
                     'authorizations' =>
                         array(
                             'apiKey' => array(
-                                'type' => 'apiKey',
-                                'passAs' => 'header',
+                                'type'    => 'apiKey',
+                                'passAs'  => 'header',
                                 'keyname' => 'access_token',
                             )
                         ),


### PR DESCRIPTION
``` php

/**
 * @ApiDoc(output={"class" = "FooBund\Form\UserType", "form_errors" = true})
 */
```

Documents the output of https://github.com/FriendsOfSymfony/FOSRestBundle/blob/master/Resources/doc/2-the-view-layer.md#forms-and-views

This will be typically used with the Swagger integration, specifically when defining an alternate response model for validation errors:

``` php

/**
 * @ApiDoc(resonseMap={
 *     400 = {"class" = "FooBund\Form\UserType", "form_errors" = true}
 *  })
 */
```
### TODO
- [x] Implementation
- [x] Unit tests
