### PR TITLE
Multiple api documentations

### DIFF
--- a/Annotation/ApiDoc.php
+++ b/Annotation/ApiDoc.php
@@ -26,6 +26,13 @@ class ApiDoc
     private $requirements = array();
 
     /**
+     * Which APIs is this route used. Defaults to "default"
+     *
+     * @var array
+     */
+    private $apis = array();
+
+    /**
      * Filters are optional parameters in the query string.
      *
      * @var array
@@ -188,6 +195,15 @@ class ApiDoc
                 unset($requirement['name']);
 
                 $this->addRequirement($name, $requirement);
+            }
+        }
+
+        if (isset($data['api'])) {
+            if (! is_array($data['api'])) {
+                $data['api'] = array($data['api']);
+            }
+            foreach ($data['api'] as $api) {
+                $this->addApi($api);
             }
         }
 
@@ -372,6 +388,23 @@ class ApiDoc
     {
         return $this->section;
     }
+
+    /**
+     * @return array
+     */
+    public function addApi($api)
+    {
+        $this->apis[] = $api;
+    }
+
+    /**
+     * @return array
+     */
+    public function getApis()
+    {
+        return $this->apis;
+    }
+
 
     /**
      * @param string $documentation
@@ -624,6 +657,11 @@ class ApiDoc
         if ($requirements = $this->requirements) {
             $data['requirements'] = $requirements;
         }
+
+        if ($apis = $this->apis) {
+            $data['apis'] = $apis;
+        }
+
 
         if ($response = $this->response) {
             $data['response'] = $response;

--- a/Controller/ApiDocController.php
+++ b/Controller/ApiDocController.php
@@ -19,9 +19,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ApiDocController extends Controller
 {
-    public function indexAction()
+    public function indexAction($api = "default")
     {
-        $extractedDoc = $this->get('nelmio_api_doc.extractor.api_doc_extractor')->all();
+        $extractedDoc = $this->get('nelmio_api_doc.extractor.api_doc_extractor')->all($api);
         $htmlContent  = $this->get('nelmio_api_doc.formatter.html_formatter')->format($extractedDoc);
 
         return new Response($htmlContent, 200, array('Content-Type' => 'text/html'));

--- a/Extractor/ApiDocExtractor.php
+++ b/Extractor/ApiDocExtractor.php
@@ -83,9 +83,9 @@ class ApiDocExtractor
      *
      * @return array
      */
-    public function all()
+    public function all($api = "default")
     {
-        return $this->extractAnnotations($this->getRoutes());
+        return $this->extractAnnotations($this->getRoutes(), $api);
     }
 
     /**
@@ -97,7 +97,7 @@ class ApiDocExtractor
      *
      * @return array
      */
