### PR TITLE
Adding annotation support for FosRest::View serializerGroups into ApiDoc output groups logic

### DIFF
--- a/Annotation/ApiDoc.php
+++ b/Annotation/ApiDoc.php
@@ -318,11 +318,19 @@ class ApiDoc
     }
 
     /**
-     * @return string|null
+     * @return string|array|null
      */
     public function getInput()
     {
         return $this->input;
+    }
+
+    /**
+     * @param array|string $input
+     */
+    public function setInput($input)
+    {
+        $this->input = $input;
     }
 
     /**
@@ -331,6 +339,14 @@ class ApiDoc
     public function getOutput()
     {
         return $this->output;
+    }
+
+    /**
+     * @param array|string $output
+     */
+    public function setOutput($output)
+    {
+        $this->output = $output;
     }
 
     /**

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -220,6 +220,8 @@ Also bundle will get information from the other annotations:
 
 * @FOS\RestBundle\Controller\Annotations\QueryParam - use as `requirements` (when strict parameter is true), `filters` (when strict is false)
 
+* @FOS\RestBundle\Controller\Annotations\View - set `output`.`groups` to `serializerGroups` if `output`.`class` is defined, but `output`.`groups` is not
+
 * @JMS\SecurityExtraBundle\Annotation\Secure - set `authentication` to true, `authenticationRoles` to the given roles
 
 * @Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache - set `cache`

--- a/Tests/Extractor/Handler/FosRestHandlerTest.php
+++ b/Tests/Extractor/Handler/FosRestHandlerTest.php
@@ -14,12 +14,14 @@ use Nelmio\ApiDocBundle\Tests\WebTestCase;
 
 class FosRestHandlerTest extends WebTestCase
 {
-
+    /**
+     * @group fosrest.queryparam
+     */
     public function testGetWithQueryParamStrict()
     {
         $container  = $this->getContainer();
         $extractor  = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
-        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\TestController::zActionWithQueryParamStrictAction', 'test_route_15');
+        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\FosRestController::zActionWithQueryParamStrictAction', 'test_route_15');
 
         $this->assertNotNull($annotation);
 
@@ -40,11 +42,14 @@ class FosRestHandlerTest extends WebTestCase
         $this->assertArrayNotHasKey('default', $requirement);
     }
 
+    /**
+     * @group fosrest.queryparam
+     */
     public function testGetWithQueryParam()
     {
         $container  = $this->getContainer();
         $extractor  = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
-        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\TestController::zActionWithQueryParamAction', 'test_route_8');
+        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\FosRestController::zActionWithQueryParamAction', 'test_route_8');
 
         $this->assertNotNull($annotation);
 
@@ -64,11 +69,14 @@ class FosRestHandlerTest extends WebTestCase
         $this->assertEquals($filter['default'], '1');
     }
 
+    /**
+     * @group fosrest.queryparam
+     */
     public function testGetWithQueryParamNoDefault()
     {
         $container  = $this->getContainer();
         $extractor  = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
-        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\TestController::zActionWithQueryParamNoDefaultAction', 'test_route_16');
+        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\FosRestController::zActionWithQueryParamNoDefaultAction', 'test_route_16');
 
         $this->assertNotNull($annotation);
 
@@ -87,11 +95,14 @@ class FosRestHandlerTest extends WebTestCase
         $this->assertArrayNotHasKey('default', $filter);
     }
 
+    /**
+     * @group fosrest.queryparam
+     */
     public function testGetWithConstraintAsRequirements()
     {
         $container  = $this->getContainer();
         $extractor  = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
-        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\TestController::zActionWithConstraintAsRequirements', 'test_route_21');
+        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\FosRestController::zActionWithConstraintAsRequirements', 'test_route_21');
 
         $this->assertNotNull($annotation);
 
@@ -105,11 +116,14 @@ class FosRestHandlerTest extends WebTestCase
         $this->assertEquals($filter['requirement'], 'Email');
     }
 
