### PR TITLE
fix undefined index actualType errors

### DIFF
--- a/Formatter/SwaggerFormatter.php
+++ b/Formatter/SwaggerFormatter.php
@@ -467,10 +467,10 @@ class SwaggerFormatter implements FormatterInterface
                             break;
                     }
                 }
-            }
 
-            if ((isset($prop['actualType'])) and (isset($this->formatMap[$prop['actualType']]))) {
-                $format = $this->formatMap[$prop['actualType']];
+                if (isset($this->formatMap[$prop['actualType']])) {
+                    $format = $this->formatMap[$prop['actualType']];
+                }
             }
 
             if (null === $type && null === $ref) {


### PR DESCRIPTION
Hi,

I see some "PHP Notice:  Undefined index: actualType" while executing api:swagger:dump. Tis PR fixes it.

Best regards,
Michal