-    public function extractAnnotations(array $routes)
+    public function extractAnnotations(array $routes, $api = "default")
     {
         $array     = array();
         $resources = array();
@@ -110,7 +110,10 @@ class ApiDocExtractor
 
             if ($method = $this->getReflectionMethod($route->getDefault('_controller'))) {
                 $annotation = $this->reader->getMethodAnnotation($method, self::ANNOTATION_CLASS);
-                if ($annotation && !in_array($annotation->getSection(), $excludeSections)) {
+                if ($annotation &&
+                    ! in_array($annotation->getSection(), $excludeSections) &&
+                    ( in_array($api, $annotation->getApis()) || (count($annotation->getApis()) == 0 && $api == "default"))
+                   ) {
                     if ($annotation->isResource()) {
                         if ($resource = $annotation->getResource()) {
                             $resources[] = $resource;

--- a/Extractor/CachingApiDocExtractor.php
+++ b/Extractor/CachingApiDocExtractor.php
@@ -47,7 +47,7 @@ class CachingApiDocExtractor extends ApiDocExtractor
         $this->cache = new ConfigCache($this->cacheFile, $debug);
     }
 
-    public function all()
+    public function all($api = "default")
     {
         if ($this->cache->isFresh() === false) {
 
@@ -63,7 +63,7 @@ class CachingApiDocExtractor extends ApiDocExtractor
 
             $resources = array_merge($resources, $this->router->getRouteCollection()->getResources());
 
-            $data = parent::all();
+            $data = parent::all($api);
             $this->cache->write(serialize($data), $resources);
             
             return $data;

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,5 +1,5 @@
 nelmio_api_doc_index:
-    pattern: /
-    defaults: { _controller: NelmioApiDocBundle:ApiDoc:index }
+    pattern: /{api}
+    defaults: { _controller: NelmioApiDocBundle:ApiDoc:index, api: "default" }
     requirements:
         _method: GET

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -180,6 +180,9 @@ class YourController
 }
 ```
 
+* `api`: the api under which this resource will be shown. Leave empty to specify the default api. Either a single api, or 
+  an array of apis.
+
 Each _filter_ has to define a `name` parameter, but other parameters are free. Filters are often optional
 parameters, and you can document them as you want, but keep in mind to be consistent for the whole documentation.
 
@@ -211,6 +214,56 @@ class YourType extends AbstractType
 
 The bundle will also get information from the routing definition (`requirements`, `pattern`, etc), so to get the
 best out of it you should define strict _method requirements etc.
+
+### Multiple API documentations ###
+With the `api` tag in the `@apidoc` annotation, it's possible to create different sets of api documentations. Without 
+the tag, all methods are located in the `default` api and can be found under the normal api documentation url. With the 
+`api` tag you can specify one or more api names under which the method will be visible. 
+
+An example:
+```
+    /**
+     * A resource
+     *
+     * @ApiDoc(
+     *  resource=true,
+     *  description="This is a description of your API method",
+     *  api = { "default", "premium" }
+     * )
+     */
+    public function getAction()
+    {
+    }
+
+    /**
+     * Another resource
+     *
+     * @ApiDoc(
+     *  resource=true,
+     *  description="This is a description of another API method",
+     *  api = { "premium" }
+     * )
+     */
+    public function getAnotherAction()
+    {
+    }
+```
+
+In this case, only the first resource will be available under the default api documentation, while both methods will
+be available under the `premium` api documentation.
+
+#### Accessing API documentation ####
+The normal `default` documentation can be found at the normal location. Other sets of documentation can be found at `documentationurl/<tagname>`.
+
+For instance, if your documenation is located at 
+
+        http://example.org/doc/api/v1/
+
+then the `premium` api will be located at:
+
+        http://example.org/doc/api/v1/premium
+
+
 
 ### Other Bundle Annotations
 
@@ -422,6 +475,11 @@ You can specify which sections to exclude from the documentation generation:
 nelmio_api_doc:
     exclude_sections: ["privateapi", "testapi"]
 ```
+
+Note that `exclude_sections` will literally exclude a section from your api documentation. It's possible however to create
+multiple apis by specifying the `api` within the `@apidoc` annotations. This allows you to move private or test methods to a 
+complete different set of api documentation instead.
+
 The bundle provides a way to register multiple `input` parsers. The first parser
 that can handle the specified input is used, so you can configure their
 priorities via container tags. Here's an example parser service registration:
@@ -450,6 +508,7 @@ nelmio_api_doc:
         enabled: true
         file: "/tmp/symfony-app/%kernel.environment%/api-doc.cache"
 ```
+
 ### Using Your Own Annotations
 
 If you have developed your own project-related annotations, and you want to parse them to populate

--- a/Tests/Annotation/ApiDocTest.php
+++ b/Tests/Annotation/ApiDocTest.php
@@ -26,6 +26,7 @@ class ApiDocTest extends TestCase
         $this->assertTrue(is_array($array));
         $this->assertFalse(isset($array['filters']));
         $this->assertFalse($annot->isResource());
+        $this->assertEmpty($annot->getApis());
         $this->assertFalse($annot->getDeprecated());
         $this->assertFalse(isset($array['description']));
         $this->assertFalse(isset($array['requirements']));

--- a/Tests/Fixtures/Controller/ResourceController.php
+++ b/Tests/Fixtures/Controller/ResourceController.php
@@ -17,6 +17,7 @@ class ResourceController
     /**
      * @ApiDoc(
      *      resource=true,
+     *      api={ "test", "premium", "default" },
      *      resourceDescription="Operations on resource.",
      *      description="List resources.",
      *      output="array<Nelmio\ApiDocBundle\Tests\Fixtures\Model\Test> as tests",
@@ -47,6 +48,7 @@ class ResourceController
     /**
      * @ApiDoc(
      *      description="Create a new resource.",
+     *      api={ "default", "premium" },
      *      input={"class" = "Nelmio\ApiDocBundle\Tests\Fixtures\Form\SimpleType", "name" = ""},
      *      output="Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested",
      *      responseMap={
@@ -62,6 +64,7 @@ class ResourceController
     /**
      * @ApiDoc(
      *      resource=true,
+     *      api={ "default", "premium" },
      *      description="List another resource.",
      *      resourceDescription="Operations on another resource.",
      *      output="array<Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsTest>"

--- a/Tests/Fixtures/Controller/TestController.php
+++ b/Tests/Fixtures/Controller/TestController.php
@@ -23,7 +23,8 @@ class TestController
 {
     /**
      * @ApiDoc(
-     *     resource="TestResource"
+     *     resource="TestResource",
+     *     api="default"
      * )
      */
     public function namedResourceAction()
@@ -48,6 +49,7 @@ class TestController
     /**
      * @ApiDoc(
      *  description="create test",
+     *  api={ "default", "premium" },
      *  input="Nelmio\ApiDocBundle\Tests\Fixtures\Form\TestType"
      * )
      */
@@ -58,6 +60,7 @@ class TestController
     /**
      * @ApiDoc(
      *     description="post test 2",
+     *     api={ "default", "premium" },
      *     resource=true
      * )
      */
@@ -109,6 +112,7 @@ class TestController
 
     /**
      * @ApiDoc(
+     *  api= { "default", "test" },
      *  description="create another test",
      *  input="dependency_type"
      * )

--- a/Tests/Formatter/SimpleFormatterTest.php
+++ b/Tests/Formatter/SimpleFormatterTest.php
@@ -158,6 +158,11 @@ class SimpleFormatterTest extends WebTestCase
                     'authentication' => false,
                     'authenticationRoles' => array(),
                     'deprecated' => false,
+                    'apis' =>
+                        array(
+                            'default',
+                            'premium',
+                        ),
                 ),
                 3 =>
                 array(
@@ -217,6 +222,11 @@ class SimpleFormatterTest extends WebTestCase
                     'authentication' => false,
                     'authenticationRoles' => array(),
                     'deprecated' => false,
+                    'apis' =>
+                        array(
+                            'default',
+                            'premium',
+                        ),
                 ),
             ),
             'others' =>
@@ -253,6 +263,11 @@ class SimpleFormatterTest extends WebTestCase
                     'authentication' => false,
                     'authenticationRoles' => array(),
                     'deprecated' => false,
+                    'apis' =>
+                        array(
+                            'default',
+                            'test',
+                        ),
                 ),
                 1 =>
                 array(
@@ -1277,6 +1292,11 @@ With multiple lines.',
                     'authentication' => false,
                     'authenticationRoles' => array(),
                     'deprecated' => false,
+                    'apis' =>
+                        array(
+                            'default',
+                            'premium',
+                        ),
                 ),
             ),
             '/tests2' =>
@@ -1298,6 +1318,11 @@ With multiple lines.',
                     'authentication' => false,
                     'authenticationRoles' => array(),
                     'deprecated' => false,
+                    'apis' =>
+                        array(
+                            'default',
+                            'premium',
+                        ),
                 ),
             ),
             'TestResource' =>
@@ -1310,6 +1335,10 @@ With multiple lines.',
                     'authentication' => false,
                     'authenticationRoles' => array(),
                     'deprecated' => false,
+                    'apis' =>
+                        array(
+                            'default',
+                        ),
                 ),
             ),
             '/api/other-resources' =>
@@ -1333,6 +1362,10 @@ With multiple lines.',
                         'authenticationRoles' =>
                             array(),
                         'deprecated' => false,
+                        'apis' => array(
+                            'default',
+                            'premium',
+                        ),
                         'response' => array(
                             '' =>
                                 array(
@@ -1655,6 +1688,11 @@ With multiple lines.',
                         'authenticationRoles' =>
                             array(),
                         'deprecated' => false,
+                        'apis' => array(
+                            'test',
+                            'premium',
+                            'default',
+                        ),
                         'response' =>
                             array (
                                 'tests' =>
@@ -1767,6 +1805,11 @@ With multiple lines.',
                                         'dataType' => '',
                                         'description' => '',
                                     ),
+                            ),
+                        'apis' =>
+                            array(
+                                'default',
+                                'premium',
                             ),
                         'response' =>
                             array(


### PR DESCRIPTION
Based on issue #404, this will allow multiple api documentations based on a new `api` tag inside the `@apidoc` annotation.

This is an initial release.