### PR TITLE
Update FormTypeParser.php

### DIFF
--- a/Parser/FormTypeParser.php
+++ b/Parser/FormTypeParser.php
@@ -121,7 +121,7 @@ class FormTypeParser implements ParserInterface
         );
     }
 
-    private function parseForm($form)
+    protected function parseForm($form)
     {
         $parameters = array();
         foreach ($form as $name => $child) {
@@ -252,11 +252,11 @@ class FormTypeParser implements ParserInterface
                     }
 
                     if (($choices = $config->getOption('choices')) && is_array($choices) && count($choices)) {
-                        $parameters[$name]['format'] = json_encode($choices);
+                        $parameters[$name]['format'] = json_encode($choices, JSON_UNESCAPED_UNICODE);
                     } elseif (($choiceList = $config->getOption('choice_list')) && $choiceList instanceof ChoiceListInterface) {
                         $choices = $this->handleChoiceListValues($choiceList);
                         if (is_array($choices) && count($choices)) {
-                            $parameters[$name]['format'] = json_encode($choices);
+                            $parameters[$name]['format'] = json_encode($choices, JSON_UNESCAPED_UNICODE);
                         }
                     }
                     break;
@@ -266,7 +266,7 @@ class FormTypeParser implements ParserInterface
         return $parameters;
     }
 
-    private function implementsType($item)
+    protected function implementsType($item)
     {
         if (!class_exists($item)) {
             return false;
@@ -277,7 +277,7 @@ class FormTypeParser implements ParserInterface
         return $refl->implementsInterface('Symfony\Component\Form\FormTypeInterface') || $refl->implementsInterface('Symfony\Component\Form\ResolvedFormTypeInterface');
     }
 
-    private function getTypeInstance($type)
+    protected function getTypeInstance($type)
     {
         $refl = new \ReflectionClass($type);
         $constructor = $refl->getConstructor();
@@ -290,7 +290,7 @@ class FormTypeParser implements ParserInterface
         return $refl->newInstance();
     }
 
-    private function createForm($item)
+    protected function createForm($item)
     {
         if ($this->implementsType($item)) {
             $type = $this->getTypeInstance($item);
@@ -307,7 +307,7 @@ class FormTypeParser implements ParserInterface
         }
     }
 
-    private function handleChoiceListValues(ChoiceListInterface $choiceList)
+    protected function handleChoiceListValues(ChoiceListInterface $choiceList)
     {
         $choices = array();
         foreach (array($choiceList->getPreferredViews(), $choiceList->getRemainingViews()) as $viewList) {
@@ -317,7 +317,7 @@ class FormTypeParser implements ParserInterface
         return $choices;
     }
 
-    private function handleChoiceViewsHierarchy(array $choiceViews)
+    protected function handleChoiceViewsHierarchy(array $choiceViews)
     {
         $choices = array();
         foreach ($choiceViews as $item) {


### PR DESCRIPTION
The json_encode parameter 'JSON_UNESCAPED_UNICODE' enables german Umlaute to be displayed correctly.
Having methods protected instead of private facilitates extension of the class (for whatever reasons, here: fixing Umlaute issue).