### PR TITLE
Fix PHP 5.4 dependency in FormTypeParser and also fix 'something else'

### DIFF
--- a/Parser/FormTypeParser.php
+++ b/Parser/FormTypeParser.php
@@ -284,7 +284,10 @@ class FormTypeParser implements ParserInterface
 
         // this fallback may lead to runtime exception, but try hard to generate the docs
         if ($constructor && $constructor->getNumberOfRequiredParameters() > 0) {
-            return $refl->newInstanceWithoutConstructor();
+            if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
+                return $refl->newInstanceWithoutConstructor();
+            }
+            return unserialize(sprintf('O:%d:"%s":0:{}', strlen($type), $type));
         }
 
         return $refl->newInstance();

--- a/Parser/FormTypeParser.php
+++ b/Parser/FormTypeParser.php
@@ -146,12 +146,13 @@ class FormTypeParser implements ParserInterface
                     } else {
                         // Embedded form collection
                         $embbededType       = $config->getOption('type');
-                        $subForm    = $this->formFactory->create($embbededType, null, $config->getOption('options', array()));
-                        $children   = $this->parseForm($subForm);
-                        $actualType = DataTypes::COLLECTION;
-                        $subType    = is_object($embbededType) ? get_class($embbededType) : $embbededType;
-
-                        if (class_exists($subType)) {
+                        if (isset($embeddedType)) {
+                            $subForm    = $this->formFactory->create($embbededType, null, $config->getOption('options', array()));
+                            $children   = $this->parseForm($subForm);
+                            $actualType = DataTypes::COLLECTION;
+                            $subType    = is_object($embbededType) ? get_class($embbededType) : $embbededType;
+                        }
+                        if (isset($embeddedType) && class_exists($subType)) {
                             $parts = explode('\\', $subType);
                             $bestType = sprintf('array of objects (%s)', end($parts));
                         } else {
@@ -284,6 +285,7 @@ class FormTypeParser implements ParserInterface
 
         // this fallback may lead to runtime exception, but try hard to generate the docs
         if ($constructor && $constructor->getNumberOfRequiredParameters() > 0) {
+            // ..but it only works with PHP 5.4 and higher
             if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
                 return $refl->newInstanceWithoutConstructor();
             }


### PR DESCRIPTION
Hi

Here's a pr that should remove the hard dependency for PHP 5.4 by falling back to older solution for older PHP versions.

I also added isset() check for $embeddedType because adding it was the only way I managed to make my project's apidoc work at all (after upgrading from version 2.3.1 in which the doc worked nicely). I have no idea of the meaning or side effects of this addition but without it the whole thing tried to create form with null object and crashed.