### PR TITLE
Add form options to ApiDoc input

### DIFF
--- a/Extractor/ApiDocExtractor.php
+++ b/Extractor/ApiDocExtractor.php
@@ -17,11 +17,11 @@ use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Nelmio\ApiDocBundle\DataTypes;
 use Nelmio\ApiDocBundle\Parser\ParserInterface;
 use Nelmio\ApiDocBundle\Parser\PostParserInterface;
-use Symfony\Component\Routing\Route;
-use Symfony\Component\Routing\RouterInterface;
+use Nelmio\ApiDocBundle\Util\DocCommentExtractor;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Nelmio\ApiDocBundle\Util\DocCommentExtractor;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouterInterface;
 
 class ApiDocExtractor
 {
@@ -366,6 +366,7 @@ class ApiDocExtractor
         $defaults = array(
             'class'   => '',
             'groups'  => array(),
+            'options'  => array(),
         );
 
         // normalize strings

--- a/Parser/FormTypeParser.php
+++ b/Parser/FormTypeParser.php
@@ -12,16 +12,16 @@
 namespace Nelmio\ApiDocBundle\Parser;
 
 use Nelmio\ApiDocBundle\DataTypes;
-use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Form\Exception\FormException;
 use Symfony\Component\Form\Exception\InvalidArgumentException;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\Extension\Core\View\ChoiceView;
 use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\ResolvedFormTypeInterface;
 use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
-use Symfony\Component\Form\FormFactoryInterface;
-use Symfony\Component\Form\Exception\FormException;
 
 class FormTypeParser implements ParserInterface
 {
@@ -63,9 +63,10 @@ class FormTypeParser implements ParserInterface
     public function supports(array $item)
     {
         $className = $item['class'];
+        $options   = $item['options'];
 
         try {
-            if ($this->createForm($className)) {
+            if ($this->createForm($className, null, $options)) {
                 return true;
             }
         } catch (FormException $e) {
@@ -82,17 +83,16 @@ class FormTypeParser implements ParserInterface
      */
     public function parse(array $item)
     {
-        $type = $item['class'];
+        $type    = $item['class'];
+        $options = $item['options'];
 
         if ($this->implementsType($type)) {
             $type = $this->getTypeInstance($type);
         }
 
-        $form = $this->formFactory->create($type);
+        $form = $this->formFactory->create($type, null, $options);
 
         $name = array_key_exists('name', $item) ? $item['name'] : $form->getName();
-
-        $options = null;
 
         if (empty($name)) {
             return $this->parseForm($form);

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -272,6 +272,14 @@ input = {
 }
 ```
 
+You can also add some options to pass to the form. You just have to use the `options` key:
+```
+input = {
+ "class" = "your_form_type",
+ "options" = {"method" => "PUT"},
+}
+```
+
 #### Used Parsers
 
 By default, all registered parsers are used, but sometimes you may want to

--- a/Tests/Parser/FormTypeParserTest.php
+++ b/Tests/Parser/FormTypeParserTest.php
@@ -34,7 +34,7 @@ class FormTypeParserTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(
-                array('class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Form\TestType'),
+                array('class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Form\TestType', 'options' => array()),
                 array(
                     'a' => array(
                         'dataType' => 'string',
@@ -75,7 +75,7 @@ class FormTypeParserTest extends \PHPUnit_Framework_TestCase
                 )
             ),
             array(
-                array('class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Form\CollectionType'),
+                array('class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Form\CollectionType', 'options' => array()),
                 array(
                     'collection_type' => array(
                         'dataType' => 'object (CollectionType)',
@@ -150,6 +150,7 @@ class FormTypeParserTest extends \PHPUnit_Framework_TestCase
                 array(
                     'class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Form\CollectionType',
                     'name' => '',
+                    'options' => array(),
                 ),
                 array(
                     'a' => array(
@@ -214,6 +215,7 @@ class FormTypeParserTest extends \PHPUnit_Framework_TestCase
                 array(
                     'class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Form\CollectionType',
                     'name' => null,
+                    'options' => array(),
                 ),
                 array(
                     'a' => array(
@@ -275,7 +277,7 @@ class FormTypeParserTest extends \PHPUnit_Framework_TestCase
                 ),
             ),
             array(
-                array('class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Form\ImprovedTestType'),
+                array('class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Form\ImprovedTestType', 'options' => array()),
                 array(
                     'dt1' => array(
                         'dataType' => 'datetime',
@@ -386,7 +388,7 @@ class FormTypeParserTest extends \PHPUnit_Framework_TestCase
                 ),
             ),
             array(
-                array('class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Form\CompoundType'),
+                array('class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Form\CompoundType', 'options' => array()),
                 array (
                     'sub_form' =>
                         array (
@@ -475,7 +477,7 @@ class FormTypeParserTest extends \PHPUnit_Framework_TestCase
                 ),
             ),
             array(
-                array('class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Form\RequireConstructionType'),
+                array('class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Form\RequireConstructionType', 'options' => array()),
                 array(
                     'require_construction_type' => array(
                         'dataType' => 'object (RequireConstructionType)',
@@ -500,7 +502,7 @@ class FormTypeParserTest extends \PHPUnit_Framework_TestCase
                 ),
             ),
             array(
-                array('class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Form\DependencyType'),
+                array('class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Form\DependencyType', 'options' => array()),
                 array(
                     'dependency_type' => array(
                         'dataType' => 'object (DependencyType)',


### PR DESCRIPTION
Hi everybody.

Just a little PR to introduce form options into the `ApiDoc`.

For Exemple : 

```php
public function buildForm(FormBuilderInterface $builder, array $options)
{
    $builder
        ->add('nickname', 'text')
    ;

    if ('POST' === $options['method']) {
        $builder
            ->add('login', 'text')
            ->add('plainPassword', 'password')
        ;
    }
}
```

```php
    /**
     * @ApiDoc(
     *  section="Product",
     *  input={
     *      "class"="Organization\Api\Form\Type\ProductType",
     *      "options"={"method": "POST"},
     *  },
     *  output={ ... }
     * )
     */
    public function createAction(Request $request, ...)
    {
        // ...
    }

    /**
     * @ApiDoc(
     *  section="Product",
     *  input={
     *      "class"="Organization\Api\Form\Type\ProductType",
     *      "options"={"method": "PUT"},
     *  },
     *  output={ ... }
     * )
     */
    public function updateAction(Request $request, ...)
    {
        // ...
    }