### PR TITLE
Allow specifying the array name for jms parsed inputs

### DIFF
--- a/Parser/JmsMetadataParser.php
+++ b/Parser/JmsMetadataParser.php
@@ -87,6 +87,33 @@ class JmsMetadataParser implements ParserInterface, PostParserInterface
         $className = $input['class'];
         $groups    = $input['groups'];
 
+        if (isset($input['name'])) {
+          $name = $input['name'];
+          $type = $className;
+
+          $subType = is_object($type) ? get_class($type) : $type;
+
+          if (class_exists($subType)) {
+              $parts = explode('\\', $subType);
+              $dataType = sprintf('object (%s)', end($parts));
+          } else {
+              $dataType = sprintf('object (%s)', $subType);
+          }
+
+          return array(
+              $name => array(
+                  'required'    => true,
+                  'readonly'    => false,
+                  'description' => '',
+                  'default'     => null,
+                  'dataType'    => $dataType,
+                  'actualType'  => DataTypes::MODEL,
+                  'subType'     => $subType,
+                  'children'    => $this->doParse($className, array(), $groups),
+              ),
+          );
+        }
+
         return $this->doParse($className, array(), $groups);
     }
 

--- a/Parser/ValidationParser.php
+++ b/Parser/ValidationParser.php
@@ -69,6 +69,33 @@ class ValidationParser implements ParserInterface, PostParserInterface
     {
         $className = $input['class'];
 
+        if (isset($input['name'])) {
+          $name = $input['name'];
+          $type = $className;
+
+          $subType = is_object($type) ? get_class($type) : $type;
+
+          if (class_exists($subType)) {
+              $parts = explode('\\', $subType);
+              $dataType = sprintf('object (%s)', end($parts));
+          } else {
+              $dataType = sprintf('object (%s)', $subType);
+          }
+
+          return array(
+              $name => array(
+                  'required'    => true,
+                  'readonly'    => false,
+                  'description' => '',
+                  'default'     => null,
+                  'dataType'    => $dataType,
+                  'actualType'  => DataTypes::MODEL,
+                  'subType'     => $subType,
+                  'children'    => $this->doParse($className, array()),
+              ),
+          );
+        }
+
         return $this->doParse($className, array());
     }
 


### PR DESCRIPTION
When you utilise a formtype as the input, you get the various elements as a subarray. Theres no way to get this behaviour currently when you utilise the jms serializer. This patch checks for a name specification in the annotation and subarrays the parameters if it exists.

This PR is discussion at the moment. If the maintainer is roughly happy with the concept I will fix up unit tests and documentation appropriately and update the PR.