### PR TITLE
Fix the PhpDoc Handler for `@link` annotation and add tests

### DIFF
--- a/Extractor/Handler/PhpDocHandler.php
+++ b/Extractor/Handler/PhpDocHandler.php
@@ -70,10 +70,10 @@ class PhpDocHandler implements HandlerInterface
             if (preg_match('{^@param (.+)}', trim($line), $matches)) {
                 $paramDocs[] = $matches[1];
             }
-            if (preg_match('{^@deprecated\b(.*)}', trim($line), $matches)) {
+            if (preg_match('{^@deprecated}', trim($line))) {
                 $annotation->setDeprecated(true);
             }
-            if (preg_match('{^@link\b(.*)}', trim($line), $matches)) {
+            if (preg_match('{^@link (.+)}', trim($line), $matches)) {
                 $annotation->setLink($matches[1]);
             }
         }

--- a/Tests/Fixtures/Controller/TestController.php
+++ b/Tests/Fixtures/Controller/TestController.php
@@ -314,4 +314,12 @@ class TestController
     public function exclusiveAction()
     {
     }
+
+    /**
+     * @ApiDoc()
+     * @link http://symfony.com
+     */
+    public function withLinkAction()
+    {
+    }
 }

--- a/Tests/Fixtures/app/config/routing.yml
+++ b/Tests/Fixtures/app/config/routing.yml
@@ -226,11 +226,16 @@ test_required_parameters:
     requirements:
         _method: POST
         _format: json|xml|html
-        
+
 test_put_disables_required_parameters:
     pattern: /api/other-resources/{id}.{_format}
     defaults: { _controller: NelmioApiDocTestBundle:Resource:requiredParametersAction, _format: json }
     requirements:
         _method: PUT
-        _format: json|xml|html        
+        _format: json|xml|html
 
+test_route_25:
+    pattern:  /with-link
+    defaults: { _controller: NelmioApiDocTestBundle:Test:withLinkAction }
+    requirements:
+        _method: GET


### PR DESCRIPTION
The `link` annotation was capturing extra spaces (" toto" instead of "toto"),
and the `deprecated` one was fetching matches for nothing.
