### PR TITLE
Update layout.html.twig

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -383,7 +383,10 @@
                     var requestFormatMethod = '{{ requestFormatMethod }}';
                     if (requestFormatMethod == 'format_param') {
                         params['_format'] = $('#request_format option:selected').text();
-                        formData.append('_format',$('#request_format option:selected').text());
+                        if (url.indexOf('{_format}') == -1) {
+                            // _format should only be added to formData when it's not present in URL
+                            formData.append('_format', $('#request_format option:selected').text());
+                        }
                     } else if (requestFormatMethod == 'accept_header') {
                         headers['Accept'] = $('#request_format').val();
                     }


### PR DESCRIPTION
When submitting a sandbox-form containing 'file'-fields the formData-object is posted instead of the params-object.

The '_format'-field should only be added to the formData-object when {_format} is not present in the URL.
'_format' gets stripped from the params-object when {_format} is present (~ line 380), but it doesn't get stripped from the formData-object as it's not available in the FormData-api. 

When not necessary, it should not be added. It could result in a 'This form should not contain extra fields' error.

Keep up the good work! The api-doc-bundle saved me hours of work already! :-)


