### PR TITLE
Added comma to list of escaped symbols in location hash layout JS scrip...

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -86,7 +86,7 @@
             };
 
             $(window).load(function() {
-                var id = getHash().substr(1).replace( /([:\.\[\]\{\}])/g, "\\$1");
+                var id = getHash().substr(1).replace( /([:\.\[\]\{\},])/g, "\\$1");
                 var elem = $('#' + id);
                 if (elem.length) {
                     setTimeout(function() {


### PR DESCRIPTION
Its pretty common to use inside URIs of API commas but this symbol is not handled the correct way for selecting API endpoint with scrollTo ($('body,html').scrollTop(elem.position().top)) functionality and doing popup. jQuery fails to recognize ID selector with comma as part of string without escaping symbol. To fix the issue I made a small change to the $(window).load script inside layout.html.twig file to support it.

Please give me a feedback if something is wrong with my proposal.

Regards