### PR TITLE
Fix parsing of filters, default values and base path in SwaggerFormatter

### DIFF
--- a/Formatter/SwaggerFormatter.php
+++ b/Formatter/SwaggerFormatter.php
@@ -218,7 +218,7 @@ class SwaggerFormatter implements FormatterInterface
             } elseif (empty($input['paramType'])) {
                 $input['paramType'] = 'form';
             }
-            
+
             $route = $apiDoc->getRoute();
 
             $itemResource = $this->normalizeResourcePath($itemResource);
@@ -253,11 +253,11 @@ class SwaggerFormatter implements FormatterInterface
                 $parameters[] = $parameter;
             }
 
+            $data = $apiDoc->toArray();
+
             if (isset($data['filters'])) {
                 $parameters = array_merge($parameters, $this->deriveQueryParameters($data['filters']));
             }
-
-            $data = $apiDoc->toArray();
 
             if (isset($data['parameters'])) {
                 $parameters = array_merge($parameters, $this->deriveParameters($data['parameters'], $input['paramType']));
@@ -392,10 +392,14 @@ class SwaggerFormatter implements FormatterInterface
         $parameters = array();
 
         foreach ($input as $name => $prop) {
+            if (!isset($prop['dataType'])) {
+                $prop['dataType'] = 'string';
+            }
             $parameters[] = array(
                 'paramType' => 'query',
                 'name' => $name,
                 'type' => isset($this->typeMap[$prop['dataType']]) ? $this->typeMap[$prop['dataType']] : 'string',
+                'description' => isset($prop['description']) ? $prop['description'] : null,
             );
         }
 
@@ -425,6 +429,10 @@ class SwaggerFormatter implements FormatterInterface
             $ref = null;
             $enum = null;
             $items = null;
+
+            if (!isset($prop['actualType'])) {
+                $prop['actualType'] = 'string';
+            }
 
             if (isset ($this->typeMap[$prop['actualType']])) {
                 $type = $this->typeMap[$prop['actualType']];
@@ -498,12 +506,16 @@ class SwaggerFormatter implements FormatterInterface
                 $parameter['enum'] = $enum;
             }
 
-            if ($prop['default'] !== null) {
+            if (isset($prop['default'])) {
                 $parameter['defaultValue'] = $prop['default'];
             }
 
             if (isset($items)) {
                 $parameter['items'] = $items;
+            }
+
+            if (isset($prop['description'])) {
+                $parameter['description'] = $prop['description'];
             }
 
             $parameters[] = $parameter;
@@ -559,7 +571,11 @@ class SwaggerFormatter implements FormatterInterface
      */
     protected function stripBasePath($path)
     {
-        $pattern = sprintf('#%s#', preg_quote($this->basePath));
+        if ('/' === $this->basePath) {
+            return $path;
+        }
+
+        $pattern = sprintf('#^%s#', preg_quote($this->basePath));
         $subPath = preg_replace($pattern, '', $path);
         return $subPath;
     }

--- a/Tests/Formatter/SwaggerFormatterTest.php
+++ b/Tests/Formatter/SwaggerFormatterTest.php
@@ -195,6 +195,7 @@ class SwaggerFormatterTest extends WebTestCase
                                                                     'paramType' => 'form',
                                                                     'name' => 'a',
                                                                     'type' => 'string',
+                                                                    'description' => 'Something that describes A.',
                                                                 ),
                                                             2 =>
                                                                 array (
@@ -786,6 +787,18 @@ With multiple lines.',
                                                                     'type' => 'string',
                                                                     'required' => true,
                                                                 ),
+                                                                array (
+                                                                    'paramType' => 'query',
+                                                                    'name' => 'a',
+                                                                    'type' => 'integer',
+                                                                    'description' => null,
+                                                                ),
+                                                                array (
+                                                                    'paramType' => 'query',
+                                                                    'name' => 'b',
+                                                                    'type' => 'string',
+                                                                    'description' => null,
+                                                                ),
                                                         ),
                                                     'responseMessages' =>
                                                         array (
@@ -810,12 +823,14 @@ With multiple lines.',
                                                                     'paramType' => 'query',
                                                                     'name' => 'a',
                                                                     'type' => 'integer',
+                                                                    'description' => null,
                                                                 ),
 
                                                                 array (
                                                                     'paramType' => 'query',
                                                                     'name' => 'b',
                                                                     'type' => 'string',
+                                                                    'description' => null,
                                                                 ),
                                                         ),
                                                     'responseMessages' =>
@@ -838,21 +853,10 @@ With multiple lines.',
                                                                 ),
 
                                                                 array (
-                                                                    'paramType' => 'query',
-                                                                    'name' => 'a',
-                                                                    'type' => 'integer',
-                                                                ),
-
-                                                                array (
-                                                                    'paramType' => 'query',
-                                                                    'name' => 'b',
-                                                                    'type' => 'string',
-                                                                ),
-
-                                                                array (
                                                                     'paramType' => 'form',
                                                                     'name' => 'a',
                                                                     'type' => 'string',
+                                                                    'description' => 'A nice description',
                                                                 ),
 
                                                                 array (
@@ -898,6 +902,7 @@ With multiple lines.',
                                                                     'paramType' => 'form',
                                                                     'name' => 'a',
                                                                     'type' => 'string',
+                                                                    'description' => 'A nice description',
                                                                 ),
 
                                                                 array (


### PR DESCRIPTION
This merge request includes some changes to the SwaggerFormatter:
1. Get the data before using it (for filters). Unfortunately this seems to break the tests, but I don't understand what the test actually does, nor why it's failing now.
2. Set some default values for poperties if they're not set. Is this correct, or are these properties mandatory?
3. Strip the base path only at the beginning. I had errors when using `/` as the base path.
4. Add descriptions for parameters and filters.
