### PR TITLE
Remove EOLed Symfony versions from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ php:
 matrix:
     include:
         - php: 5.5
-          env: SYMFONY_VERSION='2.1.*'
-        - php: 5.5
-          env: SYMFONY_VERSION='2.2.*'
-        - php: 5.5
           env: SYMFONY_VERSION='2.3.*'
         - php: 5.5
           env: SYMFONY_VERSION='2.4.*'


### PR DESCRIPTION
Currently, the testsuite relies on SensioFrameworkExtraBundle 3.x which requires Symfony 2.3+. Given that 2.1 and 2.2 are EOLed, removing them from Travis is simpler than updating the testsuite to support them.