+    /**
+     * @group fosrest.requestparam
+     */
     public function testGetWithRequestParam()
     {
         $container  = $this->getContainer();
         $extractor  = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
-        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\TestController::zActionWithRequestParamAction', 'test_route_11');
+        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\FosRestController::zActionWithRequestParamAction', 'test_route_11');
 
         $this->assertNotNull($annotation);
 
@@ -131,11 +145,14 @@ class FosRestHandlerTest extends WebTestCase
         $this->assertArrayNotHasKey('default', $parameter);
     }
 
+    /**
+     * @group fosrest.requestparam
+     */
     public function testGetWithRequestParamNullable()
     {
         $container  = $this->getContainer();
         $extractor  = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
-        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\TestController::zActionWithNullableRequestParamAction', 'test_route_22');
+        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\FosRestController::zActionWithNullableRequestParamAction', 'test_route_22');
 
         $this->assertNotNull($annotation);
 
@@ -155,5 +172,73 @@ class FosRestHandlerTest extends WebTestCase
         $this->assertEquals($parameter['required'], false);
 
         $this->assertArrayNotHasKey('default', $parameter);
+    }
+
+    /**
+     * @group fosrest.view
+     */
+    public function testViewWithNoSerializerGroups()
+    {
+        $container = $this->getContainer();
+        $extractor = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
+        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\FosRestController::zActionWithViewAndNoSerializerGroups', 'test_route_view_no_groups');
+
+        $this->assertNotNull($annotation);
+
+        $output = $annotation->getOutput();
+        $this->assertInternalType('string', $output);
+    }
+
+    /**
+     * @group fosrest.view
+     */
+    public function testViewWithSerializerGroups()
+    {
+        $container = $this->getContainer();
+        $extractor = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
+        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\FosRestController::zActionWithViewAndSerializerGroups', 'test_route_view_with_groups');
+
+        $this->assertNotNull($annotation);
+
+        $output = $annotation->getOutput();
+        $this->assertInternalType('array', $output);
+
+        $this->assertArrayHasKey('groups', $output);
+        $this->assertCount(1, $output['groups']);
+        $this->assertEquals($output['groups'][0], 'some-group');
+    }
+
+    /**
+     * @group fosrest.view
+     */
+    public function testViewWithNoOutputClass()
+    {
+        $container = $this->getContainer();
+        $extractor = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
+        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\FosRestController::zActionWithViewButNoOutputClass', 'test_route_view_no_class');
+
+        $this->assertNotNull($annotation);
+
+        $output = $annotation->getOutput();
+        $this->assertInternalType('null', $output);
+    }
+
+    /**
+     * @group fosrest.view
+     */
+    public function testViewWithGroupsInOutput()
+    {
+        $container = $this->getContainer();
+        $extractor = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
+        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\FosRestController::zActionWithViewAndGroupsInOutput', 'test_route_view_with_groups_in_output');
+
+        $this->assertNotNull($annotation);
+
+        $output = $annotation->getOutput();
+        $this->assertInternalType('array', $output);
+
+        $this->assertArrayHasKey('groups', $output);
+        $this->assertCount(1, $output['groups']);
+        $this->assertEquals($output['groups'][0], 'some-other-group');
     }
 }

