### PR TITLE
Display select to choose http method in sandbox

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -366,7 +366,7 @@
 
                 $('.pane.sandbox form').submit(function() {
                     var url = $(this).attr('action'),
-                        method = $(this).attr('method'),
+                        method = $('[name="header_method"]', this).val(),
                         self = this,
                         params = {},
                         formData = new FormData(),
@@ -377,8 +377,6 @@
 
                     if (method === 'ANY') {
                         method = 'POST';
-                    } else if (method.indexOf('|') !== -1) {
-                        method = method.split('|').sort().pop();
                     }
 
                     // set requestFormat

--- a/Resources/views/method.html.twig
+++ b/Resources/views/method.html.twig
@@ -201,7 +201,7 @@
                     {% if app.request is not null and data.https and app.request.secure != data.https %}
                     Please reload the documentation using the scheme {% if data.https %}HTTPS{% else %}HTTP{% endif %} if you want to use the sandbox.
                     {% else %}
-                        <form method="{{ data.method|upper }}" action="{% if data.host is defined %}{{ data.https ? 'https://' : 'http://' }}{{ data.host }}{% endif %}{{ data.uri }}">
+                        <form method="" action="{% if data.host is defined %}{{ data.https ? 'https://' : 'http://' }}{{ data.host }}{% endif %}{{ data.uri }}">
                             <fieldset class="parameters">
                                 <legend>Input</legend>
                                 {% if data.requirements is defined %}
@@ -247,6 +247,18 @@
                             </fieldset>
 
                             <fieldset class="headers">
+                                {% set methods = data.method|upper|split('|') %}
+                                {% if methods|length > 1 %}
+                                    <legend>Method</legend>
+                                    <select name="header_method">
+                                    {% for method in methods %}
+                                        <option value="{{ method }}">{{ method }}</option>
+                                    {% endfor %}
+                                    </select>
+                                {% else %}
+                                    <input type="hidden" name="header_method" value="{{ methods|join }}" />
+                                {% endif %}
+                                
                                 <legend>Headers</legend>
 
                                 {% if acceptType %}


### PR DESCRIPTION
In case you have a resource with several http methods (PUT|PATCH for example), you might want to choose the method to use. For now the first method is used by default (PUT|PATCH: PUT will be used).

The purpose of this PR is to allow to choose the HTTP method in case of several methods allowed via a select field, that's it.

![](http://i.imgur.com/d8GD83d.png)
![](http://i.imgur.com/EHPn7iJ.png)