--- a/Tests/Fixtures/Controller/FosRestController.php
+++ b/Tests/Fixtures/Controller/FosRestController.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Fixtures\Controller;
+
+use Symfony\Component\Validator\Constraints\Email;
+use FOS\RestBundle\Controller\Annotations\QueryParam;
+use FOS\RestBundle\Controller\Annotations\RequestParam;
+use FOS\RestBundle\Controller\Annotations\View;
+use Nelmio\ApiDocBundle\Annotation\ApiDoc;
+
+class FosRestController
+{
+
+    /**
+     * @ApiDoc()
+     * @QueryParam(strict=true, name="page", requirements="\d+", description="Page of the overview.")
+     */
+    public function zActionWithQueryParamStrictAction()
+    {
+    }
+
+    /**
+     * @ApiDoc()
+     * @QueryParam(name="page", requirements="\d+", default="1", description="Page of the overview.")
+     */
+    public function zActionWithQueryParamAction()
+    {
+    }
+
+    /**
+     * @ApiDoc()
+     * @QueryParam(name="page", requirements="\d+", description="Page of the overview.")
+     */
+    public function zActionWithQueryParamNoDefaultAction()
+    {
+    }
+
+    /**
+     * @ApiDoc()
+     * @QueryParam(name="mail", requirements=@Email, description="Email of someone.")
+     */
+    public function zActionWithConstraintAsRequirements()
+    {
+    }
+
+    /**
+     * @ApiDoc()
+     * @RequestParam(name="param1", requirements="string", description="Param1 description.")
+     */
+    public function zActionWithRequestParamAction()
+    {
+    }
+
+    /**
+     * @ApiDoc()
+     * @RequestParam(name="param1", requirements="string", description="Param1 description.", nullable=true)
+     */
+    public function zActionWithNullableRequestParamAction()
+    {
+    }
+
+    /**
+     * @ApiDoc(
+     *  description="Testing ApiDoc.output.groups not being set when View.serializerGroups is not defined",
+     *  output="Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsTest"
+     * )
+     *
+     * @View()
+     */
+    public function zActionWithViewAndNoSerializerGroups()
+    {
+    }
+
+    /**
+     * @ApiDoc(
+     *  description="Testing View.serializerGroups setting ApiDoc.output.groups",
+     *  output="Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsTest"
+     * )
+     *
+     * @View(serializerGroups={"some-group"})
+     */
+    public function zActionWithViewAndSerializerGroups()
+    {
+    }
+
+    /**
+     * @ApiDoc(
+     *  description="Testing View.serializerGroup when ApiDoc.output.class is missing"
+     * )
+     *
+     * @View(serializerGroups={"some-group"})
+     */
+    public function zActionWithViewButNoOutputClass()
+    {
+    }
+
+    /**
+     * @ApiDoc(
+     *  description="Testing groups not being overwritten with View.serializerGroups when already set in ApiDoc.output.groups",
+     *  output={
+     *      "class"  = "Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsTest",
+     *      "groups" = {"some-other-group"}
+     *  }
+     * )
+     *
+     * @View(serializerGroups={"some-group"})
+     */
+    public function zActionWithViewAndGroupsInOutput()
+    {
+    }
+}

--- a/Tests/Fixtures/Controller/TestController.php
+++ b/Tests/Fixtures/Controller/TestController.php
@@ -11,11 +11,8 @@
 
 namespace Nelmio\ApiDocBundle\Tests\Fixtures\Controller;
 
-use FOS\RestBundle\Controller\Annotations\QueryParam;
-use FOS\RestBundle\Controller\Annotations\RequestParam;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Validator\Constraints\Email;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
@@ -118,38 +115,6 @@ class TestController
     }
 
     /**
-     * @ApiDoc()
-     * @QueryParam(strict=true, name="page", requirements="\d+", description="Page of the overview.")
-     */
-    public function zActionWithQueryParamStrictAction()
-    {
-    }
-
-    /**
-     * @ApiDoc()
-     * @QueryParam(name="page", requirements="\d+", default="1", description="Page of the overview.")
-     */
-    public function zActionWithQueryParamAction()
-    {
-    }
-
-    /**
-     * @ApiDoc()
-     * @QueryParam(name="page", requirements="\d+", description="Page of the overview.")
-     */
-    public function zActionWithQueryParamNoDefaultAction()
-    {
-    }
-
-    /**
-     * @ApiDoc()
-     * @QueryParam(name="mail", requirements=@Email, description="Email of someone.")
-     */
-    public function zActionWithConstraintAsRequirements()
-    {
-    }
-
-    /**
      * @ApiDoc(
      *  description="Testing JMS",
      *  input="Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsTest"
@@ -166,22 +131,6 @@ class TestController
      * )
      */
     public function jmsReturnTestAction()
-    {
-    }
-
-    /**
-     * @ApiDoc()
-     * @RequestParam(name="param1", requirements="string", description="Param1 description.")
-     */
-    public function zActionWithRequestParamAction()
-    {
-    }
-
-    /**
-     * @ApiDoc()
-     * @RequestParam(name="param1", requirements="string", description="Param1 description.", nullable=true)
-     */
-    public function zActionWithNullableRequestParamAction()
     {
     }
 

--- a/Tests/Fixtures/app/config/routing.yml
+++ b/Tests/Fixtures/app/config/routing.yml
@@ -37,7 +37,7 @@ test_route_7:
 
 test_route_8:
     pattern:  /z-action-with-query-param
-    defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithQueryParam }
+    defaults: { _controller: NelmioApiDocTestBundle:FosRest:zActionWithQueryParam }
     requirements:
         _method: GET
 
@@ -55,7 +55,7 @@ test_route_10:
 
 test_route_11:
     pattern:  /z-action-with-request-param
-    defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithRequestParam }
+    defaults: { _controller: NelmioApiDocTestBundle:FosRest:zActionWithRequestParam }
     requirements:
         _method: POST
 
@@ -102,13 +102,13 @@ test_route_14:
 
 test_route_15:
     pattern:  /z-action-with-query-param-strict
-    defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithQueryParamStrict }
+    defaults: { _controller: NelmioApiDocTestBundle:FosRest:zActionWithQueryParamStrict }
     requirements:
         _method: GET
 
 test_route_16:
     pattern:  /z-action-with-query-param-no-default
-    defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithQueryParamNoDefault }
+    defaults: { _controller: NelmioApiDocTestBundle:FosRest:zActionWithQueryParamNoDefault }
     requirements:
         _method: GET
 
@@ -152,15 +152,31 @@ test_route_exclusive:
 
 test_route_21:
     pattern:  /z-action-with-constraint-requirements
-    defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithConstraintAsRequirements }
+    defaults: { _controller: NelmioApiDocTestBundle:FosRest:zActionWithConstraintAsRequirements }
     requirements:
         _method: GET
 
 test_route_22:
     pattern:  /z-action-with-nullable-request-param
-    defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithNullableRequestParam }
+    defaults: { _controller: NelmioApiDocTestBundle:FosRest:zActionWithNullableRequestParam }
     requirements:
         _method: POST
+
+test_route_view_no_groups:
+    pattern:  /z-action-view-with-no-serializer-groups
+    defaults: { _controller: NelmioApiDocTestBundle:FosRest:zActionWithViewAndNoSerializerGroups }
+
+test_route_view_with_groups:
+    pattern:  /z-action-view-with-serializer-groups
+    defaults: { _controller: NelmioApiDocTestBundle:FosRest:zActionWithViewAndSerializerGroups }
+
+test_route_view_no_class:
+    pattern:  /z-action-view-but-no-class
+    defaults: { _controller: NelmioApiDocTestBundle:FosRest:zActionWithViewButNoOutputClass }
+
+test_route_view_with_groups_in_output:
+    pattern:  /z-action-view-with-groups-in-output
+    defaults: { _controller: NelmioApiDocTestBundle:FosRest:zActionWithViewAndGroupsInOutput }
 
 test_route_list_resource:
     pattern: /api/resources.{_format}


### PR DESCRIPTION
Updated Tests (also broken FosRest related tests into a separate controller)

Updated documentation notifying serializerGroups can be used to offer defaults for output.groups

Added ApiDoc input/output setters (uncertain why they were not already there)

P.S. #119 also attempted to add this logic, but the PR was ultimately closed without being merged.