### PR TITLE
DunglasJsonLdApiBundle support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,16 @@ matrix:
         - php: 5.5
           env: SYMFONY_VERSION='2.4.*'
         - php: 5.5
+          env: SYMFONY_VERSION='2.6.*'
+        - php: 5.5
           env: SYMFONY_VERSION='dev-master'
     allow_failures:
-        - env: SYMFONY_VERSION=dev-master
+        - php: 5.5
+          env: SYMFONY_VERSION='dev-master'
 
 before_script:
     - composer self-update
+    - sh -c 'if [ "$SYMFONY_VERSION" != "dev-master" ] && [ "$SYMFONY_VERSION" != "2.6.*" ]; then sed -i "/dunglas\/json-ld-api-bundle/d;/symfony\/serializer/d" composer.json; fi;'
     - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi;'
     - composer install
 

--- a/DependencyInjection/AnnotationsProviderCompilerPass.php
+++ b/DependencyInjection/AnnotationsProviderCompilerPass.php
@@ -11,24 +11,30 @@
 
 namespace Nelmio\ApiDocBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class ExtractorHandlerCompilerPass implements CompilerPassInterface
+/**
+ * AnnotationsProvider compiler pass.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class AnnotationsProviderCompilerPass implements CompilerPassInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function process(ContainerBuilder $container)
     {
-        $handlers = array();
-        foreach ($container->findTaggedServiceIds('nelmio_api_doc.extractor.handler') as $id => $attributes) {
-            $handlers[] = new Reference($id);
+        $annotationsProviders = array();
+        foreach ($container->findTaggedServiceIds('nelmio_api_doc.extractor.annotations_provider') as $id => $attributes) {
+            $annotationsProviders[] = new Reference($id);
         }
 
         $container
             ->getDefinition('nelmio_api_doc.extractor.api_doc_extractor')
-            ->replaceArgument(5, $handlers);
+            ->replaceArgument(6, $annotationsProviders)
+        ;
     }
 }

--- a/DependencyInjection/LoadExtractorParsersPass.php
+++ b/DependencyInjection/LoadExtractorParsersPass.php
@@ -32,5 +32,10 @@ class LoadExtractorParsersPass implements CompilerPassInterface
         if ($container->hasDefinition('jms_serializer.serializer')) {
             $loader->load('services.jms.xml');
         }
+
+        // DunglasJsonLdApiBundle may or may not be installed, if it is, load that config as well
+        if ($container->hasDefinition('dunglas_json_ld_api.resources')) {
+            $loader->load('services.dunglas_json_ld_api.xml');
+        }
     }
 }

--- a/Extractor/AnnotationsProvider/DunglasJsonLdApiProvider.php
+++ b/Extractor/AnnotationsProvider/DunglasJsonLdApiProvider.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Extractor\AnnotationsProvider;
+
+use Doctrine\Common\Annotations\Reader;
+use Dunglas\JsonLdApiBundle\JsonLd\Resource;
+use Dunglas\JsonLdApiBundle\JsonLd\Resources;
+use Dunglas\JsonLdApiBundle\Mapping\ClassMetadataFactory;
+use Nelmio\ApiDocBundle\Annotation\ApiDoc;
+use Nelmio\ApiDocBundle\Extractor\AnnotationsProviderInterface;
+
+/**
+ * Creates ApiDoc annotations for DunglasJsonLdApiBundle.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class DunglasJsonLdApiProvider implements AnnotationsProviderInterface
+{
+    /**
+     * @var Resources
+     */
+    private $resources;
+    /**
+     * @var ClassMetadataFactory
+     */
+    private $classMetadataFactory;
+
+    public function __construct(Resources $resources, ClassMetadataFactory $classMetadataFactory)
+    {
+        $this->resources = $resources;
+        $this->classMetadataFactory = $classMetadataFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAnnotations()
+    {
+        $annotations = [];
+        foreach ($this->resources as $resource) {
+            $resource->getRouteCollection(); // Populate !route
+
+            foreach ($resource->getCollectionOperations() as $operation) {
+                $annotations[] = $this->getApiDoc($resource, $operation);
+            }
+
+            foreach ($resource->getItemOperations() as $operation) {
+                $annotations[] = $this->getApiDoc($resource, $operation);
+            }
+        }
+
+        return $annotations;
+    }
+
+    /**
+     * Builds ApiDoc annotation from DunglasJsonLdApiBundle data.
+     *
+     * @param Resource $resource
+     * @param array $operation
+     *
+     * @return ApiDoc
+     */
+    private function getApiDoc(Resource $resource, array $operation)
+    {
+        $data = [
+            'resource' => $operation['!route_path'],
+            'description' => $operation['rdfs:label'],
+            'resourceDescription' => $this->classMetadataFactory->getMetadataFor($resource->getEntityClass())->getDescription(),
+        ];
+
+        if (isset($operation['expects']) && $operation['expects'] !== 'owl:Nothing') {
+            $data['input'] = $resource->getEntityClass();
+        }
+
+        if (isset($operation['returns']) && $operation['returns'] !== 'owl:Nothing') {
+            $data['output'] = $resource->getEntityClass();
+        }
+
+        $data['filters'] = $resource->getFilters();
+
+        $apiDoc = new ApiDoc($data);
+        $apiDoc->setRoute($operation['!route']);
+
+        return $apiDoc;
+    }
+}

--- a/Extractor/AnnotationsProviderInterface.php
+++ b/Extractor/AnnotationsProviderInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Extractor;
+
+use Symfony\Component\Routing\Route;
+
+/**
+ * Interface for annotations providers.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+interface AnnotationsProviderInterface
+{
+    /**
+     * Returns an array ApiDoc annotations.
+     *
+     * @return \Nelmio\ApiDocBundle\Annotation\ApiDoc[]
+     */
+    public function getAnnotations();
+}

--- a/Extractor/CachingApiDocExtractor.php
+++ b/Extractor/CachingApiDocExtractor.php
@@ -13,6 +13,7 @@ namespace Nelmio\ApiDocBundle\Extractor;
 
 use Doctrine\Common\Annotations\Reader;
 use Nelmio\ApiDocBundle\Util\DocCommentExtractor;
+use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -37,11 +38,13 @@ class CachingApiDocExtractor extends ApiDocExtractor
         RouterInterface $router,
         Reader $reader,
         DocCommentExtractor $commentExtractor,
+        ControllerNameParser $controllerNameParser,
         array $handlers,
+        array $annotationsProviders,
         $cacheFile,
         $debug = false
     ) {
-        parent::__construct($container, $router, $reader, $commentExtractor, $handlers);
+        parent::__construct($container, $router, $reader, $commentExtractor, $controllerNameParser, $handlers, $annotationsProviders);
         $this->cacheFile = $cacheFile;
         $this->cache = new ConfigCache($this->cacheFile, $debug);
     }

--- a/NelmioApiDocBundle.php
+++ b/NelmioApiDocBundle.php
@@ -2,6 +2,7 @@
 
 namespace Nelmio\ApiDocBundle;
 
+use Nelmio\ApiDocBundle\DependencyInjection\AnnotationsProviderCompilerPass;
 use Nelmio\ApiDocBundle\DependencyInjection\SwaggerConfigCompilerPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -18,6 +19,7 @@ class NelmioApiDocBundle extends Bundle
         $container->addCompilerPass(new LoadExtractorParsersPass());
         $container->addCompilerPass(new RegisterExtractorParsersPass());
         $container->addCompilerPass(new ExtractorHandlerCompilerPass());
+        $container->addCompilerPass(new AnnotationsProviderCompilerPass());
         $container->addCompilerPass(new SwaggerConfigCompilerPass());
     }
 }

--- a/Parser/DunglasJsonLdApiParser.php
+++ b/Parser/DunglasJsonLdApiParser.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Parser;
+
+use Dunglas\JsonLdApiBundle\JsonLd\Resources;
+use Dunglas\JsonLdApiBundle\Mapping\ClassMetadataFactory;
+use Nelmio\ApiDocBundle\DataTypes;
+
+/**
+ * Use DunglasJsonLdApi to extract input and output information.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class DunglasJsonLdApiParser implements ParserInterface
+{
+    /**
+     * @var Resources
+     */
+    private $resources;
+    /**
+     * @var ClassMetadataFactory
+     */
+    private $classMetadataFactory;
+
+    public function __construct(Resources $resources, ClassMetadataFactory $classMetadataFactory)
+    {
+        $this->resources = $resources;
+        $this->classMetadataFactory = $classMetadataFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(array $item)
+    {
+        return null !== $this->resources->getResourceForEntity($item['class']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parse(array $item)
+    {
+        /**
+         * @var $resource \Dunglas\JsonLdApiBundle\JsonLd\Resource
+         */
+        $resource = $this->resources->getResourceForEntity($item['class']);
+        $classMetadata = $this->classMetadataFactory->getMetadataFor(
+            $resource->getEntityClass(),
+            $resource->getNormalizationGroups(),
+            $resource->getDenormalizationGroups(),
+            $resource->getValidationGroups()
+        );
+
+        $data = array();
+        foreach ($classMetadata->getAttributes() as $attribute) {
+            $data[$attribute->getName()] = [
+                'required' => $attribute->isRequired(),
+                'description' => $attribute->getDescription(),
+                'readonly' => $attribute->isReadable() && !$attribute->isWritable(),
+                'class' => $resource->getEntityClass(),
+            ];
+
+            if (isset($attribute->getTypes()[0])) {
+                $type = $attribute->getTypes()[0];
+                if ($type->isCollection()) {
+                    $dataType = DataTypes::COLLECTION;
+                } elseif ('object' === $type->getType()) {
+                    if ('DateTime' === $type->getClass()) {
+                        $dataType = DataTypes::DATETIME;
+                    } else {
+                        $dataType = DataTypes::STRING;
+                    }
+                } else {
+                    $dataType = $type->getType();
+                }
+
+                $data[$attribute->getName()]['dataType'] = $dataType;
+            }
+        }
+
+        return $data;
+    }
+}

--- a/Resources/config/services.dunglas_json_ld_api.xml
+++ b/Resources/config/services.dunglas_json_ld_api.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="nelmio_api_doc.annotations_provider.dunglas_json_ld_api_annotation_provider" class="Nelmio\ApiDocBundle\Extractor\AnnotationsProvider\DunglasJsonLdApiProvider">
+            <argument type="service" id="dunglas_json_ld_api.resources" />
+            <argument type="service" id="dunglas_json_ld_api.mapping.class_metadata_factory" />
+
+            <tag name="nelmio_api_doc.extractor.annotations_provider" />
+        </service>
+
+        <service id="nelmio_api_doc.parser.dunglas_json_ld_api_parser" class="Nelmio\ApiDocBundle\Parser\DunglasJsonLdApiParser">
+            <argument type="service" id="dunglas_json_ld_api.resources" />
+            <argument type="service" id="dunglas_json_ld_api.mapping.class_metadata_factory" />
+
+            <tag name="nelmio_api_doc.extractor.parser" />
+        </service>
+    </services>
+
+</container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -19,14 +19,20 @@
     </parameters>
 
     <services>
-        <service id='nelmio_api_doc.doc_comment_extractor' class="%nelmio_api_doc.doc_comment_extractor.class%" />
+        <service id="nelmio_api_doc.doc_comment_extractor" class="%nelmio_api_doc.doc_comment_extractor.class%" />
+
+        <service id="nelmio_api_doc.controller_name_parser" class="Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser" public="false">
+            <argument type="service" id="kernel" />
+        </service>
 
         <service id="nelmio_api_doc.extractor.api_doc_extractor" class="%nelmio_api_doc.extractor.api_doc_extractor.class%">
-            <argument type="service" id="service_container"/>
+            <argument type="service" id="service_container" />
             <argument type="service" id="router" />
             <argument type="service" id="annotation_reader" />
             <argument type="service" id="nelmio_api_doc.doc_comment_extractor" />
-            <argument type="collection"/>
+            <argument type="service" id="nelmio_api_doc.controller_name_parser" />
+            <argument type="collection" />
+            <argument type="collection" />
         </service>
 
         <service id="nelmio_api_doc.form.extension.description_form_type_extension" class="%nelmio_api_doc.form.extension.description_form_type_extension.class%">

--- a/Tests/Extractor/AnnotationsProvider/DunglasJsonLdApiProviderTest.php
+++ b/Tests/Extractor/AnnotationsProvider/DunglasJsonLdApiProviderTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+* This file is part of the NelmioApiDocBundle.
+*
+* (c) Nelmio <hello@nelm.io>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+namespace Nelmio\ApiDocBundle\Tests\Extractor\AnnotationsProvider;
+
+use Nelmio\ApiDocBundle\Tests\WebTestCase;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class DunglasJsonLdApiProviderTest extends WebTestCase
+{
+    protected function setUp()
+    {
+        if (!class_exists('Dunglas\JsonLdApiBundle\DunglasJsonLdApiBundle')) {
+            $this->markTestSkipped(
+                'DunglasJsonLdApiBundle is not available.'
+            );
+        }
+    }
+
+    public function testGetAnnotations()
+    {
+        $container = $this->getContainer();
+        $provider = $container->get('nelmio_api_doc.annotations_provider.dunglas_json_ld_api_annotation_provider');
+
+        $annotations = $provider->getAnnotations();
+        $this->assertCount(5, $annotations);
+
+        foreach ($annotations as $annotation) {
+            $this->assertInstanceOf('Nelmio\ApiDocBundle\Annotation\ApiDoc', $annotation);
+            $this->assertInstanceOf('Symfony\Component\Routing\Route', $annotation->getRoute());
+            $this->assertTrue('' != $annotation->getDescription());
+        }
+    }
+}

--- a/Tests/Extractor/ApiDocExtractorTest.php
+++ b/Tests/Extractor/ApiDocExtractorTest.php
@@ -17,8 +17,6 @@ use Nelmio\ApiDocBundle\Tests\WebTestCase;
 
 class ApiDocExtractorTest extends WebTestCase
 {
-    const ROUTES_QUANTITY = 33;
-
     public function testAll()
     {
         $container = $this->getContainer();
@@ -27,14 +25,22 @@ class ApiDocExtractorTest extends WebTestCase
         $data = $extractor->all();
         restore_error_handler();
 
+        if(class_exists('Dunglas\JsonLdApiBundle\DunglasJsonLdApiBundle')) {
+            $routesQuantity = 38;
+            $httpsKey = 25;
+        } else {
+            $routesQuantity = 33;
+            $httpsKey = 20;
+        }
+
         $this->assertTrue(is_array($data));
-        $this->assertCount(self::ROUTES_QUANTITY, $data);
+        $this->assertCount($routesQuantity, $data);
 
         $cacheFile = $container->getParameter('kernel.cache_dir') . '/api-doc.cache';
         $this->assertFileExists($cacheFile);
         $this->assertEquals(file_get_contents($cacheFile), serialize($data));
 
-        foreach ($data as $d) {
+        foreach ($data as $key => $d) {
             $this->assertTrue(is_array($d));
             $this->assertArrayHasKey('annotation', $d);
             $this->assertArrayHasKey('resource', $d);
@@ -76,9 +82,8 @@ class ApiDocExtractorTest extends WebTestCase
         $this->assertTrue($a4->isResource());
         $this->assertEquals('TestResource', $a4->getResource());
 
-        $a3 = $data[20]['annotation'];
+        $a3 = $data[$httpsKey]['annotation'];
         $this->assertTrue($a3->getHttps());
-
     }
 
     public function testGet()

--- a/Tests/Fixtures/Model/Popo.php
+++ b/Tests/Fixtures/Model/Popo.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Fixtures\Model;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class Popo
+{
+    /**
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @var string
+     */
+    public $foo;
+}

--- a/Tests/Fixtures/app/AppKernel.php
+++ b/Tests/Fixtures/app/AppKernel.php
@@ -26,17 +26,20 @@ class AppKernel extends Kernel
 
     public function registerBundles()
     {
-        return array(
+        $bundles = array(
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new \Symfony\Bundle\TwigBundle\TwigBundle(),
             new \JMS\SerializerBundle\JMSSerializerBundle($this),
             new \Nelmio\ApiDocBundle\NelmioApiDocBundle(),
             new \Nelmio\ApiDocBundle\Tests\Fixtures\NelmioApiDocTestBundle(),
         );
-    }
 
-    public function init()
-    {
+        if (class_exists('Dunglas\JsonLdApiBundle\DunglasJsonLdApiBundle')) {
+            $bundles[] = new \Doctrine\Bundle\DoctrineBundle\DoctrineBundle();
+            $bundles[] = new \Dunglas\JsonLdApiBundle\DunglasJsonLdApiBundle();
+        }
+
+        return $bundles;
     }
 
     public function getRootDir()
@@ -57,6 +60,10 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
         $loader->load(__DIR__.'/config/'.$this->environment.'.yml');
+
+        if (class_exists('Dunglas\JsonLdApiBundle\DunglasJsonLdApiBundle')) {
+            $loader->load(__DIR__.'/config/dunglas_json_ld_api.yml');
+        }
     }
 
     public function serialize()

--- a/Tests/Fixtures/app/config/dunglas_json_ld_api.yml
+++ b/Tests/Fixtures/app/config/dunglas_json_ld_api.yml
@@ -1,0 +1,22 @@
+doctrine:
+    dbal:
+        driver:                      "pdo_sqlite"
+        path:                        "%kernel.cache_dir%/db.sqlite"
+        charset:                     "UTF8"
+
+    orm:
+        auto_generate_proxy_classes: "%kernel.debug%"
+        auto_mapping:                true
+
+framework:
+    router:        { resource: "%kernel.root_dir%/config/dunglas_json_ld_api_routing.yml" }
+
+dunglas_json_ld_api:
+    title:       API
+    description: Test API
+
+services:
+    dunglas_json_ld_api.popo:
+        class:     "Dunglas\JsonLdApiBundle\JsonLd\Resource"
+        arguments: [ "Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\Popo" ]
+        tags:      [ { name: "json-ld.resource" } ]

--- a/Tests/Fixtures/app/config/dunglas_json_ld_api_routing.yml
+++ b/Tests/Fixtures/app/config/dunglas_json_ld_api_routing.yml
@@ -1,0 +1,9 @@
+main:
+    resource: "routing.yml"
+
+dunglas_json_ld_api_doc:
+    resource: "@DunglasJsonLdApiBundle/Resources/config/routing.xml"
+
+dunglas_json_ld_api:
+    resource: "."
+    type:     "json-ld"

--- a/Tests/Fixtures/app/config/routing.yml
+++ b/Tests/Fixtures/app/config/routing.yml
@@ -239,3 +239,4 @@ test_route_25:
     defaults: { _controller: NelmioApiDocTestBundle:Test:withLinkAction }
     requirements:
         _method: GET
+

--- a/Tests/Formatter/MarkdownFormatterTest.php
+++ b/Tests/Formatter/MarkdownFormatterTest.php
@@ -25,7 +25,1014 @@ class MarkdownFormatterTest extends WebTestCase
         restore_error_handler();
         $result = $container->get('nelmio_api_doc.formatter.markdown_formatter')->format($data);
 
-        $expected = <<<MARKDOWN
+        if(class_exists('Dunglas\JsonLdApiBundle\DunglasJsonLdApiBundle')) {
+$expected = <<<MARKDOWN
+## /api/other-resources ##
+
+### `GET` /api/other-resources.{_format} ###
+
+_List another resource._
+
+#### Requirements ####
+
+**_format**
+
+  - Requirement: json|xml|html
+
+#### Response ####
+
+[]:
+
+  * type: array of objects (JmsTest)
+
+[][foo]:
+
+  * type: string
+
+[][bar]:
+
+  * type: DateTime
+
+[][number]:
+
+  * type: double
+
+[][arr]:
+
+  * type: array
+
+[][nested]:
+
+  * type: object (JmsNested)
+
+[][nested][foo]:
+
+  * type: DateTime
+
+[][nested][bar]:
+
+  * type: string
+
+[][nested][baz][]:
+
+  * type: array of integers
+  * description: Epic description.
+
+With multiple lines.
+
+[][nested][circular]:
+
+  * type: object (JmsNested)
+
+[][nested][parent]:
+
+  * type: object (JmsTest)
+
+[][nested][parent][foo]:
+
+  * type: string
+
+[][nested][parent][bar]:
+
+  * type: DateTime
+
+[][nested][parent][number]:
+
+  * type: double
+
+[][nested][parent][arr]:
+
+  * type: array
+
+[][nested][parent][nested]:
+
+  * type: object (JmsNested)
+
+[][nested][parent][nested_array][]:
+
+  * type: array of objects (JmsNested)
+
+[][nested][since]:
+
+  * type: string
+  * versions: >=0.2
+
+[][nested][until]:
+
+  * type: string
+  * versions: <=0.3
+
+[][nested][since_and_until]:
+
+  * type: string
+  * versions: >=0.4,<=0.5
+
+[][nested_array][]:
+
+  * type: array of objects (JmsNested)
+
+
+### `PUT|PATCH` /api/other-resources/{id}.{_format} ###
+
+_Update a resource bu ID._
+
+#### Requirements ####
+
+**_format**
+
+  - Requirement: json|xml|html
+**id**
+
+
+
+## /api/resources ##
+
+### `GET` /api/resources.{_format} ###
+
+_List resources._
+
+#### Requirements ####
+
+**_format**
+
+  - Requirement: json|xml|html
+
+#### Response ####
+
+tests[]:
+
+  * type: array of objects (Test)
+
+tests[][a]:
+
+  * type: string
+
+tests[][b]:
+
+  * type: DateTime
+
+
+### `POST` /api/resources.{_format} ###
+
+_Create a new resource._
+
+#### Requirements ####
+
+**_format**
+
+  - Requirement: json|xml|html
+
+#### Parameters ####
+
+a:
+
+  * type: string
+  * required: true
+  * description: Something that describes A.
+
+b:
+
+  * type: float
+  * required: true
+
+c:
+
+  * type: choice
+  * required: true
+
+d:
+
+  * type: datetime
+  * required: true
+
+e:
+
+  * type: date
+  * required: true
+
+g:
+
+  * type: string
+  * required: true
+
+#### Response ####
+
+foo:
+
+  * type: DateTime
+
+bar:
+
+  * type: string
+
+baz[]:
+
+  * type: array of integers
+  * description: Epic description.
+
+With multiple lines.
+
+circular:
+
+  * type: object (JmsNested)
+
+circular[foo]:
+
+  * type: DateTime
+
+circular[bar]:
+
+  * type: string
+
+circular[baz][]:
+
+  * type: array of integers
+  * description: Epic description.
+
+With multiple lines.
+
+circular[circular]:
+
+  * type: object (JmsNested)
+
+circular[parent]:
+
+  * type: object (JmsTest)
+
+circular[parent][foo]:
+
+  * type: string
+
+circular[parent][bar]:
+
+  * type: DateTime
+
+circular[parent][number]:
+
+  * type: double
+
+circular[parent][arr]:
+
+  * type: array
+
+circular[parent][nested]:
+
+  * type: object (JmsNested)
+
+circular[parent][nested_array][]:
+
+  * type: array of objects (JmsNested)
+
+circular[since]:
+
+  * type: string
+  * versions: >=0.2
+
+circular[until]:
+
+  * type: string
+  * versions: <=0.3
+
+circular[since_and_until]:
+
+  * type: string
+  * versions: >=0.4,<=0.5
+
+parent:
+
+  * type: object (JmsTest)
+
+parent[foo]:
+
+  * type: string
+
+parent[bar]:
+
+  * type: DateTime
+
+parent[number]:
+
+  * type: double
+
+parent[arr]:
+
+  * type: array
+
+parent[nested]:
+
+  * type: object (JmsNested)
+
+parent[nested_array][]:
+
+  * type: array of objects (JmsNested)
+
+since:
+
+  * type: string
+  * versions: >=0.2
+
+until:
+
+  * type: string
+  * versions: <=0.3
+
+since_and_until:
+
+  * type: string
+  * versions: >=0.4,<=0.5
+
+
+### `GET` /api/resources/{id}.{_format} ###
+
+_Retrieve a resource by ID._
+
+#### Requirements ####
+
+**_format**
+
+  - Requirement: json|xml|html
+**id**
+
+
+
+### `DELETE` /api/resources/{id}.{_format} ###
+
+_Delete a resource by ID._
+
+#### Requirements ####
+
+**_format**
+
+  - Requirement: json|xml|html
+**id**
+
+
+
+## /tests ##
+
+### `GET` /tests.{_format} ###
+
+_index action_
+
+#### Requirements ####
+
+**_format**
+
+
+#### Filters ####
+
+a:
+
+  * DataType: integer
+
+b:
+
+  * DataType: string
+  * Arbitrary: ["arg1","arg2"]
+
+
+### `GET` /tests.{_format} ###
+
+_index action_
+
+#### Requirements ####
+
+**_format**
+
+
+#### Filters ####
+
+a:
+
+  * DataType: integer
+
+b:
+
+  * DataType: string
+  * Arbitrary: ["arg1","arg2"]
+
+
+### `POST` /tests.{_format} ###
+
+_create test_
+
+#### Requirements ####
+
+**_format**
+
+
+#### Parameters ####
+
+a:
+
+  * type: string
+  * required: true
+  * description: A nice description
+
+b:
+
+  * type: string
+  * required: false
+
+c:
+
+  * type: boolean
+  * required: true
+
+d:
+
+  * type: string
+  * required: true
+  * default value: DefaultTest
+
+
+### `POST` /tests.{_format} ###
+
+_create test_
+
+#### Requirements ####
+
+**_format**
+
+
+#### Parameters ####
+
+a:
+
+  * type: string
+  * required: true
+  * description: A nice description
+
+b:
+
+  * type: string
+  * required: false
+
+c:
+
+  * type: boolean
+  * required: true
+
+d:
+
+  * type: string
+  * required: true
+  * default value: DefaultTest
+
+
+## /tests2 ##
+
+### `POST` /tests2.{_format} ###
+
+_post test 2_
+
+#### Requirements ####
+
+**_format**
+
+
+
+## TestResource ##
+
+### `ANY` /named-resource ###
+
+
+
+### `POST` /another-post ###
+
+_create another test_
+
+#### Parameters ####
+
+dependency_type:
+
+  * type: object (dependency_type)
+  * required: true
+
+dependency_type[a]:
+
+  * type: string
+  * required: true
+  * description: A nice description
+
+
+### `ANY` /any ###
+
+_Action without HTTP verb_
+
+
+### `ANY` /any/{foo} ###
+
+_Action without HTTP verb_
+
+#### Requirements ####
+
+**foo**
+
+
+
+### `ANY` /authenticated ###
+
+
+
+### `POST` /jms-input-test ###
+
+_Testing JMS_
+
+#### Parameters ####
+
+foo:
+
+  * type: string
+  * required: false
+
+number:
+
+  * type: double
+  * required: false
+
+arr:
+
+  * type: array
+  * required: false
+
+nested:
+
+  * type: object (JmsNested)
+  * required: false
+
+nested[bar]:
+
+  * type: string
+  * required: false
+  * default value: baz
+
+nested[baz][]:
+
+  * type: array of integers
+  * required: false
+  * description: Epic description.
+
+With multiple lines.
+
+nested[circular]:
+
+  * type: object (JmsNested)
+  * required: false
+
+nested[parent]:
+
+  * type: object (JmsTest)
+  * required: false
+
+nested[parent][foo]:
+
+  * type: string
+  * required: false
+
+nested[parent][number]:
+
+  * type: double
+  * required: false
+
+nested[parent][arr]:
+
+  * type: array
+  * required: false
+
+nested[parent][nested]:
+
+  * type: object (JmsNested)
+  * required: false
+
+nested[parent][nested_array][]:
+
+  * type: array of objects (JmsNested)
+  * required: false
+
+nested[since]:
+
+  * type: string
+  * required: false
+
+nested[until]:
+
+  * type: string
+  * required: false
+
+nested[since_and_until]:
+
+  * type: string
+  * required: false
+
+nested_array[]:
+
+  * type: array of objects (JmsNested)
+  * required: false
+
+
+### `GET` /jms-return-test ###
+
+_Testing return_
+
+#### Response ####
+
+dependency_type:
+
+  * type: object (dependency_type)
+
+dependency_type[a]:
+
+  * type: string
+  * description: A nice description
+
+
+### `ANY` /my-commented/{id}/{page}/{paramType}/{param} ###
+
+_This method is useful to test if the getDocComment works._
+
+#### Requirements ####
+
+**id**
+
+  - Type: int
+  - Description: A nice comment
+**page**
+
+  - Type: int
+**paramType**
+
+  - Type: int
+  - Description: The param type
+**param**
+
+  - Type: int
+  - Description: The param id
+
+
+### `GET|HEAD` /popos ###
+
+_Retrieves the collection of Popo resources._
+
+#### Response ####
+
+foo:
+
+  * type: string
+
+
+### `POST` /popos ###
+
+_Creates a Popo resource._
+
+#### Parameters ####
+
+foo:
+
+  * type: string
+  * required: false
+
+#### Response ####
+
+foo:
+
+  * type: string
+
+
+### `GET|HEAD` /popos/{id} ###
+
+_Retrieves Popo resource._
+
+#### Requirements ####
+
+**id**
+
+  - Type: int
+
+#### Response ####
+
+foo:
+
+  * type: string
+
+
+### `PUT` /popos/{id} ###
+
+_Replaces the Popo resource._
+
+#### Requirements ####
+
+**id**
+
+  - Type: string
+
+#### Parameters ####
+
+foo:
+
+  * type: string
+  * required: false
+
+#### Response ####
+
+foo:
+
+  * type: string
+
+
+### `DELETE` /popos/{id} ###
+
+_Deletes the Popo resource._
+
+#### Requirements ####
+
+**id**
+
+  - Type: string
+
+
+### `ANY` /return-nested-output ###
+
+
+#### Response ####
+
+foo:
+
+  * type: string
+
+bar:
+
+  * type: DateTime
+
+number:
+
+  * type: double
+
+arr:
+
+  * type: array
+
+nested:
+
+  * type: object (JmsNested)
+
+nested[foo]:
+
+  * type: DateTime
+
+nested[bar]:
+
+  * type: string
+
+nested[baz][]:
+
+  * type: array of integers
+  * description: Epic description.
+
+With multiple lines.
+
+nested[circular]:
+
+  * type: object (JmsNested)
+
+nested[parent]:
+
+  * type: object (JmsTest)
+
+nested[parent][foo]:
+
+  * type: string
+
+nested[parent][bar]:
+
+  * type: DateTime
+
+nested[parent][number]:
+
+  * type: double
+
+nested[parent][arr]:
+
+  * type: array
+
+nested[parent][nested]:
+
+  * type: object (JmsNested)
+
+nested[parent][nested_array][]:
+
+  * type: array of objects (JmsNested)
+
+nested[since]:
+
+  * type: string
+  * versions: >=0.2
+
+nested[until]:
+
+  * type: string
+  * versions: <=0.3
+
+nested[since_and_until]:
+
+  * type: string
+  * versions: >=0.4,<=0.5
+
+nested_array[]:
+
+  * type: array of objects (JmsNested)
+
+
+### `ANY` /secure-route ###
+
+
+
+### `ANY` /yet-another/{id} ###
+
+
+#### Requirements ####
+
+**id**
+
+  - Requirement: \d+
+
+
+### `GET` /z-action-with-deprecated-indicator ###
+### This method is deprecated ###
+
+
+
+
+### `POST` /z-action-with-nullable-request-param ###
+
+
+#### Parameters ####
+
+param1:
+
+  * type: string
+  * required: false
+  * description: Param1 description.
+
+
+### `GET` /z-action-with-query-param ###
+
+
+#### Filters ####
+
+page:
+
+  * Requirement: \d+
+  * Description: Page of the overview.
+  * Default: 1
+
+
+### `GET` /z-action-with-query-param-no-default ###
+
+
+#### Filters ####
+
+page:
+
+  * Requirement: \d+
+  * Description: Page of the overview.
+
+
+### `GET` /z-action-with-query-param-strict ###
+
+
+#### Requirements ####
+
+**page**
+
+  - Requirement: \d+
+  - Description: Page of the overview.
+
+
+### `POST` /z-action-with-request-param ###
+
+
+#### Parameters ####
+
+param1:
+
+  * type: string
+  * required: true
+  * description: Param1 description.
+
+
+### `ANY` /z-return-jms-and-validator-output ###
+
+
+#### Response ####
+
+bar:
+
+  * type: DateTime
+
+objects[]:
+
+  * type: array of objects (Test)
+
+objects[][a]:
+
+  * type: string
+
+objects[][b]:
+
+  * type: DateTime
+
+number:
+
+  * type: DateTime
+
+related:
+
+  * type: object (Test)
+
+related[a]:
+
+  * type: string
+
+related[b]:
+
+  * type: DateTime
+
+
+### `ANY` /z-return-selected-parsers-input ###
+
+
+#### Parameters ####
+
+a:
+
+  * type: string
+  * required: true
+  * description: A nice description
+
+b:
+
+  * type: string
+  * required: false
+
+c:
+
+  * type: boolean
+  * required: true
+
+d:
+
+  * type: string
+  * required: true
+  * default value: DefaultTest
+
+
+### `ANY` /z-return-selected-parsers-output ###
+
+
+#### Response ####
+
+bar:
+
+  * type: DateTime
+
+objects[]:
+
+  * type: array of objects (Test)
+
+objects[][a]:
+
+  * type: string
+
+objects[][b]:
+
+  * type: DateTime
+
+number:
+
+  * type: DateTime
+
+related:
+
+  * type: object (Test)
+
+related[a]:
+
+  * type: string
+
+related[b]:
+
+  * type: DateTime
+
+
+### `POST` /zcached ###
+
+
+
+### `POST` /zsecured ###
+MARKDOWN;
+        } else {
+            $expected = <<<MARKDOWN
 ## /api/other-resources ##
 
 ### `GET` /api/other-resources.{_format} ###
@@ -949,6 +1956,7 @@ related[b]:
 
 ### `POST` /zsecured ###
 MARKDOWN;
+        }
 
         $this->assertEquals($expected, $result);
     }

--- a/Tests/Formatter/SimpleFormatterTest.php
+++ b/Tests/Formatter/SimpleFormatterTest.php
@@ -26,741 +26,2491 @@ class SimpleFormatterTest extends WebTestCase
         restore_error_handler();
         $result    = $container->get('nelmio_api_doc.formatter.simple_formatter')->format($data);
 
-        $expected = array(
-            '/tests' =>
-            array(
-                0 =>
-                array(
-                    'method' => 'GET',
-                    'uri' => '/tests.{_format}',
-                    'description' => 'index action',
-                    'filters' =>
-                    array(
-                        'a' =>
-                        array(
-                            'dataType' => 'integer',
-                        ),
-                        'b' =>
-                        array(
-                            'dataType' => 'string',
-                            'arbitrary' =>
-                            array(
-                                0 => 'arg1',
-                                1 => 'arg2',
-                            ),
-                        ),
-                    ),
-                    'requirements' =>
-                    array(
-                        '_format' =>
-                        array(
-                            'requirement' => '',
-                            'dataType' => '',
-                            'description' => '',
-                        ),
-                    ),
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false,
-                ),
-                1 =>
-                array(
-                    'method' => 'GET',
-                    'uri' => '/tests.{_format}',
-                    'description' => 'index action',
-                    'filters' =>
-                    array(
-                        'a' =>
-                        array(
-                            'dataType' => 'integer',
-                        ),
-                        'b' =>
-                        array(
-                            'dataType' => 'string',
-                            'arbitrary' =>
-                            array(
-                                0 => 'arg1',
-                                1 => 'arg2',
-                            ),
-                        ),
-                    ),
-                    'requirements' =>
-                    array(
-                        '_format' =>
-                        array(
-                            'requirement' => '',
-                            'dataType' => '',
-                            'description' => '',
-                        ),
-                    ),
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false,
-                ),
-                2 =>
-                array(
-                    'method' => 'POST',
-                    'uri' => '/tests.{_format}',
-                    'host' => 'api.test.dev',
-                    'description' => 'create test',
-                    'parameters' =>
-                    array(
-                        'a' => array(
-                            'dataType' => 'string',
-                            'actualType' => DataTypes::STRING,
-                            'subType' => null,
-                            'default' => null,
-                            'required' => true,
-                            'description' => 'A nice description',
-                            'readonly' => false,
-                        ),
-                        'b' => array(
-                            'dataType' => 'string',
-                            'actualType' => DataTypes::STRING,
-                            'subType' => null,
-                            'default' => null,
-                            'required' => false,
-                            'description' => '',
-                            'readonly' => false,
-                        ),
-                        'c' => array(
-                            'dataType' => 'boolean',
-                            'actualType' => DataTypes::BOOLEAN,
-                            'subType' => null,
-                            'default' => null,
-                            'required' => true,
-                            'description' => '',
-                            'readonly' => false,
-                        ),
-                        'd' => array(
-                            'dataType' => 'string',
-                            'actualType' => DataTypes::STRING,
-                            'subType' => null,
-                            'default' => null,
-                            'default' => "DefaultTest",
-                            'required' => true,
-                            'description' => '',
-                            'readonly' => false,
-                        ),
-                    ),
-                    'requirements' =>
-                    array(
-                        '_format' =>
-                        array(
-                            'requirement' => '',
-                            'dataType' => '',
-                            'description' => '',
-                        ),
-                    ),
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false,
-                ),
-                3 =>
-                array(
-                    'method' => 'POST',
-                    'uri' => '/tests.{_format}',
-                    'host' => 'api.test.dev',
-                    'description' => 'create test',
-                    'parameters' =>
-                    array(
-                        'a' => array(
-                            'dataType' => 'string',
-                            'actualType' => DataTypes::STRING,
-                            'subType' => null,
-                            'default' => null,
-                            'required' => true,
-                            'description' => 'A nice description',
-                            'readonly' => false,
-                        ),
-                        'b' => array(
-                            'dataType' => 'string',
-                            'actualType' => DataTypes::STRING,
-                            'subType' => null,
-                            'default' => null,
-                            'required' => false,
-                            'description' => '',
-                            'readonly' => false,
-                        ),
-                        'c' => array(
-                            'dataType' => 'boolean',
-                            'actualType' => DataTypes::BOOLEAN,
-                            'subType' => null,
-                            'default' => null,
-                            'required' => true,
-                            'description' => '',
-                            'readonly' => false,
-                        ),
-                        'd' => array(
-                            'dataType' => 'string',
-                            'actualType' => DataTypes::STRING,
-                            'subType' => null,
-                            'default' => "DefaultTest",
-                            'required' => true,
-                            'description' => '',
-                            'readonly' => false,
-                        ),
-                    ),
-                    'requirements' =>
-                    array(
-                        '_format' =>
-                        array(
-                            'requirement' => '',
-                            'dataType' => '',
-                            'description' => '',
-                        ),
-                    ),
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false,
-                ),
-            ),
-            'others' =>
-            array(
-                0 =>
-                array(
-                    'method' => 'POST',
-                    'uri' => '/another-post',
-                    'description' => 'create another test',
-                    'parameters' =>
-                    array(
-                        'dependency_type' => array(
-                            'dataType' => 'object (dependency_type)',
-                            'actualType' => DataTypes::MODEL,
-                            'subType' => 'dependency_type',
-                            'default' => null,
-                            'required' => true,
-                            'readonly' => false,
-                            'description' => '',
-                            'children' => array(
-                                'a' => array(
-                                    'dataType' => 'string',
-                                    'actualType' => DataTypes::STRING,
-                                    'subType' => null,
-                                    'default' => null,
-                                    'required' => true,
-                                    'description' => 'A nice description',
-                                    'readonly' => false,
-                                ),
-                            ),
-                        ),
-                    ),
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false,
-                ),
-                1 =>
-                array(
-                    'method' => 'ANY',
-                    'uri' => '/any',
-                    'description' => 'Action without HTTP verb',
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false,
-                ),
-                2 =>
-                array(
-                    'method' => 'ANY',
-                    'uri' => '/any/{foo}',
-                    'description' => 'Action without HTTP verb',
-                    'requirements' =>
-                    array(
-                        'foo' =>
-                        array(
-                            'requirement' => '',
-                            'dataType' => '',
-                            'description' => '',
-                        ),
-                    ),
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false,
-                ),
-                3 =>
-                array(
-                    'method' => 'ANY',
-                    'uri' => '/authenticated',
-                    'https' => false,
-                    'authentication' => true,
-                    'authenticationRoles' => array('ROLE_USER','ROLE_FOOBAR'),
-                    'deprecated' => false,
-                ),
-                4 =>
-                array(
-                    'method' => 'POST',
-                    'uri' => '/jms-input-test',
-                    'description' => 'Testing JMS',
-                    'parameters' =>
-                    array(
-                        'foo' =>
-                        array(
-                            'dataType' => 'string',
-                            'actualType' => DataTypes::STRING,
-                            'subType' => null,
-                            'default' => null,
-                            'required' => false,
-                            'description' => '',
-                            'readonly' => false,
-                            'sinceVersion' => null,
-                            'untilVersion' => null,
-                        ),
-                        'bar' =>
-                        array(
-                            'dataType' => 'DateTime',
-                            'actualType' => DataTypes::DATETIME,
-                            'subType' => null,
-                            'default' => null,
-                            'required' => false,
-                            'description' => '',
-                            'readonly' => true,
-                            'sinceVersion' => null,
-                            'untilVersion' => null,
-                        ),
-                        'number' =>
-                        array(
-                            'dataType' => 'double',
-                            'actualType' => DataTypes::FLOAT,
-                            'subType' => null,
-                            'default' => null,
-                            'required' => false,
-                            'description' => '',
-                            'readonly' => false,
-                            'sinceVersion' => null,
-                            'untilVersion' => null,
-                        ),
-                        'arr' =>
-                        array(
-                            'dataType' => 'array',
-                            'actualType' => DataTypes::COLLECTION,
-                            'subType' => null,
-                            'default' => null,
-                            'required' => false,
-                            'description' => '',
-                            'readonly' => false,
-                            'sinceVersion' => null,
-                            'untilVersion' => null,
-                        ),
-                        'nested' =>
-                        array(
-                            'dataType' => 'object (JmsNested)',
-                            'actualType' => DataTypes::MODEL,
-                            'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested',
-                            'default' => null,
-                            'required' => false,
-                            'description' => '',
-                            'readonly' => false,
-                            'sinceVersion' => null,
-                            'untilVersion' => null,
-                            'children' =>
-                            array(
-                                'foo' =>
-                                array(
-                                    'dataType' => 'DateTime',
-                                    'actualType' => DataTypes::DATETIME,
-                                    'subType' => null,
-                                    'default' => null,
-                                    'required' => false,
-                                    'description' => '',
-                                    'readonly' => true,
-                                    'sinceVersion' => null,
-                                    'untilVersion' => null,
-                                ),
-                                'bar' =>
-                                array(
-                                    'dataType' => 'string',
-                                    'actualType' => DataTypes::STRING,
-                                    'subType' => null,
-                                    'default' => 'baz',
-                                    'required' => false,
-                                    'description' => '',
-                                    'readonly' => false,
-                                    'sinceVersion' => null,
-                                    'untilVersion' => null,
-                                ),
-                                'baz' =>
-                                array(
-                                    'dataType' => 'array of integers',
-                                    'actualType' => DataTypes::COLLECTION,
-                                    'subType' => DataTypes::INTEGER,
-                                    'default' => null,
-                                    'required' => false,
-                                    'description' => 'Epic description.
+        if (class_exists('Dunglas\JsonLdApiBundle\DunglasJsonLdApiBundle')) {
+            $expected = array (
+                '/api/other-resources' =>
+                    array (
+                        0 =>
+                            array (
+                                'method' => 'GET',
+                                'uri' => '/api/other-resources.{_format}',
+                                'description' => 'List another resource.',
+                                'requirements' =>
+                                    array (
+                                        '_format' =>
+                                            array (
+                                                'requirement' => 'json|xml|html',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
+                                    ),
+                                'response' =>
+                                    array (
+                                        '' =>
+                                            array (
+                                                'dataType' => 'array of objects (JmsTest)',
+                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsTest',
+                                                'actualType' => 'collection',
+                                                'readonly' => true,
+                                                'required' => true,
+                                                'default' => true,
+                                                'description' => '',
+                                                'children' =>
+                                                    array (
+                                                        'foo' =>
+                                                            array (
+                                                                'dataType' => 'string',
+                                                                'actualType' => 'string',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'bar' =>
+                                                            array (
+                                                                'dataType' => 'DateTime',
+                                                                'actualType' => 'datetime',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => true,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'number' =>
+                                                            array (
+                                                                'dataType' => 'double',
+                                                                'actualType' => 'float',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'arr' =>
+                                                            array (
+                                                                'dataType' => 'array',
+                                                                'actualType' => 'collection',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'nested' =>
+                                                            array (
+                                                                'dataType' => 'object (JmsNested)',
+                                                                'actualType' => 'model',
+                                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                                'children' =>
+                                                                    array (
+                                                                        'foo' =>
+                                                                            array (
+                                                                                'dataType' => 'DateTime',
+                                                                                'actualType' => 'datetime',
+                                                                                'subType' => NULL,
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => true,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                        'bar' =>
+                                                                            array (
+                                                                                'dataType' => 'string',
+                                                                                'actualType' => 'string',
+                                                                                'subType' => NULL,
+                                                                                'required' => false,
+                                                                                'default' => 'baz',
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                        'baz' =>
+                                                                            array (
+                                                                                'dataType' => 'array of integers',
+                                                                                'actualType' => 'collection',
+                                                                                'subType' => 'integer',
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => 'Epic description.
 
 With multiple lines.',
-                                    'readonly' => false,
-                                    'sinceVersion' => null,
-                                    'untilVersion' => null,
-                                ),
-                                'circular' =>
-                                array(
-                                    'dataType' => 'object (JmsNested)',
-                                    'actualType' => DataTypes::MODEL,
-                                    'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested',
-                                    'default' => null,
-                                    'required' => false,
-                                    'description' => '',
-                                    'readonly' => false,
-                                    'sinceVersion' => null,
-                                    'untilVersion' => null,
-                                ),
-                                'parent' =>
-                                array(
-                                    'dataType' => 'object (JmsTest)',
-                                    'actualType' => DataTypes::MODEL,
-                                    'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsTest',
-                                    'default' => null,
-                                    'required' => false,
-                                    'description' => '',
-                                    'readonly' => false,
-                                    'sinceVersion' => null,
-                                    'untilVersion' => null,
-                                    'children' =>
-                                    array(
-                                        'foo' =>
-                                        array(
-                                            'dataType' => 'string',
-                                            'actualType' => DataTypes::STRING,
-                                            'subType' => null,
-                                            'default' => null,
-                                            'required' => false,
-                                            'description' => '',
-                                            'readonly' => false,
-                                            'sinceVersion' => null,
-                                            'untilVersion' => null,
-                                        ),
-                                        'bar' =>
-                                        array(
-                                            'dataType' => 'DateTime',
-                                            'actualType' => DataTypes::DATETIME,
-                                            'subType' => null,
-                                            'default' => null,
-                                            'required' => false,
-                                            'description' => '',
-                                            'readonly' => true,
-                                            'sinceVersion' => null,
-                                            'untilVersion' => null,
-                                        ),
-                                        'number' =>
-                                        array(
-                                            'dataType' => 'double',
-                                            'actualType' => DataTypes::FLOAT,
-                                            'subType' => null,
-                                            'default' => null,
-                                            'required' => false,
-                                            'description' => '',
-                                            'readonly' => false,
-                                            'sinceVersion' => null,
-                                            'untilVersion' => null,
-                                        ),
-                                        'arr' =>
-                                        array(
-                                            'dataType' => 'array',
-                                            'actualType' => DataTypes::COLLECTION,
-                                            'subType' => null,
-                                            'default' => null,
-                                            'required' => false,
-                                            'description' => '',
-                                            'readonly' => false,
-                                            'sinceVersion' => null,
-                                            'untilVersion' => null,
-                                        ),
-                                        'nested' =>
-                                        array(
-                                            'dataType' => 'object (JmsNested)',
-                                            'actualType' => DataTypes::MODEL,
-                                            'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested',
-                                            'default' => null,
-                                            'required' => false,
-                                            'description' => '',
-                                            'readonly' => false,
-                                            'sinceVersion' => null,
-                                            'untilVersion' => null,
-                                        ),
-                                        'nested_array' =>
-                                        array(
-                                            'dataType' => 'array of objects (JmsNested)',
-                                            'actualType' => DataTypes::COLLECTION,
-                                            'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested',
-                                            'default' => null,
-                                            'required' => false,
-                                            'description' => '',
-                                            'readonly' => false,
-                                            'sinceVersion' => null,
-                                            'untilVersion' => null,
-                                        ),
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                        'circular' =>
+                                                                            array (
+                                                                                'dataType' => 'object (JmsNested)',
+                                                                                'actualType' => 'model',
+                                                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                        'parent' =>
+                                                                            array (
+                                                                                'dataType' => 'object (JmsTest)',
+                                                                                'actualType' => 'model',
+                                                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsTest',
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                                'children' =>
+                                                                                    array (
+                                                                                        'foo' =>
+                                                                                            array (
+                                                                                                'dataType' => 'string',
+                                                                                                'actualType' => 'string',
+                                                                                                'subType' => NULL,
+                                                                                                'required' => false,
+                                                                                                'default' => NULL,
+                                                                                                'description' => '',
+                                                                                                'readonly' => false,
+                                                                                                'sinceVersion' => NULL,
+                                                                                                'untilVersion' => NULL,
+                                                                                            ),
+                                                                                        'bar' =>
+                                                                                            array (
+                                                                                                'dataType' => 'DateTime',
+                                                                                                'actualType' => 'datetime',
+                                                                                                'subType' => NULL,
+                                                                                                'required' => false,
+                                                                                                'default' => NULL,
+                                                                                                'description' => '',
+                                                                                                'readonly' => true,
+                                                                                                'sinceVersion' => NULL,
+                                                                                                'untilVersion' => NULL,
+                                                                                            ),
+                                                                                        'number' =>
+                                                                                            array (
+                                                                                                'dataType' => 'double',
+                                                                                                'actualType' => 'float',
+                                                                                                'subType' => NULL,
+                                                                                                'required' => false,
+                                                                                                'default' => NULL,
+                                                                                                'description' => '',
+                                                                                                'readonly' => false,
+                                                                                                'sinceVersion' => NULL,
+                                                                                                'untilVersion' => NULL,
+                                                                                            ),
+                                                                                        'arr' =>
+                                                                                            array (
+                                                                                                'dataType' => 'array',
+                                                                                                'actualType' => 'collection',
+                                                                                                'subType' => NULL,
+                                                                                                'required' => false,
+                                                                                                'default' => NULL,
+                                                                                                'description' => '',
+                                                                                                'readonly' => false,
+                                                                                                'sinceVersion' => NULL,
+                                                                                                'untilVersion' => NULL,
+                                                                                            ),
+                                                                                        'nested' =>
+                                                                                            array (
+                                                                                                'dataType' => 'object (JmsNested)',
+                                                                                                'actualType' => 'model',
+                                                                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                                                                'required' => false,
+                                                                                                'default' => NULL,
+                                                                                                'description' => '',
+                                                                                                'readonly' => false,
+                                                                                                'sinceVersion' => NULL,
+                                                                                                'untilVersion' => NULL,
+                                                                                            ),
+                                                                                        'nested_array' =>
+                                                                                            array (
+                                                                                                'dataType' => 'array of objects (JmsNested)',
+                                                                                                'actualType' => 'collection',
+                                                                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                                                                'required' => false,
+                                                                                                'default' => NULL,
+                                                                                                'description' => '',
+                                                                                                'readonly' => false,
+                                                                                                'sinceVersion' => NULL,
+                                                                                                'untilVersion' => NULL,
+                                                                                            ),
+                                                                                    ),
+                                                                            ),
+                                                                        'since' =>
+                                                                            array (
+                                                                                'dataType' => 'string',
+                                                                                'actualType' => 'string',
+                                                                                'subType' => NULL,
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => '0.2',
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                        'until' =>
+                                                                            array (
+                                                                                'dataType' => 'string',
+                                                                                'actualType' => 'string',
+                                                                                'subType' => NULL,
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => '0.3',
+                                                                            ),
+                                                                        'since_and_until' =>
+                                                                            array (
+                                                                                'dataType' => 'string',
+                                                                                'actualType' => 'string',
+                                                                                'subType' => NULL,
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => '0.4',
+                                                                                'untilVersion' => '0.5',
+                                                                            ),
+                                                                    ),
+                                                            ),
+                                                        'nested_array' =>
+                                                            array (
+                                                                'dataType' => 'array of objects (JmsNested)',
+                                                                'actualType' => 'collection',
+                                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                    ),
+                                            ),
                                     ),
-                                ),
-                                'since' =>
-                                array (
-                                    'dataType' => 'string',
-                                    'actualType' => DataTypes::STRING,
-                                    'subType' => null,
-                                    'default' => null,
-                                    'required' => false,
-                                    'description' => '',
-                                    'readonly' => false,
-                                    'sinceVersion' => '0.2',
-                                    'untilVersion' => null,
-                                ),
-                                'until' =>
-                                array (
-                                    'dataType' => 'string',
-                                    'actualType' => DataTypes::STRING,
-                                    'subType' => null,
-                                    'default' => null,
-                                    'required' => false,
-                                    'description' => '',
-                                    'readonly' => false,
-                                    'sinceVersion' => null,
-                                    'untilVersion' => '0.3',
-                                ),
-                                'since_and_until' =>
-                                array (
-                                    'dataType' => 'string',
-                                    'actualType' => DataTypes::STRING,
-                                    'subType' => null,
-                                    'default' => null,
-                                    'required' => false,
-                                    'description' => '',
-                                    'readonly' => false,
-                                    'sinceVersion' => '0.4',
-                                    'untilVersion' => '0.5',
-                                ),
+                                'resourceDescription' => 'Operations on another resource.',
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
                             ),
-                        ),
-                        'nested_array' =>
-                        array(
-                            'dataType' => 'array of objects (JmsNested)',
-                            'actualType' => DataTypes::COLLECTION,
-                            'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested',
-                            'default' => null,
-                            'required' => false,
-                            'description' => '',
-                            'readonly' => false,
-                            'sinceVersion' => null,
-                            'untilVersion' => null,
-                        ),
-                    ),
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false,
-                ),
-                5 =>
-                array(
-                    'method' => 'GET',
-                    'uri' => '/jms-return-test',
-                    'description' => 'Testing return',
-                    'response' =>
-                    array(
-                        'dependency_type' => array(
-                            'dataType' => 'object (dependency_type)',
-                            'actualType' => DataTypes::MODEL,
-                            'subType' => 'dependency_type',
-                            'default' => null,
-                            'required' => true,
-                            'readonly' => false,
-                            'description' => '',
-                            'children' => array(
-                                'a' => array(
-                                    'dataType' => 'string',
-                                    'actualType' => DataTypes::STRING,
-                                    'subType' => null,
-                                    'default' => null,
-                                    'required' => true,
-                                    'description' => 'A nice description',
-                                    'readonly' => false,
-                                ),
+                        1 =>
+                            array (
+                                'method' => 'PUT|PATCH',
+                                'uri' => '/api/other-resources/{id}.{_format}',
+                                'description' => 'Update a resource bu ID.',
+                                'requirements' =>
+                                    array (
+                                        '_format' =>
+                                            array (
+                                                'requirement' => 'json|xml|html',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
+                                        'id' =>
+                                            array (
+                                                'requirement' => '',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
                             ),
-                        ),
                     ),
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false,
-                ),
-                6 =>
-                array(
-                    'method' => 'ANY',
-                    'uri' => '/my-commented/{id}/{page}/{paramType}/{param}',
-                    'description' => 'This method is useful to test if the getDocComment works.',
-                    'documentation' => 'This method is useful to test if the getDocComment works.
+                '/api/resources' =>
+                    array (
+                        0 =>
+                            array (
+                                'method' => 'GET',
+                                'uri' => '/api/resources.{_format}',
+                                'description' => 'List resources.',
+                                'requirements' =>
+                                    array (
+                                        '_format' =>
+                                            array (
+                                                'requirement' => 'json|xml|html',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
+                                    ),
+                                'response' =>
+                                    array (
+                                        'tests' =>
+                                            array (
+                                                'dataType' => 'array of objects (Test)',
+                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\Test',
+                                                'actualType' => 'collection',
+                                                'readonly' => true,
+                                                'required' => true,
+                                                'default' => true,
+                                                'description' => '',
+                                                'children' =>
+                                                    array (
+                                                        'a' =>
+                                                            array (
+                                                                'default' => 'nelmio',
+                                                                'actualType' => 'string',
+                                                                'subType' => NULL,
+                                                                'format' => '{length: min: foo}, {not blank}',
+                                                                'required' => true,
+                                                                'dataType' => 'string',
+                                                                'readonly' => NULL,
+                                                            ),
+                                                        'b' =>
+                                                            array (
+                                                                'default' => NULL,
+                                                                'actualType' => 'datetime',
+                                                                'subType' => NULL,
+                                                                'dataType' => 'DateTime',
+                                                                'readonly' => NULL,
+                                                                'required' => NULL,
+                                                            ),
+                                                    ),
+                                            ),
+                                    ),
+                                'statusCodes' =>
+                                    array (
+                                        200 =>
+                                            array (
+                                                0 => 'Returned on success.',
+                                            ),
+                                        404 =>
+                                            array (
+                                                0 => 'Returned if resource cannot be found.',
+                                            ),
+                                    ),
+                                'resourceDescription' => 'Operations on resource.',
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        1 =>
+                            array (
+                                'method' => 'POST',
+                                'uri' => '/api/resources.{_format}',
+                                'description' => 'Create a new resource.',
+                                'parameters' =>
+                                    array (
+                                        'a' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'actualType' => 'string',
+                                                'subType' => NULL,
+                                                'default' => NULL,
+                                                'required' => true,
+                                                'description' => 'Something that describes A.',
+                                                'readonly' => false,
+                                            ),
+                                        'b' =>
+                                            array (
+                                                'dataType' => 'float',
+                                                'actualType' => 'float',
+                                                'subType' => NULL,
+                                                'default' => NULL,
+                                                'required' => true,
+                                                'description' => NULL,
+                                                'readonly' => false,
+                                            ),
+                                        'c' =>
+                                            array (
+                                                'dataType' => 'choice',
+                                                'actualType' => 'choice',
+                                                'subType' => NULL,
+                                                'default' => NULL,
+                                                'required' => true,
+                                                'description' => NULL,
+                                                'readonly' => false,
+                                                'format' => '{"x":"X","y":"Y","z":"Z"}',
+                                            ),
+                                        'd' =>
+                                            array (
+                                                'dataType' => 'datetime',
+                                                'actualType' => 'datetime',
+                                                'subType' => NULL,
+                                                'default' => NULL,
+                                                'required' => true,
+                                                'description' => NULL,
+                                                'readonly' => false,
+                                            ),
+                                        'e' =>
+                                            array (
+                                                'dataType' => 'date',
+                                                'actualType' => 'date',
+                                                'subType' => NULL,
+                                                'default' => NULL,
+                                                'required' => true,
+                                                'description' => NULL,
+                                                'readonly' => false,
+                                            ),
+                                        'g' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'actualType' => 'string',
+                                                'subType' => NULL,
+                                                'default' => NULL,
+                                                'required' => true,
+                                                'description' => NULL,
+                                                'readonly' => false,
+                                            ),
+                                    ),
+                                'requirements' =>
+                                    array (
+                                        '_format' =>
+                                            array (
+                                                'requirement' => 'json|xml|html',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
+                                    ),
+                                'response' =>
+                                    array (
+                                        'foo' =>
+                                            array (
+                                                'dataType' => 'DateTime',
+                                                'actualType' => 'datetime',
+                                                'subType' => NULL,
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => true,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => NULL,
+                                            ),
+                                        'bar' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'actualType' => 'string',
+                                                'subType' => NULL,
+                                                'required' => false,
+                                                'default' => 'baz',
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => NULL,
+                                            ),
+                                        'baz' =>
+                                            array (
+                                                'dataType' => 'array of integers',
+                                                'actualType' => 'collection',
+                                                'subType' => 'integer',
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => 'Epic description.
+
+With multiple lines.',
+                                                'readonly' => false,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => NULL,
+                                            ),
+                                        'circular' =>
+                                            array (
+                                                'dataType' => 'object (JmsNested)',
+                                                'actualType' => 'model',
+                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => NULL,
+                                                'children' =>
+                                                    array (
+                                                        'foo' =>
+                                                            array (
+                                                                'dataType' => 'DateTime',
+                                                                'actualType' => 'datetime',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => true,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'bar' =>
+                                                            array (
+                                                                'dataType' => 'string',
+                                                                'actualType' => 'string',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => 'baz',
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'baz' =>
+                                                            array (
+                                                                'dataType' => 'array of integers',
+                                                                'actualType' => 'collection',
+                                                                'subType' => 'integer',
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => 'Epic description.
+
+With multiple lines.',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'circular' =>
+                                                            array (
+                                                                'dataType' => 'object (JmsNested)',
+                                                                'actualType' => 'model',
+                                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'parent' =>
+                                                            array (
+                                                                'dataType' => 'object (JmsTest)',
+                                                                'actualType' => 'model',
+                                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsTest',
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                                'children' =>
+                                                                    array (
+                                                                        'foo' =>
+                                                                            array (
+                                                                                'dataType' => 'string',
+                                                                                'actualType' => 'string',
+                                                                                'subType' => NULL,
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                        'bar' =>
+                                                                            array (
+                                                                                'dataType' => 'DateTime',
+                                                                                'actualType' => 'datetime',
+                                                                                'subType' => NULL,
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => true,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                        'number' =>
+                                                                            array (
+                                                                                'dataType' => 'double',
+                                                                                'actualType' => 'float',
+                                                                                'subType' => NULL,
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                        'arr' =>
+                                                                            array (
+                                                                                'dataType' => 'array',
+                                                                                'actualType' => 'collection',
+                                                                                'subType' => NULL,
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                        'nested' =>
+                                                                            array (
+                                                                                'dataType' => 'object (JmsNested)',
+                                                                                'actualType' => 'model',
+                                                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                        'nested_array' =>
+                                                                            array (
+                                                                                'dataType' => 'array of objects (JmsNested)',
+                                                                                'actualType' => 'collection',
+                                                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                    ),
+                                                            ),
+                                                        'since' =>
+                                                            array (
+                                                                'dataType' => 'string',
+                                                                'actualType' => 'string',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => '0.2',
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'until' =>
+                                                            array (
+                                                                'dataType' => 'string',
+                                                                'actualType' => 'string',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => '0.3',
+                                                            ),
+                                                        'since_and_until' =>
+                                                            array (
+                                                                'dataType' => 'string',
+                                                                'actualType' => 'string',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => '0.4',
+                                                                'untilVersion' => '0.5',
+                                                            ),
+                                                    ),
+                                            ),
+                                        'parent' =>
+                                            array (
+                                                'dataType' => 'object (JmsTest)',
+                                                'actualType' => 'model',
+                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsTest',
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => NULL,
+                                                'children' =>
+                                                    array (
+                                                        'foo' =>
+                                                            array (
+                                                                'dataType' => 'string',
+                                                                'actualType' => 'string',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'bar' =>
+                                                            array (
+                                                                'dataType' => 'DateTime',
+                                                                'actualType' => 'datetime',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => true,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'number' =>
+                                                            array (
+                                                                'dataType' => 'double',
+                                                                'actualType' => 'float',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'arr' =>
+                                                            array (
+                                                                'dataType' => 'array',
+                                                                'actualType' => 'collection',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'nested' =>
+                                                            array (
+                                                                'dataType' => 'object (JmsNested)',
+                                                                'actualType' => 'model',
+                                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'nested_array' =>
+                                                            array (
+                                                                'dataType' => 'array of objects (JmsNested)',
+                                                                'actualType' => 'collection',
+                                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                    ),
+                                            ),
+                                        'since' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'actualType' => 'string',
+                                                'subType' => NULL,
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => '0.2',
+                                                'untilVersion' => NULL,
+                                            ),
+                                        'until' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'actualType' => 'string',
+                                                'subType' => NULL,
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => '0.3',
+                                            ),
+                                        'since_and_until' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'actualType' => 'string',
+                                                'subType' => NULL,
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => '0.4',
+                                                'untilVersion' => '0.5',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        2 =>
+                            array (
+                                'method' => 'GET',
+                                'uri' => '/api/resources/{id}.{_format}',
+                                'description' => 'Retrieve a resource by ID.',
+                                'requirements' =>
+                                    array (
+                                        '_format' =>
+                                            array (
+                                                'requirement' => 'json|xml|html',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
+                                        'id' =>
+                                            array (
+                                                'requirement' => '',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        3 =>
+                            array (
+                                'method' => 'DELETE',
+                                'uri' => '/api/resources/{id}.{_format}',
+                                'description' => 'Delete a resource by ID.',
+                                'requirements' =>
+                                    array (
+                                        '_format' =>
+                                            array (
+                                                'requirement' => 'json|xml|html',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
+                                        'id' =>
+                                            array (
+                                                'requirement' => '',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                    ),
+                '/tests' =>
+                    array (
+                        0 =>
+                            array (
+                                'method' => 'GET',
+                                'uri' => '/tests.{_format}',
+                                'description' => 'index action',
+                                'filters' =>
+                                    array (
+                                        'a' =>
+                                            array (
+                                                'dataType' => 'integer',
+                                            ),
+                                        'b' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'arbitrary' =>
+                                                    array (
+                                                        0 => 'arg1',
+                                                        1 => 'arg2',
+                                                    ),
+                                            ),
+                                    ),
+                                'requirements' =>
+                                    array (
+                                        '_format' =>
+                                            array (
+                                                'requirement' => '',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        1 =>
+                            array (
+                                'method' => 'GET',
+                                'uri' => '/tests.{_format}',
+                                'description' => 'index action',
+                                'filters' =>
+                                    array (
+                                        'a' =>
+                                            array (
+                                                'dataType' => 'integer',
+                                            ),
+                                        'b' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'arbitrary' =>
+                                                    array (
+                                                        0 => 'arg1',
+                                                        1 => 'arg2',
+                                                    ),
+                                            ),
+                                    ),
+                                'requirements' =>
+                                    array (
+                                        '_format' =>
+                                            array (
+                                                'requirement' => '',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        2 =>
+                            array (
+                                'method' => 'POST',
+                                'uri' => '/tests.{_format}',
+                                'host' => 'api.test.dev',
+                                'description' => 'create test',
+                                'parameters' =>
+                                    array (
+                                        'a' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'actualType' => 'string',
+                                                'subType' => NULL,
+                                                'default' => NULL,
+                                                'required' => true,
+                                                'description' => 'A nice description',
+                                                'readonly' => false,
+                                            ),
+                                        'b' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'actualType' => 'string',
+                                                'subType' => NULL,
+                                                'default' => NULL,
+                                                'required' => false,
+                                                'description' => NULL,
+                                                'readonly' => false,
+                                            ),
+                                        'c' =>
+                                            array (
+                                                'dataType' => 'boolean',
+                                                'actualType' => 'boolean',
+                                                'subType' => NULL,
+                                                'default' => false,
+                                                'required' => true,
+                                                'description' => NULL,
+                                                'readonly' => false,
+                                            ),
+                                        'd' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'actualType' => 'string',
+                                                'subType' => NULL,
+                                                'default' => 'DefaultTest',
+                                                'required' => true,
+                                                'description' => NULL,
+                                                'readonly' => false,
+                                            ),
+                                    ),
+                                'requirements' =>
+                                    array (
+                                        '_format' =>
+                                            array (
+                                                'requirement' => '',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        3 =>
+                            array (
+                                'method' => 'POST',
+                                'uri' => '/tests.{_format}',
+                                'host' => 'api.test.dev',
+                                'description' => 'create test',
+                                'parameters' =>
+                                    array (
+                                        'a' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'actualType' => 'string',
+                                                'subType' => NULL,
+                                                'default' => NULL,
+                                                'required' => true,
+                                                'description' => 'A nice description',
+                                                'readonly' => false,
+                                            ),
+                                        'b' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'actualType' => 'string',
+                                                'subType' => NULL,
+                                                'default' => NULL,
+                                                'required' => false,
+                                                'description' => NULL,
+                                                'readonly' => false,
+                                            ),
+                                        'c' =>
+                                            array (
+                                                'dataType' => 'boolean',
+                                                'actualType' => 'boolean',
+                                                'subType' => NULL,
+                                                'default' => false,
+                                                'required' => true,
+                                                'description' => NULL,
+                                                'readonly' => false,
+                                            ),
+                                        'd' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'actualType' => 'string',
+                                                'subType' => NULL,
+                                                'default' => 'DefaultTest',
+                                                'required' => true,
+                                                'description' => NULL,
+                                                'readonly' => false,
+                                            ),
+                                    ),
+                                'requirements' =>
+                                    array (
+                                        '_format' =>
+                                            array (
+                                                'requirement' => '',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                    ),
+                '/tests2' =>
+                    array (
+                        0 =>
+                            array (
+                                'method' => 'POST',
+                                'uri' => '/tests2.{_format}',
+                                'description' => 'post test 2',
+                                'requirements' =>
+                                    array (
+                                        '_format' =>
+                                            array (
+                                                'requirement' => '',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                    ),
+                'TestResource' =>
+                    array (
+                        0 =>
+                            array (
+                                'method' => 'ANY',
+                                'uri' => '/named-resource',
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                    ),
+                'others' =>
+                    array (
+                        0 =>
+                            array (
+                                'method' => 'POST',
+                                'uri' => '/another-post',
+                                'description' => 'create another test',
+                                'parameters' =>
+                                    array (
+                                        'dependency_type' =>
+                                            array (
+                                                'required' => true,
+                                                'readonly' => false,
+                                                'description' => '',
+                                                'default' => NULL,
+                                                'dataType' => 'object (dependency_type)',
+                                                'actualType' => 'model',
+                                                'subType' => 'dependency_type',
+                                                'children' =>
+                                                    array (
+                                                        'a' =>
+                                                            array (
+                                                                'dataType' => 'string',
+                                                                'actualType' => 'string',
+                                                                'subType' => NULL,
+                                                                'default' => NULL,
+                                                                'required' => true,
+                                                                'description' => 'A nice description',
+                                                                'readonly' => false,
+                                                            ),
+                                                    ),
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        1 =>
+                            array (
+                                'method' => 'ANY',
+                                'uri' => '/any',
+                                'description' => 'Action without HTTP verb',
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        2 =>
+                            array (
+                                'method' => 'ANY',
+                                'uri' => '/any/{foo}',
+                                'description' => 'Action without HTTP verb',
+                                'requirements' =>
+                                    array (
+                                        'foo' =>
+                                            array (
+                                                'requirement' => '',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        3 =>
+                            array (
+                                'method' => 'ANY',
+                                'uri' => '/authenticated',
+                                'https' => false,
+                                'authentication' => true,
+                                'authenticationRoles' =>
+                                    array (
+                                        0 => 'ROLE_USER',
+                                        1 => 'ROLE_FOOBAR',
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        4 =>
+                            array (
+                                'method' => 'POST',
+                                'uri' => '/jms-input-test',
+                                'description' => 'Testing JMS',
+                                'parameters' =>
+                                    array (
+                                        'foo' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'actualType' => 'string',
+                                                'subType' => NULL,
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => NULL,
+                                            ),
+                                        'bar' =>
+                                            array (
+                                                'dataType' => 'DateTime',
+                                                'actualType' => 'datetime',
+                                                'subType' => NULL,
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => true,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => NULL,
+                                            ),
+                                        'number' =>
+                                            array (
+                                                'dataType' => 'double',
+                                                'actualType' => 'float',
+                                                'subType' => NULL,
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => NULL,
+                                            ),
+                                        'arr' =>
+                                            array (
+                                                'dataType' => 'array',
+                                                'actualType' => 'collection',
+                                                'subType' => NULL,
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => NULL,
+                                            ),
+                                        'nested' =>
+                                            array (
+                                                'dataType' => 'object (JmsNested)',
+                                                'actualType' => 'model',
+                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => NULL,
+                                                'children' =>
+                                                    array (
+                                                        'foo' =>
+                                                            array (
+                                                                'dataType' => 'DateTime',
+                                                                'actualType' => 'datetime',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => true,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'bar' =>
+                                                            array (
+                                                                'dataType' => 'string',
+                                                                'actualType' => 'string',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => 'baz',
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'baz' =>
+                                                            array (
+                                                                'dataType' => 'array of integers',
+                                                                'actualType' => 'collection',
+                                                                'subType' => 'integer',
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => 'Epic description.
+
+With multiple lines.',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'circular' =>
+                                                            array (
+                                                                'dataType' => 'object (JmsNested)',
+                                                                'actualType' => 'model',
+                                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'parent' =>
+                                                            array (
+                                                                'dataType' => 'object (JmsTest)',
+                                                                'actualType' => 'model',
+                                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsTest',
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                                'children' =>
+                                                                    array (
+                                                                        'foo' =>
+                                                                            array (
+                                                                                'dataType' => 'string',
+                                                                                'actualType' => 'string',
+                                                                                'subType' => NULL,
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                        'bar' =>
+                                                                            array (
+                                                                                'dataType' => 'DateTime',
+                                                                                'actualType' => 'datetime',
+                                                                                'subType' => NULL,
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => true,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                        'number' =>
+                                                                            array (
+                                                                                'dataType' => 'double',
+                                                                                'actualType' => 'float',
+                                                                                'subType' => NULL,
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                        'arr' =>
+                                                                            array (
+                                                                                'dataType' => 'array',
+                                                                                'actualType' => 'collection',
+                                                                                'subType' => NULL,
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                        'nested' =>
+                                                                            array (
+                                                                                'dataType' => 'object (JmsNested)',
+                                                                                'actualType' => 'model',
+                                                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                        'nested_array' =>
+                                                                            array (
+                                                                                'dataType' => 'array of objects (JmsNested)',
+                                                                                'actualType' => 'collection',
+                                                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                    ),
+                                                            ),
+                                                        'since' =>
+                                                            array (
+                                                                'dataType' => 'string',
+                                                                'actualType' => 'string',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => '0.2',
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'until' =>
+                                                            array (
+                                                                'dataType' => 'string',
+                                                                'actualType' => 'string',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => '0.3',
+                                                            ),
+                                                        'since_and_until' =>
+                                                            array (
+                                                                'dataType' => 'string',
+                                                                'actualType' => 'string',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => '0.4',
+                                                                'untilVersion' => '0.5',
+                                                            ),
+                                                    ),
+                                            ),
+                                        'nested_array' =>
+                                            array (
+                                                'dataType' => 'array of objects (JmsNested)',
+                                                'actualType' => 'collection',
+                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => NULL,
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        5 =>
+                            array (
+                                'method' => 'GET',
+                                'uri' => '/jms-return-test',
+                                'description' => 'Testing return',
+                                'response' =>
+                                    array (
+                                        'dependency_type' =>
+                                            array (
+                                                'required' => true,
+                                                'readonly' => false,
+                                                'description' => '',
+                                                'default' => NULL,
+                                                'dataType' => 'object (dependency_type)',
+                                                'actualType' => 'model',
+                                                'subType' => 'dependency_type',
+                                                'children' =>
+                                                    array (
+                                                        'a' =>
+                                                            array (
+                                                                'dataType' => 'string',
+                                                                'actualType' => 'string',
+                                                                'subType' => NULL,
+                                                                'default' => NULL,
+                                                                'required' => true,
+                                                                'description' => 'A nice description',
+                                                                'readonly' => false,
+                                                            ),
+                                                    ),
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        6 =>
+                            array (
+                                'method' => 'ANY',
+                                'uri' => '/my-commented/{id}/{page}/{paramType}/{param}',
+                                'description' => 'This method is useful to test if the getDocComment works.',
+                                'documentation' => 'This method is useful to test if the getDocComment works.
 And, it supports multilines until the first \'@\' char.',
-                    'requirements' =>
-                    array(
-                        'id' =>
-                        array(
-                            'dataType' => 'int',
-                            'description' => 'A nice comment',
-                            'requirement' => '',
-                        ),
-                        'page' =>
-                        array(
-                            'dataType' => 'int',
-                            'description' => '',
-                            'requirement' => '',
-                        ),
-                        'paramType' =>
-                        array (
-                            'dataType' => 'int',
-                            'description' => 'The param type',
-                            'requirement' => '',
-                        ),
-                        'param' =>
-                        array (
-                            'dataType' => 'int',
-                            'description' => 'The param id',
-                            'requirement' => '',
-                        ),
-                    ),
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false,
-                ),
-                7 =>
-                array(
-                    'method' => 'ANY',
-                    'uri' => '/return-nested-output',
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false,
-                    'response' =>
-                    array (
-                        'foo' =>
-                        array (
-                            'dataType' => 'string',
-                            'actualType' => DataTypes::STRING,
-                            'subType' => null,
-                            'default' => null,
-                            'required' => false,
-                            'description' => '',
-                            'readonly' => false,
-                            'sinceVersion' => null,
-                            'untilVersion' => null,
-                        ),
-                        'bar' =>
-                        array (
-                            'dataType' => 'DateTime',
-                            'actualType' => DataTypes::DATETIME,
-                            'subType' => null,
-                            'default' => null,
-                            'required' => false,
-                            'description' => '',
-                            'readonly' => true,
-                            'sinceVersion' => null,
-                            'untilVersion' => null,
-                        ),
-                        'number' =>
-                        array (
-                            'dataType' => 'double',
-                            'actualType' => DataTypes::FLOAT,
-                            'subType' => null,
-                            'default' => null,
-                            'required' => false,
-                            'description' => '',
-                            'readonly' => false,
-                            'sinceVersion' => null,
-                            'untilVersion' => null,
-                        ),
-                        'arr' =>
-                        array (
-                            'dataType' => 'array',
-                            'actualType' => DataTypes::COLLECTION,
-                            'subType' => null,
-                            'default' => null,
-                            'required' => false,
-                            'description' => '',
-                            'readonly' => false,
-                            'sinceVersion' => null,
-                            'untilVersion' => null,
-                        ),
-                        'nested' =>
-                        array (
-                            'dataType' => 'object (JmsNested)',
-                            'actualType' => DataTypes::MODEL,
-                            'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested',
-                            'default' => null,
-                            'required' => false,
-                            'description' => '',
-                            'readonly' => false,
-                            'sinceVersion' => null,
-                            'untilVersion' => null,
-                            'children' =>
+                                'requirements' =>
+                                    array (
+                                        'id' =>
+                                            array (
+                                                'dataType' => 'int',
+                                                'description' => 'A nice comment',
+                                                'requirement' => '',
+                                            ),
+                                        'page' =>
+                                            array (
+                                                'dataType' => 'int',
+                                                'description' => '',
+                                                'requirement' => '',
+                                            ),
+                                        'paramType' =>
+                                            array (
+                                                'dataType' => 'int',
+                                                'description' => 'The param type',
+                                                'requirement' => '',
+                                            ),
+                                        'param' =>
+                                            array (
+                                                'dataType' => 'int',
+                                                'description' => 'The param id',
+                                                'requirement' => '',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        7 =>
                             array (
-                                'foo' =>
-                                array (
-                                    'dataType' => 'DateTime',
-                                    'actualType' => DataTypes::DATETIME,
-                                    'subType' => null,
-                                    'default' => null,
-                                    'required' => false,
-                                    'description' => '',
-                                    'readonly' => true,
-                                    'sinceVersion' => null,
-                                    'untilVersion' => null,
-                                ),
-                                'bar' =>
-                                array (
-                                    'dataType' => 'string',
-                                    'actualType' => DataTypes::STRING,
-                                    'subType' => null,
-                                    'default' => 'baz',
-                                    'required' => false,
-                                    'description' => '',
-                                    'readonly' => false,
-                                    'sinceVersion' => null,
-                                    'untilVersion' => null,
-                                ),
-                                'baz' =>
-                                array (
-                                    'dataType' => 'array of integers',
-                                    'actualType' => DataTypes::COLLECTION,
-                                    'subType' => DataTypes::INTEGER,
-                                    'default' => null,
-                                    'required' => false,
-                                    'description' => 'Epic description.
-
-With multiple lines.',
-                                    'readonly' => false,
-                                    'sinceVersion' => null,
-                                    'untilVersion' => null,
-                                ),
-                                'circular' =>
-                                array (
-                                    'dataType' => 'object (JmsNested)',
-                                    'actualType' => DataTypes::MODEL,
-                                    'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested',
-                                    'default' => null,
-                                    'required' => false,
-                                    'description' => '',
-                                    'readonly' => false,
-                                    'sinceVersion' => null,
-                                    'untilVersion' => null,
-                                ),
-                                'parent' =>
-                                array (
-                                    'dataType' => 'object (JmsTest)',
-                                    'actualType' => DataTypes::MODEL,
-                                    'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsTest',
-                                    'default' => null,
-                                    'required' => false,
-                                    'description' => '',
-                                    'readonly' => false,
-                                    'sinceVersion' => null,
-                                    'untilVersion' => null,
-                                    'children' =>
+                                'method' => 'GET|HEAD',
+                                'uri' => '/popos',
+                                'description' => 'Retrieves the collection of Popo resources.',
+                                'documentation' => 'Gets the collection.',
+                                'response' =>
                                     array (
                                         'foo' =>
-                                        array (
+                                            array (
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'dataType' => 'string',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        8 =>
+                            array (
+                                'method' => 'POST',
+                                'uri' => '/popos',
+                                'description' => 'Creates a Popo resource.',
+                                'documentation' => 'Adds an element to the collection.',
+                                'parameters' =>
+                                    array (
+                                        'foo' =>
+                                            array (
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'dataType' => 'string',
+                                            ),
+                                    ),
+                                'response' =>
+                                    array (
+                                        'foo' =>
+                                            array (
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'dataType' => 'string',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        9 =>
+                            array (
+                                'method' => 'GET|HEAD',
+                                'uri' => '/popos/{id}',
+                                'description' => 'Retrieves Popo resource.',
+                                'documentation' => 'Gets an element of the collection.',
+                                'requirements' =>
+                                    array (
+                                        'id' =>
+                                            array (
+                                                'dataType' => 'int',
+                                                'description' => '',
+                                                'requirement' => '',
+                                            ),
+                                    ),
+                                'response' =>
+                                    array (
+                                        'foo' =>
+                                            array (
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'dataType' => 'string',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        10 =>
+                            array (
+                                'method' => 'PUT',
+                                'uri' => '/popos/{id}',
+                                'description' => 'Replaces the Popo resource.',
+                                'documentation' => 'Replaces an element of the collection.',
+                                'parameters' =>
+                                    array (
+                                        'foo' =>
+                                            array (
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'dataType' => 'string',
+                                            ),
+                                    ),
+                                'requirements' =>
+                                    array (
+                                        'id' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'description' => '',
+                                                'requirement' => '',
+                                            ),
+                                    ),
+                                'response' =>
+                                    array (
+                                        'foo' =>
+                                            array (
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'dataType' => 'string',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        11 =>
+                            array (
+                                'method' => 'DELETE',
+                                'uri' => '/popos/{id}',
+                                'description' => 'Deletes the Popo resource.',
+                                'documentation' => 'Deletes an element of the collection.',
+                                'requirements' =>
+                                    array (
+                                        'id' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'description' => '',
+                                                'requirement' => '',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        12 =>
+                            array (
+                                'method' => 'ANY',
+                                'uri' => '/return-nested-output',
+                                'response' =>
+                                    array (
+                                        'foo' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'actualType' => 'string',
+                                                'subType' => NULL,
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => NULL,
+                                            ),
+                                        'bar' =>
+                                            array (
+                                                'dataType' => 'DateTime',
+                                                'actualType' => 'datetime',
+                                                'subType' => NULL,
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => true,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => NULL,
+                                            ),
+                                        'number' =>
+                                            array (
+                                                'dataType' => 'double',
+                                                'actualType' => 'float',
+                                                'subType' => NULL,
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => NULL,
+                                            ),
+                                        'arr' =>
+                                            array (
+                                                'dataType' => 'array',
+                                                'actualType' => 'collection',
+                                                'subType' => NULL,
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => NULL,
+                                            ),
+                                        'nested' =>
+                                            array (
+                                                'dataType' => 'object (JmsNested)',
+                                                'actualType' => 'model',
+                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => NULL,
+                                                'children' =>
+                                                    array (
+                                                        'foo' =>
+                                                            array (
+                                                                'dataType' => 'DateTime',
+                                                                'actualType' => 'datetime',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => true,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'bar' =>
+                                                            array (
+                                                                'dataType' => 'string',
+                                                                'actualType' => 'string',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => 'baz',
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'baz' =>
+                                                            array (
+                                                                'dataType' => 'array of integers',
+                                                                'actualType' => 'collection',
+                                                                'subType' => 'integer',
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => 'Epic description.
+
+With multiple lines.',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'circular' =>
+                                                            array (
+                                                                'dataType' => 'object (JmsNested)',
+                                                                'actualType' => 'model',
+                                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'parent' =>
+                                                            array (
+                                                                'dataType' => 'object (JmsTest)',
+                                                                'actualType' => 'model',
+                                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsTest',
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => NULL,
+                                                                'children' =>
+                                                                    array (
+                                                                        'foo' =>
+                                                                            array (
+                                                                                'dataType' => 'string',
+                                                                                'actualType' => 'string',
+                                                                                'subType' => NULL,
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                        'bar' =>
+                                                                            array (
+                                                                                'dataType' => 'DateTime',
+                                                                                'actualType' => 'datetime',
+                                                                                'subType' => NULL,
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => true,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                        'number' =>
+                                                                            array (
+                                                                                'dataType' => 'double',
+                                                                                'actualType' => 'float',
+                                                                                'subType' => NULL,
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                        'arr' =>
+                                                                            array (
+                                                                                'dataType' => 'array',
+                                                                                'actualType' => 'collection',
+                                                                                'subType' => NULL,
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                        'nested' =>
+                                                                            array (
+                                                                                'dataType' => 'object (JmsNested)',
+                                                                                'actualType' => 'model',
+                                                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                        'nested_array' =>
+                                                                            array (
+                                                                                'dataType' => 'array of objects (JmsNested)',
+                                                                                'actualType' => 'collection',
+                                                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                                                'required' => false,
+                                                                                'default' => NULL,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => NULL,
+                                                                                'untilVersion' => NULL,
+                                                                            ),
+                                                                    ),
+                                                            ),
+                                                        'since' =>
+                                                            array (
+                                                                'dataType' => 'string',
+                                                                'actualType' => 'string',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => '0.2',
+                                                                'untilVersion' => NULL,
+                                                            ),
+                                                        'until' =>
+                                                            array (
+                                                                'dataType' => 'string',
+                                                                'actualType' => 'string',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => NULL,
+                                                                'untilVersion' => '0.3',
+                                                            ),
+                                                        'since_and_until' =>
+                                                            array (
+                                                                'dataType' => 'string',
+                                                                'actualType' => 'string',
+                                                                'subType' => NULL,
+                                                                'required' => false,
+                                                                'default' => NULL,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => '0.4',
+                                                                'untilVersion' => '0.5',
+                                                            ),
+                                                    ),
+                                            ),
+                                        'nested_array' =>
+                                            array (
+                                                'dataType' => 'array of objects (JmsNested)',
+                                                'actualType' => 'collection',
+                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => NULL,
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        13 =>
+                            array (
+                                'method' => 'ANY',
+                                'uri' => '/secure-route',
+                                'https' => true,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        14 =>
+                            array (
+                                'method' => 'ANY',
+                                'uri' => '/yet-another/{id}',
+                                'requirements' =>
+                                    array (
+                                        'id' =>
+                                            array (
+                                                'requirement' => '\\d+',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        15 =>
+                            array (
+                                'method' => 'GET',
+                                'uri' => '/z-action-with-deprecated-indicator',
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => true,
+                            ),
+                        16 =>
+                            array (
+                                'method' => 'POST',
+                                'uri' => '/z-action-with-nullable-request-param',
+                                'parameters' =>
+                                    array (
+                                        'param1' =>
+                                            array (
+                                                'required' => false,
+                                                'dataType' => 'string',
+                                                'actualType' => 'string',
+                                                'subType' => NULL,
+                                                'description' => 'Param1 description.',
+                                                'readonly' => false,
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        17 =>
+                            array (
+                                'method' => 'GET',
+                                'uri' => '/z-action-with-query-param',
+                                'filters' =>
+                                    array (
+                                        'page' =>
+                                            array (
+                                                'requirement' => '\\d+',
+                                                'description' => 'Page of the overview.',
+                                                'default' => '1',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        18 =>
+                            array (
+                                'method' => 'GET',
+                                'uri' => '/z-action-with-query-param-no-default',
+                                'filters' =>
+                                    array (
+                                        'page' =>
+                                            array (
+                                                'requirement' => '\\d+',
+                                                'description' => 'Page of the overview.',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        19 =>
+                            array (
+                                'method' => 'GET',
+                                'uri' => '/z-action-with-query-param-strict',
+                                'requirements' =>
+                                    array (
+                                        'page' =>
+                                            array (
+                                                'requirement' => '\\d+',
+                                                'dataType' => '',
+                                                'description' => 'Page of the overview.',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        20 =>
+                            array (
+                                'method' => 'POST',
+                                'uri' => '/z-action-with-request-param',
+                                'parameters' =>
+                                    array (
+                                        'param1' =>
+                                            array (
+                                                'required' => true,
+                                                'dataType' => 'string',
+                                                'actualType' => 'string',
+                                                'subType' => NULL,
+                                                'description' => 'Param1 description.',
+                                                'readonly' => false,
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        21 =>
+                            array (
+                                'method' => 'ANY',
+                                'uri' => '/z-return-jms-and-validator-output',
+                                'response' =>
+                                    array (
+                                        'bar' =>
+                                            array (
+                                                'default' => NULL,
+                                                'actualType' => 'datetime',
+                                                'subType' => NULL,
+                                                'dataType' => 'DateTime',
+                                                'readonly' => NULL,
+                                                'required' => NULL,
+                                            ),
+                                        'objects' =>
+                                            array (
+                                                'default' => NULL,
+                                                'actualType' => 'collection',
+                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\Test',
+                                                'dataType' => 'array of objects (Test)',
+                                                'children' =>
+                                                    array (
+                                                        'a' =>
+                                                            array (
+                                                                'default' => 'nelmio',
+                                                                'actualType' => 'string',
+                                                                'subType' => NULL,
+                                                                'format' => '{length: min: foo}, {not blank}',
+                                                                'required' => true,
+                                                                'dataType' => 'string',
+                                                                'readonly' => NULL,
+                                                            ),
+                                                        'b' =>
+                                                            array (
+                                                                'default' => NULL,
+                                                                'actualType' => 'datetime',
+                                                                'subType' => NULL,
+                                                                'dataType' => 'DateTime',
+                                                                'readonly' => NULL,
+                                                                'required' => NULL,
+                                                            ),
+                                                    ),
+                                                'readonly' => NULL,
+                                                'required' => NULL,
+                                            ),
+                                        'number' =>
+                                            array (
+                                                'dataType' => 'DateTime',
+                                                'actualType' => 'datetime',
+                                                'subType' => NULL,
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => NULL,
+                                            ),
+                                        'related' =>
+                                            array (
+                                                'dataType' => 'object (Test)',
+                                                'actualType' => 'model',
+                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\Test',
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => NULL,
+                                                'children' =>
+                                                    array (
+                                                        'a' =>
+                                                            array (
+                                                                'default' => 'nelmio',
+                                                                'actualType' => 'string',
+                                                                'subType' => NULL,
+                                                                'format' => '{length: min: foo}, {not blank}',
+                                                                'required' => true,
+                                                                'dataType' => 'string',
+                                                                'readonly' => NULL,
+                                                            ),
+                                                        'b' =>
+                                                            array (
+                                                                'default' => NULL,
+                                                                'actualType' => 'datetime',
+                                                                'subType' => NULL,
+                                                                'dataType' => 'DateTime',
+                                                                'readonly' => NULL,
+                                                                'required' => NULL,
+                                                            ),
+                                                    ),
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        22 =>
+                            array (
+                                'method' => 'ANY',
+                                'uri' => '/z-return-selected-parsers-input',
+                                'parameters' =>
+                                    array (
+                                        'a' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'actualType' => 'string',
+                                                'subType' => NULL,
+                                                'default' => NULL,
+                                                'required' => true,
+                                                'description' => 'A nice description',
+                                                'readonly' => false,
+                                            ),
+                                        'b' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'actualType' => 'string',
+                                                'subType' => NULL,
+                                                'default' => NULL,
+                                                'required' => false,
+                                                'description' => NULL,
+                                                'readonly' => false,
+                                            ),
+                                        'c' =>
+                                            array (
+                                                'dataType' => 'boolean',
+                                                'actualType' => 'boolean',
+                                                'subType' => NULL,
+                                                'default' => false,
+                                                'required' => true,
+                                                'description' => NULL,
+                                                'readonly' => false,
+                                            ),
+                                        'd' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'actualType' => 'string',
+                                                'subType' => NULL,
+                                                'default' => 'DefaultTest',
+                                                'required' => true,
+                                                'description' => NULL,
+                                                'readonly' => false,
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        23 =>
+                            array (
+                                'method' => 'ANY',
+                                'uri' => '/z-return-selected-parsers-output',
+                                'response' =>
+                                    array (
+                                        'bar' =>
+                                            array (
+                                                'default' => NULL,
+                                                'actualType' => 'datetime',
+                                                'subType' => NULL,
+                                                'dataType' => 'DateTime',
+                                                'readonly' => NULL,
+                                                'required' => NULL,
+                                            ),
+                                        'objects' =>
+                                            array (
+                                                'default' => NULL,
+                                                'actualType' => 'collection',
+                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\Test',
+                                                'dataType' => 'array of objects (Test)',
+                                                'children' =>
+                                                    array (
+                                                        'a' =>
+                                                            array (
+                                                                'default' => 'nelmio',
+                                                                'actualType' => 'string',
+                                                                'subType' => NULL,
+                                                                'format' => '{length: min: foo}, {not blank}',
+                                                                'required' => true,
+                                                                'dataType' => 'string',
+                                                                'readonly' => NULL,
+                                                            ),
+                                                        'b' =>
+                                                            array (
+                                                                'default' => NULL,
+                                                                'actualType' => 'datetime',
+                                                                'subType' => NULL,
+                                                                'dataType' => 'DateTime',
+                                                                'readonly' => NULL,
+                                                                'required' => NULL,
+                                                            ),
+                                                    ),
+                                                'readonly' => NULL,
+                                                'required' => NULL,
+                                            ),
+                                        'number' =>
+                                            array (
+                                                'dataType' => 'DateTime',
+                                                'actualType' => 'datetime',
+                                                'subType' => NULL,
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => NULL,
+                                            ),
+                                        'related' =>
+                                            array (
+                                                'dataType' => 'object (Test)',
+                                                'actualType' => 'model',
+                                                'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\Test',
+                                                'required' => false,
+                                                'default' => NULL,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => NULL,
+                                                'untilVersion' => NULL,
+                                                'children' =>
+                                                    array (
+                                                        'a' =>
+                                                            array (
+                                                                'default' => 'nelmio',
+                                                                'actualType' => 'string',
+                                                                'subType' => NULL,
+                                                                'format' => '{length: min: foo}, {not blank}',
+                                                                'required' => true,
+                                                                'dataType' => 'string',
+                                                                'readonly' => NULL,
+                                                            ),
+                                                        'b' =>
+                                                            array (
+                                                                'default' => NULL,
+                                                                'actualType' => 'datetime',
+                                                                'subType' => NULL,
+                                                                'dataType' => 'DateTime',
+                                                                'readonly' => NULL,
+                                                                'required' => NULL,
+                                                            ),
+                                                    ),
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        24 =>
+                            array (
+                                'method' => 'POST',
+                                'uri' => '/zcached',
+                                'cache' => 60,
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        25 =>
+                            array (
+                                'method' => 'POST',
+                                'uri' => '/zsecured',
+                                'https' => false,
+                                'authentication' => true,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                    ),
+            );
+        } else {
+            $expected = array(
+                '/tests' =>
+                    array(
+                        0 =>
+                            array(
+                                'method' => 'GET',
+                                'uri' => '/tests.{_format}',
+                                'description' => 'index action',
+                                'filters' =>
+                                    array(
+                                        'a' =>
+                                            array(
+                                                'dataType' => 'integer',
+                                            ),
+                                        'b' =>
+                                            array(
+                                                'dataType' => 'string',
+                                                'arbitrary' =>
+                                                    array(
+                                                        0 => 'arg1',
+                                                        1 => 'arg2',
+                                                    ),
+                                            ),
+                                    ),
+                                'requirements' =>
+                                    array(
+                                        '_format' =>
+                                            array(
+                                                'requirement' => '',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
+                            ),
+                        1 =>
+                            array(
+                                'method' => 'GET',
+                                'uri' => '/tests.{_format}',
+                                'description' => 'index action',
+                                'filters' =>
+                                    array(
+                                        'a' =>
+                                            array(
+                                                'dataType' => 'integer',
+                                            ),
+                                        'b' =>
+                                            array(
+                                                'dataType' => 'string',
+                                                'arbitrary' =>
+                                                    array(
+                                                        0 => 'arg1',
+                                                        1 => 'arg2',
+                                                    ),
+                                            ),
+                                    ),
+                                'requirements' =>
+                                    array(
+                                        '_format' =>
+                                            array(
+                                                'requirement' => '',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
+                            ),
+                        2 =>
+                            array(
+                                'method' => 'POST',
+                                'uri' => '/tests.{_format}',
+                                'host' => 'api.test.dev',
+                                'description' => 'create test',
+                                'parameters' =>
+                                    array(
+                                        'a' => array(
+                                            'dataType' => 'string',
+                                            'actualType' => DataTypes::STRING,
+                                            'subType' => null,
+                                            'default' => null,
+                                            'required' => true,
+                                            'description' => 'A nice description',
+                                            'readonly' => false,
+                                        ),
+                                        'b' => array(
                                             'dataType' => 'string',
                                             'actualType' => DataTypes::STRING,
                                             'subType' => null,
@@ -768,1306 +2518,1462 @@ With multiple lines.',
                                             'required' => false,
                                             'description' => '',
                                             'readonly' => false,
-                                            'sinceVersion' => null,
-                                            'untilVersion' => null,
                                         ),
-                                        'bar' =>
-                                        array (
-                                            'dataType' => 'DateTime',
-                                            'actualType' => DataTypes::DATETIME,
+                                        'c' => array(
+                                            'dataType' => 'boolean',
+                                            'actualType' => DataTypes::BOOLEAN,
                                             'subType' => null,
                                             'default' => null,
-                                            'required' => false,
+                                            'required' => true,
                                             'description' => '',
-                                            'readonly' => true,
-                                            'sinceVersion' => null,
-                                            'untilVersion' => null,
+                                            'readonly' => false,
                                         ),
-                                        'number' =>
-                                        array (
-                                            'dataType' => 'double',
-                                            'actualType' => DataTypes::FLOAT,
+                                        'd' => array(
+                                            'dataType' => 'string',
+                                            'actualType' => DataTypes::STRING,
                                             'subType' => null,
                                             'default' => null,
-                                            'required' => false,
+                                            'default' => "DefaultTest",
+                                            'required' => true,
                                             'description' => '',
                                             'readonly' => false,
-                                            'sinceVersion' => null,
-                                            'untilVersion' => null,
-                                        ),
-                                        'arr' =>
-                                        array (
-                                            'dataType' => 'array',
-                                            'actualType' => DataTypes::COLLECTION,
-                                            'subType' => null,
-                                            'default' => null,
-                                            'required' => false,
-                                            'description' => '',
-                                            'readonly' => false,
-                                            'sinceVersion' => null,
-                                            'untilVersion' => null,
-                                        ),
-                                        'nested' =>
-                                        array (
-                                            'dataType' => 'object (JmsNested)',
-                                            'actualType' => DataTypes::MODEL,
-                                            'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested',
-                                            'default' => null,
-                                            'required' => false,
-                                            'description' => '',
-                                            'readonly' => false,
-                                            'sinceVersion' => null,
-                                            'untilVersion' => null,
-                                        ),
-                                        'nested_array' =>
-                                        array (
-                                            'dataType' => 'array of objects (JmsNested)',
-                                            'actualType' => DataTypes::COLLECTION,
-                                            'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested',
-                                            'default' => null,
-                                            'required' => false,
-                                            'description' => '',
-                                            'readonly' => false,
-                                            'sinceVersion' => null,
-                                            'untilVersion' => null,
                                         ),
                                     ),
-                                ),
-                                'since' =>
-                                array (
-                                    'dataType' => 'string',
-                                    'actualType' => DataTypes::STRING,
-                                    'subType' => null,
-                                    'default' => null,
-                                    'required' => false,
-                                    'description' => '',
-                                    'readonly' => false,
-                                    'sinceVersion' => '0.2',
-                                    'untilVersion' => null,
-                                ),
-                                'until' =>
-                                array (
-                                    'dataType' => 'string',
-                                    'actualType' => DataTypes::STRING,
-                                    'subType' => null,
-                                    'default' => null,
-                                    'required' => false,
-                                    'description' => '',
-                                    'readonly' => false,
-                                    'sinceVersion' => null,
-                                    'untilVersion' => '0.3',
-                                ),
-                                'since_and_until' =>
-                                array (
-                                    'dataType' => 'string',
-                                    'actualType' => DataTypes::STRING,
-                                    'subType' => null,
-                                    'default' => null,
-                                    'required' => false,
-                                    'description' => '',
-                                    'readonly' => false,
-                                    'sinceVersion' => '0.4',
-                                    'untilVersion' => '0.5',
-                                ),
-                            ),
-                        ),
-                        'nested_array' =>
-                        array (
-                            'dataType' => 'array of objects (JmsNested)',
-                            'actualType' => DataTypes::COLLECTION,
-                            'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested',
-                            'default' => null,
-                            'required' => false,
-                            'description' => '',
-                            'readonly' => false,
-                            'sinceVersion' => null,
-                            'untilVersion' => null,
-                        ),
-                    ),
-                ),
-                8 =>
-                array(
-                    'method' => 'ANY',
-                    'uri' => '/secure-route',
-                    'https' => true,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false,
-                ),
-                9 =>
-                array(
-                    'method' => 'ANY',
-                    'uri' => '/yet-another/{id}',
-                    'requirements' =>
-                    array(
-                        'id' =>
-                        array(
-                            'requirement' => '\\d+',
-                            'dataType' => '',
-                            'description' => '',
-                        ),
-                    ),
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false,
-                ),
-                10 =>
-                array(
-                    'method' => 'GET',
-                    'uri' => '/z-action-with-deprecated-indicator',
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => true,
-                ),
-                11 =>
-                array(
-                    'method' => 'POST',
-                    'uri' => '/z-action-with-nullable-request-param',
-                    'parameters' =>
-                    array(
-                        'param1' =>
-                        array(
-                            'required' => false,
-                            'dataType' => 'string',
-                            'description' => 'Param1 description.',
-                            'readonly' => false,
-                            'actualType' => 'string',
-                            'subType' => null,
-                        ),
-                    ),
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false,
-                ),
-                12 =>
-                array(
-                    'method' => 'GET',
-                    'uri' => '/z-action-with-query-param',
-                    'filters' =>
-                    array(
-                        'page' =>
-                        array(
-                            'requirement' => '\\d+',
-                            'description' => 'Page of the overview.',
-                            'default' => '1',
-                        ),
-                    ),
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false,
-                ),
-                13 =>
-                array(
-                    'method' => 'GET',
-                    'uri' => '/z-action-with-query-param-no-default',
-                    'filters' =>
-                    array (
-                        'page' =>
-                        array (
-                            'requirement' => '\\d+',
-                            'description' => 'Page of the overview.',
-                        ),
-                    ),
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false,
-                ),
-                14 =>
-                array(
-                    'method' => 'GET',
-                    'uri' => '/z-action-with-query-param-strict',
-                    'requirements' =>
-                    array (
-                        'page' =>
-                        array (
-                            'requirement' => '\\d+',
-                            'dataType' => '',
-                            'description' => 'Page of the overview.',
-                        ),
-                    ),
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false,
-                ),
-                15 =>
-                array(
-                    'method' => 'POST',
-                    'uri' => '/z-action-with-request-param',
-                    'parameters' =>
-                    array(
-                        'param1' =>
-                        array(
-                            'required' => true,
-                            'dataType' => 'string',
-                            'actualType' => DataTypes::STRING,
-                            'subType' => null,
-                            'description' => 'Param1 description.',
-                            'readonly' => false,
-                        ),
-                    ),
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false,
-                ),
-                16 =>
-                array(
-                    'method' => 'ANY',
-                    'uri' => '/z-return-jms-and-validator-output',
-                    'https' => false,
-                    'authentication' => false,
-                    'deprecated' => false,
-                    'response' => array (
-                        'bar' => array(
-                            'dataType' => 'DateTime',
-                            'actualType' => DataTypes::DATETIME,
-                            'subType' => null,
-                            'default' => null,
-                            'required' => null,
-                            'readonly' => null
-                        ),
-                        'number' => array(
-                            'dataType' => 'DateTime',
-                            'actualType' => DataTypes::DATETIME,
-                            'subType' => null,
-                            'default' => null,
-                            'required' => false,
-                            'description' => '',
-                            'readonly' => false,
-                            'sinceVersion' => null,
-                            'untilVersion' => null
-                        ),
-                        'objects' => array(
-                            'dataType' => 'array of objects (Test)',
-                            'actualType' => DataTypes::COLLECTION,
-                            'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\Test',
-                            'default' => null,
-                            'readonly' => null,
-                            'required' => null,
-                            'children' => array(
-                                'a' => array(
-                                    'dataType' => 'string',
-                                    'actualType' => DataTypes::STRING,
-                                    'subType' => null,
-                                    'default' => 'nelmio',
-                                    'format' => '{length: min: foo}, {not blank}',
-                                    'required' => true,
-                                    'readonly' => null
-                                ),
-                                'b' => array(
-                                    'dataType' => 'DateTime',
-                                    'actualType' => DataTypes::DATETIME,
-                                    'subType' => null,
-                                    'default' => null,
-                                    'required' => null,
-                                    'readonly' => null,
-                                )
-                            )
-                        ),
-                        'related' => array(
-                            'dataType' => 'object (Test)',
-                            'actualType' => DataTypes::MODEL,
-                            'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\Test',
-                            'default' => null,
-                            'readonly' => false,
-                            'required' => false,
-                            'description' => '',
-                            'sinceVersion' => null,
-                            'untilVersion' => null,
-                            'children' => array(
-                                'a' => array(
-                                    'dataType' => 'string',
-                                    'actualType' => DataTypes::STRING,
-                                    'subType' => null,
-                                    'default' => 'nelmio',
-                                    'format' => '{length: min: foo}, {not blank}',
-                                    'required' => true,
-                                    'readonly' => null
-                                ),
-                                'b' => array(
-                                    'dataType' => 'DateTime',
-                                    'actualType' => DataTypes::DATETIME,
-                                    'subType' => null,
-                                    'default' => null,
-                                    'required' => null,
-                                    'readonly' => null
-                                )
-                            ),
-                        )
-                    ),
-                    'authenticationRoles' => array(),
-                ),
-                17 =>
-                array(
-                    'method' => "ANY",
-                    'uri' => "/z-return-selected-parsers-input",
-                    'https' => false,
-                    'authentication' => false,
-                    'deprecated' => false,
-                    'authenticationRoles' => array(),
-                    'parameters' =>
-                    array(
-                        'a' => array(
-                            'dataType' => 'string',
-                            'actualType' => DataTypes::STRING,
-                            'subType' => null,
-                            'default' => null,
-                            'required' => true,
-                            'description' => 'A nice description',
-                            'readonly' => false,
-                        ),
-                        'b' => array(
-                            'dataType' => 'string',
-                            'actualType' => DataTypes::STRING,
-                            'subType' => null,
-                            'default' => null,
-                            'required' => false,
-                            'description' => '',
-                            'readonly' => false,
-                        ),
-                        'c' => array(
-                            'dataType' => 'boolean',
-                            'actualType' => DataTypes::BOOLEAN,
-                            'subType' => null,
-                            'default' => null,
-                            'required' => true,
-                            'description' => '',
-                            'readonly' => false,
-                        ),
-                        'd' => array(
-                            'dataType' => 'string',
-                            'actualType' => DataTypes::STRING,
-                            'subType' => null,
-                            'default' => "DefaultTest",
-                            'required' => true,
-                            'description' => '',
-                            'readonly' => false,
-                        ),
-                    )
-                ),
-                18 =>
-                array(
-                    'method' => "ANY",
-                    'uri' => "/z-return-selected-parsers-output",
-                    'https' => false,
-                    'authentication' => false,
-                    'deprecated' => false,
-                    'response' => array (
-                        'bar' => array(
-                            'dataType' => 'DateTime',
-                            'actualType' => DataTypes::DATETIME,
-                            'subType' => null,
-                            'default' => null,
-                            'required' => null,
-                            'readonly' => null
-                        ),
-                        'number' => array(
-                            'dataType' => 'DateTime',
-                            'actualType' => DataTypes::DATETIME,
-                            'subType' => null,
-                            'default' => null,
-                            'required' => false,
-                            'description' => '',
-                            'readonly' => false,
-                            'sinceVersion' => null,
-                            'untilVersion' => null
-                        ),
-                        'objects' => array(
-                            'dataType' => 'array of objects (Test)',
-                            'actualType' => DataTypes::COLLECTION,
-                            'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\Test',
-                            'default' => null,
-                            'readonly' => null,
-                            'required' => null,
-                            'children' => array(
-                                'a' => array(
-                                    'dataType' => 'string',
-                                    'actualType' => DataTypes::STRING,
-                                    'subType' => null,
-                                    'default' => 'nelmio',
-                                    'format' => '{length: min: foo}, {not blank}',
-                                    'required' => true,
-                                    'readonly' => null
-                                ),
-                                'b' => array(
-                                    'dataType' => 'DateTime',
-                                    'actualType' => DataTypes::DATETIME,
-                                    'subType' => null,
-                                    'default' => null,
-                                    'required' => null,
-                                    'readonly' => null
-                                )
-                            )
-                        ),
-                        'related' => array(
-                            'dataType' => 'object (Test)',
-                            'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\Test',
-                            'actualType' => DataTypes::MODEL,
-                            'default' => null,
-                            'readonly' => false,
-                            'required' => false,
-                            'description' => '',
-                            'sinceVersion' => null,
-                            'untilVersion' => null,
-                            'children' => array(
-                                'a' => array(
-                                    'dataType' => 'string',
-                                    'actualType' => DataTypes::STRING,
-                                    'subType' => null,
-                                    'default' => 'nelmio',
-                                    'format' => '{length: min: foo}, {not blank}',
-                                    'required' => true,
-                                    'readonly' => null
-                                ),
-                                'b' => array(
-                                    'dataType' => 'DateTime',
-                                    'actualType' => DataTypes::DATETIME,
-                                    'subType' => null,
-                                    'default' => null,
-                                    'required' => null,
-                                    'readonly' => null
-                                )
-                            ),
-                        )
-                    ),
-                    'authenticationRoles' => array(),
-                ),
-                19 =>
-                array(
-                    'cache' => 60,
-                    'method' => 'POST',
-                    'uri' => '/zcached',
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false
-                ),
-                20 =>
-                array(
-                    'authentication' => true,
-                    'method' => 'POST',
-                    'uri' => '/zsecured',
-                    'https' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false
-                )
-            ),
-            '/tests2' =>
-            array(
-                array(
-                    'method' => 'POST',
-                    'uri' => '/tests2.{_format}',
-                    'description' => 'post test 2',
-                    'requirements' =>
-                    array(
-                        '_format' =>
-                        array(
-                            'requirement' => '',
-                            'dataType' => '',
-                            'description' => '',
-                        ),
-                    ),
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false,
-                ),
-            ),
-            '/tests2' =>
-            array(
-                array(
-                    'method' => 'POST',
-                    'uri' => '/tests2.{_format}',
-                    'description' => 'post test 2',
-                    'requirements' =>
-                    array(
-                        '_format' =>
-                        array(
-                            'requirement' => '',
-                            'dataType' => '',
-                            'description' => '',
-                        ),
-                    ),
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false,
-                ),
-            ),
-            'TestResource' =>
-            array(
-                0 =>
-                array(
-                    'method' => 'ANY',
-                    'uri' => '/named-resource',
-                    'https' => false,
-                    'authentication' => false,
-                    'authenticationRoles' => array(),
-                    'deprecated' => false,
-                ),
-            ),
-            '/api/other-resources' =>
-                array(
-                    array(
-                        'method' => 'GET',
-                        'uri' => '/api/other-resources.{_format}',
-                        'description' => 'List another resource.',
-                        'requirements' =>
-                            array(
-                                '_format' =>
+                                'requirements' =>
                                     array(
-                                        'requirement' => 'json|xml|html',
-                                        'dataType' => '',
-                                        'description' => '',
+                                        '_format' =>
+                                            array(
+                                                'requirement' => '',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
                                     ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
                             ),
-                        'resourceDescription' => 'Operations on another resource.',
-                        'https' => false,
-                        'authentication' => false,
-                        'authenticationRoles' =>
-                            array(),
-                        'deprecated' => false,
-                        'response' => array(
-                            '' =>
-                                array(
-                                    'dataType'    => 'array of objects (JmsTest)',
-                                    'subType'     => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsTest',
-                                    'actualType'  => 'collection',
-                                    'readonly'    => true,
-                                    'required'    => true,
-                                    'default'     => true,
-                                    'description' => '',
-                                    'children'    =>
-                                        array(
-                                            'foo'          =>
-                                                array(
-                                                    'dataType'     => 'string',
-                                                    'actualType'   => 'string',
-                                                    'subType'      => null,
-                                                    'required'     => false,
-                                                    'default'      => null,
-                                                    'description'  => '',
-                                                    'readonly'     => false,
-                                                    'sinceVersion' => null,
-                                                    'untilVersion' => null,
+                        3 =>
+                            array(
+                                'method' => 'POST',
+                                'uri' => '/tests.{_format}',
+                                'host' => 'api.test.dev',
+                                'description' => 'create test',
+                                'parameters' =>
+                                    array(
+                                        'a' => array(
+                                            'dataType' => 'string',
+                                            'actualType' => DataTypes::STRING,
+                                            'subType' => null,
+                                            'default' => null,
+                                            'required' => true,
+                                            'description' => 'A nice description',
+                                            'readonly' => false,
+                                        ),
+                                        'b' => array(
+                                            'dataType' => 'string',
+                                            'actualType' => DataTypes::STRING,
+                                            'subType' => null,
+                                            'default' => null,
+                                            'required' => false,
+                                            'description' => '',
+                                            'readonly' => false,
+                                        ),
+                                        'c' => array(
+                                            'dataType' => 'boolean',
+                                            'actualType' => DataTypes::BOOLEAN,
+                                            'subType' => null,
+                                            'default' => null,
+                                            'required' => true,
+                                            'description' => '',
+                                            'readonly' => false,
+                                        ),
+                                        'd' => array(
+                                            'dataType' => 'string',
+                                            'actualType' => DataTypes::STRING,
+                                            'subType' => null,
+                                            'default' => "DefaultTest",
+                                            'required' => true,
+                                            'description' => '',
+                                            'readonly' => false,
+                                        ),
+                                    ),
+                                'requirements' =>
+                                    array(
+                                        '_format' =>
+                                            array(
+                                                'requirement' => '',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
+                            ),
+                    ),
+                'others' =>
+                    array(
+                        0 =>
+                            array(
+                                'method' => 'POST',
+                                'uri' => '/another-post',
+                                'description' => 'create another test',
+                                'parameters' =>
+                                    array(
+                                        'dependency_type' => array(
+                                            'dataType' => 'object (dependency_type)',
+                                            'actualType' => DataTypes::MODEL,
+                                            'subType' => 'dependency_type',
+                                            'default' => null,
+                                            'required' => true,
+                                            'readonly' => false,
+                                            'description' => '',
+                                            'children' => array(
+                                                'a' => array(
+                                                    'dataType' => 'string',
+                                                    'actualType' => DataTypes::STRING,
+                                                    'subType' => null,
+                                                    'default' => null,
+                                                    'required' => true,
+                                                    'description' => 'A nice description',
+                                                    'readonly' => false,
                                                 ),
-                                            'bar'          =>
-                                                array(
-                                                    'dataType'     => 'DateTime',
-                                                    'actualType'   => 'datetime',
-                                                    'subType'      => null,
-                                                    'required'     => false,
-                                                    'default'      => null,
-                                                    'description'  => '',
-                                                    'readonly'     => true,
-                                                    'sinceVersion' => null,
-                                                    'untilVersion' => null,
-                                                ),
-                                            'number'       =>
-                                                array(
-                                                    'dataType'     => 'double',
-                                                    'actualType'   => 'float',
-                                                    'subType'      => null,
-                                                    'required'     => false,
-                                                    'default'      => null,
-                                                    'description'  => '',
-                                                    'readonly'     => false,
-                                                    'sinceVersion' => null,
-                                                    'untilVersion' => null,
-                                                ),
-                                            'arr'          =>
-                                                array(
-                                                    'dataType'     => 'array',
-                                                    'actualType'   => 'collection',
-                                                    'subType'      => null,
-                                                    'required'     => false,
-                                                    'default'      => null,
-                                                    'description'  => '',
-                                                    'readonly'     => false,
-                                                    'sinceVersion' => null,
-                                                    'untilVersion' => null,
-                                                ),
-                                            'nested'       =>
-                                                array(
-                                                    'dataType'     => 'object (JmsNested)',
-                                                    'actualType'   => 'model',
-                                                    'subType'      => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
-                                                    'required'     => false,
-                                                    'default'      => null,
-                                                    'description'  => '',
-                                                    'readonly'     => false,
-                                                    'sinceVersion' => null,
-                                                    'untilVersion' => null,
-                                                    'children'     =>
-                                                        array(
-                                                            'foo'             =>
-                                                                array(
-                                                                    'dataType'     => 'DateTime',
-                                                                    'actualType'   => 'datetime',
-                                                                    'subType'      => null,
-                                                                    'required'     => false,
-                                                                    'default'      => null,
-                                                                    'description'  => '',
-                                                                    'readonly'     => true,
-                                                                    'sinceVersion' => null,
-                                                                    'untilVersion' => null,
-                                                                ),
-                                                            'bar'             =>
-                                                                array(
-                                                                    'dataType'     => 'string',
-                                                                    'actualType'   => 'string',
-                                                                    'subType'      => null,
-                                                                    'required'     => false,
-                                                                    'default'      => 'baz',
-                                                                    'description'  => '',
-                                                                    'readonly'     => false,
-                                                                    'sinceVersion' => null,
-                                                                    'untilVersion' => null,
-                                                                ),
-                                                            'baz'             =>
-                                                                array(
-                                                                    'dataType'     => 'array of integers',
-                                                                    'actualType'   => 'collection',
-                                                                    'subType'      => 'integer',
-                                                                    'required'     => false,
-                                                                    'default'      => null,
-                                                                    'description'  => 'Epic description.
+                                            ),
+                                        ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
+                            ),
+                        1 =>
+                            array(
+                                'method' => 'ANY',
+                                'uri' => '/any',
+                                'description' => 'Action without HTTP verb',
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
+                            ),
+                        2 =>
+                            array(
+                                'method' => 'ANY',
+                                'uri' => '/any/{foo}',
+                                'description' => 'Action without HTTP verb',
+                                'requirements' =>
+                                    array(
+                                        'foo' =>
+                                            array(
+                                                'requirement' => '',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
+                            ),
+                        3 =>
+                            array(
+                                'method' => 'ANY',
+                                'uri' => '/authenticated',
+                                'https' => false,
+                                'authentication' => true,
+                                'authenticationRoles' => array('ROLE_USER', 'ROLE_FOOBAR'),
+                                'deprecated' => false,
+                            ),
+                        4 =>
+                            array(
+                                'method' => 'POST',
+                                'uri' => '/jms-input-test',
+                                'description' => 'Testing JMS',
+                                'parameters' =>
+                                    array(
+                                        'foo' =>
+                                            array(
+                                                'dataType' => 'string',
+                                                'actualType' => DataTypes::STRING,
+                                                'subType' => null,
+                                                'default' => null,
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => null,
+                                                'untilVersion' => null,
+                                            ),
+                                        'bar' =>
+                                            array(
+                                                'dataType' => 'DateTime',
+                                                'actualType' => DataTypes::DATETIME,
+                                                'subType' => null,
+                                                'default' => null,
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => true,
+                                                'sinceVersion' => null,
+                                                'untilVersion' => null,
+                                            ),
+                                        'number' =>
+                                            array(
+                                                'dataType' => 'double',
+                                                'actualType' => DataTypes::FLOAT,
+                                                'subType' => null,
+                                                'default' => null,
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => null,
+                                                'untilVersion' => null,
+                                            ),
+                                        'arr' =>
+                                            array(
+                                                'dataType' => 'array',
+                                                'actualType' => DataTypes::COLLECTION,
+                                                'subType' => null,
+                                                'default' => null,
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => null,
+                                                'untilVersion' => null,
+                                            ),
+                                        'nested' =>
+                                            array(
+                                                'dataType' => 'object (JmsNested)',
+                                                'actualType' => DataTypes::MODEL,
+                                                'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested',
+                                                'default' => null,
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => null,
+                                                'untilVersion' => null,
+                                                'children' =>
+                                                    array(
+                                                        'foo' =>
+                                                            array(
+                                                                'dataType' => 'DateTime',
+                                                                'actualType' => DataTypes::DATETIME,
+                                                                'subType' => null,
+                                                                'default' => null,
+                                                                'required' => false,
+                                                                'description' => '',
+                                                                'readonly' => true,
+                                                                'sinceVersion' => null,
+                                                                'untilVersion' => null,
+                                                            ),
+                                                        'bar' =>
+                                                            array(
+                                                                'dataType' => 'string',
+                                                                'actualType' => DataTypes::STRING,
+                                                                'subType' => null,
+                                                                'default' => 'baz',
+                                                                'required' => false,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => null,
+                                                                'untilVersion' => null,
+                                                            ),
+                                                        'baz' =>
+                                                            array(
+                                                                'dataType' => 'array of integers',
+                                                                'actualType' => DataTypes::COLLECTION,
+                                                                'subType' => DataTypes::INTEGER,
+                                                                'default' => null,
+                                                                'required' => false,
+                                                                'description' => 'Epic description.
 
 With multiple lines.',
-                                                                    'readonly'     => false,
-                                                                    'sinceVersion' => null,
-                                                                    'untilVersion' => null,
-                                                                ),
-                                                            'circular'        =>
-                                                                array(
-                                                                    'dataType'     => 'object (JmsNested)',
-                                                                    'actualType'   => 'model',
-                                                                    'subType'      => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
-                                                                    'required'     => false,
-                                                                    'default'      => null,
-                                                                    'description'  => '',
-                                                                    'readonly'     => false,
-                                                                    'sinceVersion' => null,
-                                                                    'untilVersion' => null,
-                                                                ),
-                                                            'parent'          =>
-                                                                array(
-                                                                    'dataType'     => 'object (JmsTest)',
-                                                                    'actualType'   => 'model',
-                                                                    'subType'      => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsTest',
-                                                                    'required'     => false,
-                                                                    'default'      => null,
-                                                                    'description'  => '',
-                                                                    'readonly'     => false,
-                                                                    'sinceVersion' => null,
-                                                                    'untilVersion' => null,
-                                                                    'children'     =>
-                                                                        array(
-                                                                            'foo'          =>
-                                                                                array(
-                                                                                    'dataType'     => 'string',
-                                                                                    'actualType'   => 'string',
-                                                                                    'subType'      => null,
-                                                                                    'required'     => false,
-                                                                                    'default'      => null,
-                                                                                    'description'  => '',
-                                                                                    'readonly'     => false,
-                                                                                    'sinceVersion' => null,
-                                                                                    'untilVersion' => null,
-                                                                                ),
-                                                                            'bar'          =>
-                                                                                array(
-                                                                                    'dataType'     => 'DateTime',
-                                                                                    'actualType'   => 'datetime',
-                                                                                    'subType'      => null,
-                                                                                    'required'     => false,
-                                                                                    'default'      => null,
-                                                                                    'description'  => '',
-                                                                                    'readonly'     => true,
-                                                                                    'sinceVersion' => null,
-                                                                                    'untilVersion' => null,
-                                                                                ),
-                                                                            'number'       =>
-                                                                                array(
-                                                                                    'dataType'     => 'double',
-                                                                                    'actualType'   => 'float',
-                                                                                    'subType'      => null,
-                                                                                    'required'     => false,
-                                                                                    'default'      => null,
-                                                                                    'description'  => '',
-                                                                                    'readonly'     => false,
-                                                                                    'sinceVersion' => null,
-                                                                                    'untilVersion' => null,
-                                                                                ),
-                                                                            'arr'          =>
-                                                                                array(
-                                                                                    'dataType'     => 'array',
-                                                                                    'actualType'   => 'collection',
-                                                                                    'subType'      => null,
-                                                                                    'required'     => false,
-                                                                                    'default'      => null,
-                                                                                    'description'  => '',
-                                                                                    'readonly'     => false,
-                                                                                    'sinceVersion' => null,
-                                                                                    'untilVersion' => null,
-                                                                                ),
-                                                                            'nested'       =>
-                                                                                array(
-                                                                                    'dataType'     => 'object (JmsNested)',
-                                                                                    'actualType'   => 'model',
-                                                                                    'subType'      => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
-                                                                                    'required'     => false,
-                                                                                    'default'      => null,
-                                                                                    'description'  => '',
-                                                                                    'readonly'     => false,
-                                                                                    'sinceVersion' => null,
-                                                                                    'untilVersion' => null,
-                                                                                ),
-                                                                            'nested_array' =>
-                                                                                array(
-                                                                                    'dataType'     => 'array of objects (JmsNested)',
-                                                                                    'actualType'   => 'collection',
-                                                                                    'subType'      => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
-                                                                                    'required'     => false,
-                                                                                    'default'      => null,
-                                                                                    'description'  => '',
-                                                                                    'readonly'     => false,
-                                                                                    'sinceVersion' => null,
-                                                                                    'untilVersion' => null,
-                                                                                ),
-                                                                        ),
-                                                                ),
-                                                            'since'           =>
-                                                                array(
-                                                                    'dataType'     => 'string',
-                                                                    'actualType'   => 'string',
-                                                                    'subType'      => null,
-                                                                    'required'     => false,
-                                                                    'default'      => null,
-                                                                    'description'  => '',
-                                                                    'readonly'     => false,
-                                                                    'sinceVersion' => '0.2',
-                                                                    'untilVersion' => null,
-                                                                ),
-                                                            'until'           =>
-                                                                array(
-                                                                    'dataType'     => 'string',
-                                                                    'actualType'   => 'string',
-                                                                    'subType'      => null,
-                                                                    'required'     => false,
-                                                                    'default'      => null,
-                                                                    'description'  => '',
-                                                                    'readonly'     => false,
-                                                                    'sinceVersion' => null,
-                                                                    'untilVersion' => '0.3',
-                                                                ),
-                                                            'since_and_until' =>
-                                                                array(
-                                                                    'dataType'     => 'string',
-                                                                    'actualType'   => 'string',
-                                                                    'subType'      => null,
-                                                                    'required'     => false,
-                                                                    'default'      => null,
-                                                                    'description'  => '',
-                                                                    'readonly'     => false,
-                                                                    'sinceVersion' => '0.4',
-                                                                    'untilVersion' => '0.5',
-                                                                ),
-                                                        ),
+                                                                'readonly' => false,
+                                                                'sinceVersion' => null,
+                                                                'untilVersion' => null,
+                                                            ),
+                                                        'circular' =>
+                                                            array(
+                                                                'dataType' => 'object (JmsNested)',
+                                                                'actualType' => DataTypes::MODEL,
+                                                                'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested',
+                                                                'default' => null,
+                                                                'required' => false,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => null,
+                                                                'untilVersion' => null,
+                                                            ),
+                                                        'parent' =>
+                                                            array(
+                                                                'dataType' => 'object (JmsTest)',
+                                                                'actualType' => DataTypes::MODEL,
+                                                                'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsTest',
+                                                                'default' => null,
+                                                                'required' => false,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => null,
+                                                                'untilVersion' => null,
+                                                                'children' =>
+                                                                    array(
+                                                                        'foo' =>
+                                                                            array(
+                                                                                'dataType' => 'string',
+                                                                                'actualType' => DataTypes::STRING,
+                                                                                'subType' => null,
+                                                                                'default' => null,
+                                                                                'required' => false,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => null,
+                                                                                'untilVersion' => null,
+                                                                            ),
+                                                                        'bar' =>
+                                                                            array(
+                                                                                'dataType' => 'DateTime',
+                                                                                'actualType' => DataTypes::DATETIME,
+                                                                                'subType' => null,
+                                                                                'default' => null,
+                                                                                'required' => false,
+                                                                                'description' => '',
+                                                                                'readonly' => true,
+                                                                                'sinceVersion' => null,
+                                                                                'untilVersion' => null,
+                                                                            ),
+                                                                        'number' =>
+                                                                            array(
+                                                                                'dataType' => 'double',
+                                                                                'actualType' => DataTypes::FLOAT,
+                                                                                'subType' => null,
+                                                                                'default' => null,
+                                                                                'required' => false,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => null,
+                                                                                'untilVersion' => null,
+                                                                            ),
+                                                                        'arr' =>
+                                                                            array(
+                                                                                'dataType' => 'array',
+                                                                                'actualType' => DataTypes::COLLECTION,
+                                                                                'subType' => null,
+                                                                                'default' => null,
+                                                                                'required' => false,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => null,
+                                                                                'untilVersion' => null,
+                                                                            ),
+                                                                        'nested' =>
+                                                                            array(
+                                                                                'dataType' => 'object (JmsNested)',
+                                                                                'actualType' => DataTypes::MODEL,
+                                                                                'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested',
+                                                                                'default' => null,
+                                                                                'required' => false,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => null,
+                                                                                'untilVersion' => null,
+                                                                            ),
+                                                                        'nested_array' =>
+                                                                            array(
+                                                                                'dataType' => 'array of objects (JmsNested)',
+                                                                                'actualType' => DataTypes::COLLECTION,
+                                                                                'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested',
+                                                                                'default' => null,
+                                                                                'required' => false,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => null,
+                                                                                'untilVersion' => null,
+                                                                            ),
+                                                                    ),
+                                                            ),
+                                                        'since' =>
+                                                            array(
+                                                                'dataType' => 'string',
+                                                                'actualType' => DataTypes::STRING,
+                                                                'subType' => null,
+                                                                'default' => null,
+                                                                'required' => false,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => '0.2',
+                                                                'untilVersion' => null,
+                                                            ),
+                                                        'until' =>
+                                                            array(
+                                                                'dataType' => 'string',
+                                                                'actualType' => DataTypes::STRING,
+                                                                'subType' => null,
+                                                                'default' => null,
+                                                                'required' => false,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => null,
+                                                                'untilVersion' => '0.3',
+                                                            ),
+                                                        'since_and_until' =>
+                                                            array(
+                                                                'dataType' => 'string',
+                                                                'actualType' => DataTypes::STRING,
+                                                                'subType' => null,
+                                                                'default' => null,
+                                                                'required' => false,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => '0.4',
+                                                                'untilVersion' => '0.5',
+                                                            ),
+                                                    ),
+                                            ),
+                                        'nested_array' =>
+                                            array(
+                                                'dataType' => 'array of objects (JmsNested)',
+                                                'actualType' => DataTypes::COLLECTION,
+                                                'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested',
+                                                'default' => null,
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => null,
+                                                'untilVersion' => null,
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
+                            ),
+                        5 =>
+                            array(
+                                'method' => 'GET',
+                                'uri' => '/jms-return-test',
+                                'description' => 'Testing return',
+                                'response' =>
+                                    array(
+                                        'dependency_type' => array(
+                                            'dataType' => 'object (dependency_type)',
+                                            'actualType' => DataTypes::MODEL,
+                                            'subType' => 'dependency_type',
+                                            'default' => null,
+                                            'required' => true,
+                                            'readonly' => false,
+                                            'description' => '',
+                                            'children' => array(
+                                                'a' => array(
+                                                    'dataType' => 'string',
+                                                    'actualType' => DataTypes::STRING,
+                                                    'subType' => null,
+                                                    'default' => null,
+                                                    'required' => true,
+                                                    'description' => 'A nice description',
+                                                    'readonly' => false,
                                                 ),
-                                            'nested_array' =>
-                                                array(
-                                                    'dataType'     => 'array of objects (JmsNested)',
-                                                    'actualType'   => 'collection',
-                                                    'subType'      => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
-                                                    'required'     => false,
-                                                    'default'      => null,
-                                                    'description'  => '',
-                                                    'readonly'     => false,
-                                                    'sinceVersion' => null,
-                                                    'untilVersion' => null,
-                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
+                            ),
+                        6 =>
+                            array(
+                                'method' => 'ANY',
+                                'uri' => '/my-commented/{id}/{page}/{paramType}/{param}',
+                                'description' => 'This method is useful to test if the getDocComment works.',
+                                'documentation' => 'This method is useful to test if the getDocComment works.
+And, it supports multilines until the first \'@\' char.',
+                                'requirements' =>
+                                    array(
+                                        'id' =>
+                                            array(
+                                                'dataType' => 'int',
+                                                'description' => 'A nice comment',
+                                                'requirement' => '',
+                                            ),
+                                        'page' =>
+                                            array(
+                                                'dataType' => 'int',
+                                                'description' => '',
+                                                'requirement' => '',
+                                            ),
+                                        'paramType' =>
+                                            array(
+                                                'dataType' => 'int',
+                                                'description' => 'The param type',
+                                                'requirement' => '',
+                                            ),
+                                        'param' =>
+                                            array(
+                                                'dataType' => 'int',
+                                                'description' => 'The param id',
+                                                'requirement' => '',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
+                            ),
+                        7 =>
+                            array(
+                                'method' => 'ANY',
+                                'uri' => '/return-nested-output',
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
+                                'response' =>
+                                    array(
+                                        'foo' =>
+                                            array(
+                                                'dataType' => 'string',
+                                                'actualType' => DataTypes::STRING,
+                                                'subType' => null,
+                                                'default' => null,
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => null,
+                                                'untilVersion' => null,
+                                            ),
+                                        'bar' =>
+                                            array(
+                                                'dataType' => 'DateTime',
+                                                'actualType' => DataTypes::DATETIME,
+                                                'subType' => null,
+                                                'default' => null,
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => true,
+                                                'sinceVersion' => null,
+                                                'untilVersion' => null,
+                                            ),
+                                        'number' =>
+                                            array(
+                                                'dataType' => 'double',
+                                                'actualType' => DataTypes::FLOAT,
+                                                'subType' => null,
+                                                'default' => null,
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => null,
+                                                'untilVersion' => null,
+                                            ),
+                                        'arr' =>
+                                            array(
+                                                'dataType' => 'array',
+                                                'actualType' => DataTypes::COLLECTION,
+                                                'subType' => null,
+                                                'default' => null,
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => null,
+                                                'untilVersion' => null,
+                                            ),
+                                        'nested' =>
+                                            array(
+                                                'dataType' => 'object (JmsNested)',
+                                                'actualType' => DataTypes::MODEL,
+                                                'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested',
+                                                'default' => null,
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => null,
+                                                'untilVersion' => null,
+                                                'children' =>
+                                                    array(
+                                                        'foo' =>
+                                                            array(
+                                                                'dataType' => 'DateTime',
+                                                                'actualType' => DataTypes::DATETIME,
+                                                                'subType' => null,
+                                                                'default' => null,
+                                                                'required' => false,
+                                                                'description' => '',
+                                                                'readonly' => true,
+                                                                'sinceVersion' => null,
+                                                                'untilVersion' => null,
+                                                            ),
+                                                        'bar' =>
+                                                            array(
+                                                                'dataType' => 'string',
+                                                                'actualType' => DataTypes::STRING,
+                                                                'subType' => null,
+                                                                'default' => 'baz',
+                                                                'required' => false,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => null,
+                                                                'untilVersion' => null,
+                                                            ),
+                                                        'baz' =>
+                                                            array(
+                                                                'dataType' => 'array of integers',
+                                                                'actualType' => DataTypes::COLLECTION,
+                                                                'subType' => DataTypes::INTEGER,
+                                                                'default' => null,
+                                                                'required' => false,
+                                                                'description' => 'Epic description.
+
+With multiple lines.',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => null,
+                                                                'untilVersion' => null,
+                                                            ),
+                                                        'circular' =>
+                                                            array(
+                                                                'dataType' => 'object (JmsNested)',
+                                                                'actualType' => DataTypes::MODEL,
+                                                                'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested',
+                                                                'default' => null,
+                                                                'required' => false,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => null,
+                                                                'untilVersion' => null,
+                                                            ),
+                                                        'parent' =>
+                                                            array(
+                                                                'dataType' => 'object (JmsTest)',
+                                                                'actualType' => DataTypes::MODEL,
+                                                                'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsTest',
+                                                                'default' => null,
+                                                                'required' => false,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => null,
+                                                                'untilVersion' => null,
+                                                                'children' =>
+                                                                    array(
+                                                                        'foo' =>
+                                                                            array(
+                                                                                'dataType' => 'string',
+                                                                                'actualType' => DataTypes::STRING,
+                                                                                'subType' => null,
+                                                                                'default' => null,
+                                                                                'required' => false,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => null,
+                                                                                'untilVersion' => null,
+                                                                            ),
+                                                                        'bar' =>
+                                                                            array(
+                                                                                'dataType' => 'DateTime',
+                                                                                'actualType' => DataTypes::DATETIME,
+                                                                                'subType' => null,
+                                                                                'default' => null,
+                                                                                'required' => false,
+                                                                                'description' => '',
+                                                                                'readonly' => true,
+                                                                                'sinceVersion' => null,
+                                                                                'untilVersion' => null,
+                                                                            ),
+                                                                        'number' =>
+                                                                            array(
+                                                                                'dataType' => 'double',
+                                                                                'actualType' => DataTypes::FLOAT,
+                                                                                'subType' => null,
+                                                                                'default' => null,
+                                                                                'required' => false,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => null,
+                                                                                'untilVersion' => null,
+                                                                            ),
+                                                                        'arr' =>
+                                                                            array(
+                                                                                'dataType' => 'array',
+                                                                                'actualType' => DataTypes::COLLECTION,
+                                                                                'subType' => null,
+                                                                                'default' => null,
+                                                                                'required' => false,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => null,
+                                                                                'untilVersion' => null,
+                                                                            ),
+                                                                        'nested' =>
+                                                                            array(
+                                                                                'dataType' => 'object (JmsNested)',
+                                                                                'actualType' => DataTypes::MODEL,
+                                                                                'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested',
+                                                                                'default' => null,
+                                                                                'required' => false,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => null,
+                                                                                'untilVersion' => null,
+                                                                            ),
+                                                                        'nested_array' =>
+                                                                            array(
+                                                                                'dataType' => 'array of objects (JmsNested)',
+                                                                                'actualType' => DataTypes::COLLECTION,
+                                                                                'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested',
+                                                                                'default' => null,
+                                                                                'required' => false,
+                                                                                'description' => '',
+                                                                                'readonly' => false,
+                                                                                'sinceVersion' => null,
+                                                                                'untilVersion' => null,
+                                                                            ),
+                                                                    ),
+                                                            ),
+                                                        'since' =>
+                                                            array(
+                                                                'dataType' => 'string',
+                                                                'actualType' => DataTypes::STRING,
+                                                                'subType' => null,
+                                                                'default' => null,
+                                                                'required' => false,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => '0.2',
+                                                                'untilVersion' => null,
+                                                            ),
+                                                        'until' =>
+                                                            array(
+                                                                'dataType' => 'string',
+                                                                'actualType' => DataTypes::STRING,
+                                                                'subType' => null,
+                                                                'default' => null,
+                                                                'required' => false,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => null,
+                                                                'untilVersion' => '0.3',
+                                                            ),
+                                                        'since_and_until' =>
+                                                            array(
+                                                                'dataType' => 'string',
+                                                                'actualType' => DataTypes::STRING,
+                                                                'subType' => null,
+                                                                'default' => null,
+                                                                'required' => false,
+                                                                'description' => '',
+                                                                'readonly' => false,
+                                                                'sinceVersion' => '0.4',
+                                                                'untilVersion' => '0.5',
+                                                            ),
+                                                    ),
+                                            ),
+                                        'nested_array' =>
+                                            array(
+                                                'dataType' => 'array of objects (JmsNested)',
+                                                'actualType' => DataTypes::COLLECTION,
+                                                'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsNested',
+                                                'default' => null,
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'sinceVersion' => null,
+                                                'untilVersion' => null,
+                                            ),
+                                    ),
+                            ),
+                        8 =>
+                            array(
+                                'method' => 'ANY',
+                                'uri' => '/secure-route',
+                                'https' => true,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
+                            ),
+                        9 =>
+                            array(
+                                'method' => 'ANY',
+                                'uri' => '/yet-another/{id}',
+                                'requirements' =>
+                                    array(
+                                        'id' =>
+                                            array(
+                                                'requirement' => '\\d+',
+                                                'dataType' => '',
+                                                'description' => '',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
+                            ),
+                        10 =>
+                            array(
+                                'method' => 'GET',
+                                'uri' => '/z-action-with-deprecated-indicator',
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => true,
+                            ),
+                        11 =>
+                            array(
+                                'method' => 'POST',
+                                'uri' => '/z-action-with-nullable-request-param',
+                                'parameters' =>
+                                    array(
+                                        'param1' =>
+                                            array(
+                                                'required' => false,
+                                                'dataType' => 'string',
+                                                'description' => 'Param1 description.',
+                                                'readonly' => false,
+                                                'actualType' => 'string',
+                                                'subType' => null,
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
+                            ),
+                        12 =>
+                            array(
+                                'method' => 'GET',
+                                'uri' => '/z-action-with-query-param',
+                                'filters' =>
+                                    array(
+                                        'page' =>
+                                            array(
+                                                'requirement' => '\\d+',
+                                                'description' => 'Page of the overview.',
+                                                'default' => '1',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
+                            ),
+                        13 =>
+                            array(
+                                'method' => 'GET',
+                                'uri' => '/z-action-with-query-param-no-default',
+                                'filters' =>
+                                    array(
+                                        'page' =>
+                                            array(
+                                                'requirement' => '\\d+',
+                                                'description' => 'Page of the overview.',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
+                            ),
+                        14 =>
+                            array(
+                                'method' => 'GET',
+                                'uri' => '/z-action-with-query-param-strict',
+                                'requirements' =>
+                                    array(
+                                        'page' =>
+                                            array(
+                                                'requirement' => '\\d+',
+                                                'dataType' => '',
+                                                'description' => 'Page of the overview.',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
+                            ),
+                        15 =>
+                            array(
+                                'method' => 'POST',
+                                'uri' => '/z-action-with-request-param',
+                                'parameters' =>
+                                    array(
+                                        'param1' =>
+                                            array(
+                                                'required' => true,
+                                                'dataType' => 'string',
+                                                'actualType' => DataTypes::STRING,
+                                                'subType' => null,
+                                                'description' => 'Param1 description.',
+                                                'readonly' => false,
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
+                            ),
+                        16 =>
+                            array(
+                                'method' => 'ANY',
+                                'uri' => '/z-return-jms-and-validator-output',
+                                'https' => false,
+                                'authentication' => false,
+                                'deprecated' => false,
+                                'response' => array(
+                                    'bar' => array(
+                                        'dataType' => 'DateTime',
+                                        'actualType' => DataTypes::DATETIME,
+                                        'subType' => null,
+                                        'default' => null,
+                                        'required' => null,
+                                        'readonly' => null
+                                    ),
+                                    'number' => array(
+                                        'dataType' => 'DateTime',
+                                        'actualType' => DataTypes::DATETIME,
+                                        'subType' => null,
+                                        'default' => null,
+                                        'required' => false,
+                                        'description' => '',
+                                        'readonly' => false,
+                                        'sinceVersion' => null,
+                                        'untilVersion' => null
+                                    ),
+                                    'objects' => array(
+                                        'dataType' => 'array of objects (Test)',
+                                        'actualType' => DataTypes::COLLECTION,
+                                        'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\Test',
+                                        'default' => null,
+                                        'readonly' => null,
+                                        'required' => null,
+                                        'children' => array(
+                                            'a' => array(
+                                                'dataType' => 'string',
+                                                'actualType' => DataTypes::STRING,
+                                                'subType' => null,
+                                                'default' => 'nelmio',
+                                                'format' => '{length: min: foo}, {not blank}',
+                                                'required' => true,
+                                                'readonly' => null
+                                            ),
+                                            'b' => array(
+                                                'dataType' => 'DateTime',
+                                                'actualType' => DataTypes::DATETIME,
+                                                'subType' => null,
+                                                'default' => null,
+                                                'required' => null,
+                                                'readonly' => null,
+                                            )
+                                        )
+                                    ),
+                                    'related' => array(
+                                        'dataType' => 'object (Test)',
+                                        'actualType' => DataTypes::MODEL,
+                                        'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\Test',
+                                        'default' => null,
+                                        'readonly' => false,
+                                        'required' => false,
+                                        'description' => '',
+                                        'sinceVersion' => null,
+                                        'untilVersion' => null,
+                                        'children' => array(
+                                            'a' => array(
+                                                'dataType' => 'string',
+                                                'actualType' => DataTypes::STRING,
+                                                'subType' => null,
+                                                'default' => 'nelmio',
+                                                'format' => '{length: min: foo}, {not blank}',
+                                                'required' => true,
+                                                'readonly' => null
+                                            ),
+                                            'b' => array(
+                                                'dataType' => 'DateTime',
+                                                'actualType' => DataTypes::DATETIME,
+                                                'subType' => null,
+                                                'default' => null,
+                                                'required' => null,
+                                                'readonly' => null
+                                            )
+                                        ),
+                                    )
+                                ),
+                                'authenticationRoles' => array(),
+                            ),
+                        17 =>
+                            array(
+                                'method' => "ANY",
+                                'uri' => "/z-return-selected-parsers-input",
+                                'https' => false,
+                                'authentication' => false,
+                                'deprecated' => false,
+                                'authenticationRoles' => array(),
+                                'parameters' =>
+                                    array(
+                                        'a' => array(
+                                            'dataType' => 'string',
+                                            'actualType' => DataTypes::STRING,
+                                            'subType' => null,
+                                            'default' => null,
+                                            'required' => true,
+                                            'description' => 'A nice description',
+                                            'readonly' => false,
+                                        ),
+                                        'b' => array(
+                                            'dataType' => 'string',
+                                            'actualType' => DataTypes::STRING,
+                                            'subType' => null,
+                                            'default' => null,
+                                            'required' => false,
+                                            'description' => '',
+                                            'readonly' => false,
+                                        ),
+                                        'c' => array(
+                                            'dataType' => 'boolean',
+                                            'actualType' => DataTypes::BOOLEAN,
+                                            'subType' => null,
+                                            'default' => null,
+                                            'required' => true,
+                                            'description' => '',
+                                            'readonly' => false,
+                                        ),
+                                        'd' => array(
+                                            'dataType' => 'string',
+                                            'actualType' => DataTypes::STRING,
+                                            'subType' => null,
+                                            'default' => "DefaultTest",
+                                            'required' => true,
+                                            'description' => '',
+                                            'readonly' => false,
+                                        ),
+                                    )
+                            ),
+                        18 =>
+                            array(
+                                'method' => "ANY",
+                                'uri' => "/z-return-selected-parsers-output",
+                                'https' => false,
+                                'authentication' => false,
+                                'deprecated' => false,
+                                'response' => array(
+                                    'bar' => array(
+                                        'dataType' => 'DateTime',
+                                        'actualType' => DataTypes::DATETIME,
+                                        'subType' => null,
+                                        'default' => null,
+                                        'required' => null,
+                                        'readonly' => null
+                                    ),
+                                    'number' => array(
+                                        'dataType' => 'DateTime',
+                                        'actualType' => DataTypes::DATETIME,
+                                        'subType' => null,
+                                        'default' => null,
+                                        'required' => false,
+                                        'description' => '',
+                                        'readonly' => false,
+                                        'sinceVersion' => null,
+                                        'untilVersion' => null
+                                    ),
+                                    'objects' => array(
+                                        'dataType' => 'array of objects (Test)',
+                                        'actualType' => DataTypes::COLLECTION,
+                                        'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\Test',
+                                        'default' => null,
+                                        'readonly' => null,
+                                        'required' => null,
+                                        'children' => array(
+                                            'a' => array(
+                                                'dataType' => 'string',
+                                                'actualType' => DataTypes::STRING,
+                                                'subType' => null,
+                                                'default' => 'nelmio',
+                                                'format' => '{length: min: foo}, {not blank}',
+                                                'required' => true,
+                                                'readonly' => null
+                                            ),
+                                            'b' => array(
+                                                'dataType' => 'DateTime',
+                                                'actualType' => DataTypes::DATETIME,
+                                                'subType' => null,
+                                                'default' => null,
+                                                'required' => null,
+                                                'readonly' => null
+                                            )
+                                        )
+                                    ),
+                                    'related' => array(
+                                        'dataType' => 'object (Test)',
+                                        'subType' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\Test',
+                                        'actualType' => DataTypes::MODEL,
+                                        'default' => null,
+                                        'readonly' => false,
+                                        'required' => false,
+                                        'description' => '',
+                                        'sinceVersion' => null,
+                                        'untilVersion' => null,
+                                        'children' => array(
+                                            'a' => array(
+                                                'dataType' => 'string',
+                                                'actualType' => DataTypes::STRING,
+                                                'subType' => null,
+                                                'default' => 'nelmio',
+                                                'format' => '{length: min: foo}, {not blank}',
+                                                'required' => true,
+                                                'readonly' => null
+                                            ),
+                                            'b' => array(
+                                                'dataType' => 'DateTime',
+                                                'actualType' => DataTypes::DATETIME,
+                                                'subType' => null,
+                                                'default' => null,
+                                                'required' => null,
+                                                'readonly' => null
+                                            )
+                                        ),
+                                    )
+                                ),
+                                'authenticationRoles' => array(),
+                            ),
+                        19 =>
+                            array(
+                                'cache' => 60,
+                                'method' => 'POST',
+                                'uri' => '/zcached',
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false
+                            ),
+                        20 =>
+                            array(
+                                'authentication' => true,
+                                'method' => 'POST',
+                                'uri' => '/zsecured',
+                                'https' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false
+                            )
+                    ),
+                '/tests2' =>
+                    array(
+                        array(
+                            'method' => 'POST',
+                            'uri' => '/tests2.{_format}',
+                            'description' => 'post test 2',
+                            'requirements' =>
+                                array(
+                                    '_format' =>
+                                        array(
+                                            'requirement' => '',
+                                            'dataType' => '',
+                                            'description' => '',
                                         ),
                                 ),
+                            'https' => false,
+                            'authentication' => false,
+                            'authenticationRoles' => array(),
+                            'deprecated' => false,
                         ),
                     ),
+                '/tests2' =>
                     array(
-                        'method' => 'PUT|PATCH',
-                        'uri' => '/api/other-resources/{id}.{_format}',
-                        'description' => 'Update a resource bu ID.',
-                        'requirements' =>
-                            array(
-                                '_format' =>
-                                    array(
-                                        'requirement' => 'json|xml|html',
-                                        'dataType' => '',
-                                        'description' => '',
-                                    ),
-                                'id' =>
-                                    array(
-                                        'requirement' => '',
-                                        'dataType' => '',
-                                        'description' => '',
-                                    ),
-                            ),
-                        'https' => false,
-                        'authentication' => false,
-                        'authenticationRoles' =>
-                            array(),
-                        'deprecated' => false,
+                        array(
+                            'method' => 'POST',
+                            'uri' => '/tests2.{_format}',
+                            'description' => 'post test 2',
+                            'requirements' =>
+                                array(
+                                    '_format' =>
+                                        array(
+                                            'requirement' => '',
+                                            'dataType' => '',
+                                            'description' => '',
+                                        ),
+                                ),
+                            'https' => false,
+                            'authentication' => false,
+                            'authenticationRoles' => array(),
+                            'deprecated' => false,
+                        ),
                     ),
-                ),
-            '/api/resources' =>
-                array(
+                'TestResource' =>
                     array(
-                        'method' => 'GET',
-                        'uri' => '/api/resources.{_format}',
-                        'description' => 'List resources.',
-                        'requirements' =>
+                        0 =>
                             array(
-                                '_format' =>
-                                    array(
-                                        'requirement' => 'json|xml|html',
-                                        'dataType' => '',
-                                        'description' => '',
-                                    ),
+                                'method' => 'ANY',
+                                'uri' => '/named-resource',
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
                             ),
-                        'statusCodes' =>
-                            array(
-                                200 =>
+                    ),
+                '/api/other-resources' =>
+                    array(
+                        array(
+                            'method' => 'GET',
+                            'uri' => '/api/other-resources.{_format}',
+                            'description' => 'List another resource.',
+                            'requirements' =>
+                                array(
+                                    '_format' =>
+                                        array(
+                                            'requirement' => 'json|xml|html',
+                                            'dataType' => '',
+                                            'description' => '',
+                                        ),
+                                ),
+                            'resourceDescription' => 'Operations on another resource.',
+                            'https' => false,
+                            'authentication' => false,
+                            'authenticationRoles' =>
+                                array(),
+                            'deprecated' => false,
+                            'response' => array(
+                                '' =>
                                     array(
-                                        'Returned on success.',
-                                    ),
-                                404 =>
-                                    array(
-                                        'Returned if resource cannot be found.',
-                                    ),
-                            ),
-                        'resourceDescription' => 'Operations on resource.',
-                        'https' => false,
-                        'authentication' => false,
-                        'authenticationRoles' =>
-                            array(),
-                        'deprecated' => false,
-                        'response' =>
-                            array (
-                                'tests' =>
-                                    array (
-                                        'dataType' => 'array of objects (Test)',
-                                        'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\Test',
+                                        'dataType' => 'array of objects (JmsTest)',
+                                        'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsTest',
                                         'actualType' => 'collection',
                                         'readonly' => true,
                                         'required' => true,
                                         'default' => true,
                                         'description' => '',
                                         'children' =>
-                                            array (
-                                                'a' =>
-                                                    array (
-                                                        'default' => 'nelmio',
-                                                        'actualType' => 'string',
-                                                        'subType' => NULL,
-                                                        'format' => '{length: min: foo}, {not blank}',
-                                                        'required' => true,
-                                                        'dataType' => 'string',
-                                                        'readonly' => NULL,
-                                                    ),
-                                                'b' =>
-                                                    array (
-                                                        'default' => NULL,
-                                                        'actualType' => 'datetime',
-                                                        'subType' => NULL,
-                                                        'dataType' => 'DateTime',
-                                                        'readonly' => NULL,
-                                                        'required' => NULL,
-                                                    ),
-                                            ),
-                                    ),
-                            ),
-                    ),
-                    array(
-                        'method' => 'POST',
-                        'uri' => '/api/resources.{_format}',
-                        'description' => 'Create a new resource.',
-                        'parameters' =>
-                            array(
-                                'a' =>
-                                    array(
-                                        'dataType' => 'string',
-                                        'actualType' => 'string',
-                                        'subType' => NULL,
-                                        'required' => true,
-                                        'description' => 'Something that describes A.',
-                                        'readonly' => false,
-                                        'default' => null,
-                                    ),
-                                'b' =>
-                                    array(
-                                        'dataType' => 'float',
-                                        'actualType' => 'float',
-                                        'subType' => NULL,
-                                        'required' => true,
-                                        'description' => '',
-                                        'readonly' => false,
-                                        'default' => null,
-                                    ),
-                                'c' =>
-                                    array(
-                                        'dataType' => 'choice',
-                                        'actualType' => 'choice',
-                                        'subType' => NULL,
-                                        'required' => true,
-                                        'description' => '',
-                                        'readonly' => false,
-                                        'format' => '{"x":"X","y":"Y","z":"Z"}',
-                                        'default' => null,
-                                    ),
-                                'd' =>
-                                    array(
-                                        'dataType' => 'datetime',
-                                        'actualType' => 'datetime',
-                                        'subType' => NULL,
-                                        'required' => true,
-                                        'description' => '',
-                                        'readonly' => false,
-                                        'default' => null,
-                                    ),
-                                'e' =>
-                                    array(
-                                        'dataType' => 'date',
-                                        'actualType' => 'date',
-                                        'subType' => NULL,
-                                        'required' => true,
-                                        'description' => '',
-                                        'readonly' => false,
-                                        'default' => null,
-                                    ),
-                                'g' =>
-                                    array(
-                                        'dataType' => 'string',
-                                        'actualType' => 'string',
-                                        'subType' => NULL,
-                                        'required' => true,
-                                        'description' => '',
-                                        'readonly' => false,
-                                        'default' => null,
-                                    ),
-                            ),
-                        'requirements' =>
-                            array(
-                                '_format' =>
-                                    array(
-                                        'requirement' => 'json|xml|html',
-                                        'dataType' => '',
-                                        'description' => '',
-                                    ),
-                            ),
-                        'response' =>
-                            array(
-                                'foo' =>
-                                    array(
-                                        'dataType' => 'DateTime',
-                                        'actualType' => 'datetime',
-                                        'default' => null,
-                                        'subType' => NULL,
-                                        'required' => false,
-                                        'description' => '',
-                                        'readonly' => true,
-                                        'sinceVersion' => NULL,
-                                        'untilVersion' => NULL,
-                                    ),
-                                'bar' =>
-                                    array(
-                                        'dataType' => 'string',
-                                        'actualType' => 'string',
-                                        'default' => 'baz',
-                                        'subType' => NULL,
-                                        'required' => false,
-                                        'description' => '',
-                                        'readonly' => false,
-                                        'sinceVersion' => NULL,
-                                        'untilVersion' => NULL,
-                                    ),
-                                'baz' =>
-                                    array(
-                                        'dataType' => 'array of integers',
-                                        'actualType' => 'collection',
-                                        'subType' => 'integer',
-                                        'required' => false,
-                                        'description' => 'Epic description.
-
-With multiple lines.',
-                                        'readonly' => false,
-                                        'sinceVersion' => NULL,
-                                        'default' => null,
-                                        'untilVersion' => NULL,
-                                    ),
-                                'circular' =>
-                                    array(
-                                        'dataType' => 'object (JmsNested)',
-                                        'actualType' => 'model',
-                                        'default' => null,
-                                        'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
-                                        'required' => false,
-                                        'description' => '',
-                                        'readonly' => false,
-                                        'sinceVersion' => NULL,
-                                        'untilVersion' => NULL,
-                                        'children' =>
-                                            array(
-                                                'foo' =>
-                                                    array(
-                                                        'dataType' => 'DateTime',
-                                                        'actualType' => 'datetime',
-                                                        'default' => null,
-                                                        'subType' => NULL,
-                                                        'required' => false,
-                                                        'description' => '',
-                                                        'readonly' => true,
-                                                        'sinceVersion' => NULL,
-                                                        'untilVersion' => NULL,
-                                                    ),
-                                                'bar' =>
-                                                    array(
-                                                        'dataType' => 'string',
-                                                        'actualType' => 'string',
-                                                        'subType' => NULL,
-                                                        'default' => 'baz',
-                                                        'required' => false,
-                                                        'description' => '',
-                                                        'readonly' => false,
-                                                        'sinceVersion' => NULL,
-                                                        'untilVersion' => NULL,
-                                                    ),
-                                                'baz' =>
-                                                    array(
-                                                        'dataType' => 'array of integers',
-                                                        'actualType' => 'collection',
-                                                        'subType' => 'integer',
-                                                        'required' => false,
-                                                        'description' => 'Epic description.
-
-With multiple lines.',
-                                                        'readonly' => false,
-                                                        'sinceVersion' => NULL,
-                                                        'untilVersion' => NULL,
-                                                        'default' => null,
-                                                    ),
-                                                'circular' =>
-                                                    array(
-                                                        'dataType' => 'object (JmsNested)',
-                                                        'actualType' => 'model',
-                                                        'default' => null,
-                                                        'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
-                                                        'required' => false,
-                                                        'description' => '',
-                                                        'readonly' => false,
-                                                        'sinceVersion' => NULL,
-                                                        'untilVersion' => NULL,
-                                                    ),
-                                                'parent' =>
-                                                    array(
-                                                        'dataType' => 'object (JmsTest)',
-                                                        'actualType' => 'model',
-                                                        'default' => null,
-                                                        'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsTest',
-                                                        'required' => false,
-                                                        'description' => '',
-                                                        'readonly' => false,
-                                                        'sinceVersion' => NULL,
-                                                        'untilVersion' => NULL,
-                                                        'children' =>
-                                                            array(
-                                                                'foo' =>
-                                                                    array(
-                                                                        'dataType' => 'string',
-                                                                        'actualType' => 'string',
-                                                                        'subType' => NULL,
-                                                                        'required' => false,
-                                                                        'description' => '',
-                                                                        'readonly' => false,
-                                                                        'sinceVersion' => NULL,
-                                                                        'untilVersion' => NULL,
-                                                                        'default' => null,
-                                                                    ),
-                                                                'bar' =>
-                                                                    array(
-                                                                        'dataType' => 'DateTime',
-                                                                        'actualType' => 'datetime',
-                                                                        'subType' => NULL,
-                                                                        'required' => false,
-                                                                        'description' => '',
-                                                                        'readonly' => true,
-                                                                        'sinceVersion' => NULL,
-                                                                        'untilVersion' => NULL,
-                                                                        'default' => null,
-                                                                    ),
-                                                                'number' =>
-                                                                    array(
-                                                                        'dataType' => 'double',
-                                                                        'actualType' => 'float',
-                                                                        'subType' => NULL,
-                                                                        'required' => false,
-                                                                        'description' => '',
-                                                                        'readonly' => false,
-                                                                        'sinceVersion' => NULL,
-                                                                        'untilVersion' => NULL,
-                                                                        'default' => null,
-                                                                    ),
-                                                                'arr' =>
-                                                                    array(
-                                                                        'dataType' => 'array',
-                                                                        'actualType' => 'collection',
-                                                                        'subType' => NULL,
-                                                                        'required' => false,
-                                                                        'description' => '',
-                                                                        'readonly' => false,
-                                                                        'sinceVersion' => NULL,
-                                                                        'untilVersion' => NULL,
-                                                                        'default' => null,
-                                                                    ),
-                                                                'nested' =>
-                                                                    array(
-                                                                        'dataType' => 'object (JmsNested)',
-                                                                        'actualType' => 'model',
-                                                                        'default' => null,
-                                                                        'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
-                                                                        'required' => false,
-                                                                        'description' => '',
-                                                                        'readonly' => false,
-                                                                        'sinceVersion' => NULL,
-                                                                        'untilVersion' => NULL,
-                                                                    ),
-                                                                'nested_array' =>
-                                                                    array(
-                                                                        'dataType' => 'array of objects (JmsNested)',
-                                                                        'actualType' => 'collection',
-                                                                        'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
-                                                                        'required' => false,
-                                                                        'description' => '',
-                                                                        'readonly' => false,
-                                                                        'sinceVersion' => NULL,
-                                                                        'untilVersion' => NULL,
-                                                                        'default' => null,
-                                                                    ),
-                                                            ),
-                                                    ),
-                                                'since' =>
-                                                    array(
-                                                        'dataType' => 'string',
-                                                        'actualType' => 'string',
-                                                        'subType' => NULL,
-                                                        'required' => false,
-                                                        'description' => '',
-                                                        'readonly' => false,
-                                                        'sinceVersion' => '0.2',
-                                                        'untilVersion' => NULL,
-                                                        'default' => null,
-                                                    ),
-                                                'until' =>
-                                                    array(
-                                                        'dataType' => 'string',
-                                                        'actualType' => 'string',
-                                                        'subType' => NULL,
-                                                        'required' => false,
-                                                        'description' => '',
-                                                        'readonly' => false,
-                                                        'sinceVersion' => NULL,
-                                                        'untilVersion' => '0.3',
-                                                        'default' => null,
-                                                    ),
-                                                'since_and_until' =>
-                                                    array(
-                                                        'dataType' => 'string',
-                                                        'actualType' => 'string',
-                                                        'subType' => NULL,
-                                                        'required' => false,
-                                                        'description' => '',
-                                                        'readonly' => false,
-                                                        'sinceVersion' => '0.4',
-                                                        'untilVersion' => '0.5',
-                                                        'default' => null,
-                                                    ),
-                                            ),
-                                    ),
-                                'parent' =>
-                                    array(
-                                        'dataType' => 'object (JmsTest)',
-                                        'actualType' => 'model',
-                                        'default' => null,
-                                        'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsTest',
-                                        'required' => false,
-                                        'description' => '',
-                                        'readonly' => false,
-                                        'sinceVersion' => NULL,
-                                        'untilVersion' => NULL,
-                                        'children' =>
                                             array(
                                                 'foo' =>
                                                     array(
                                                         'dataType' => 'string',
                                                         'actualType' => 'string',
-                                                        'subType' => NULL,
-                                                        'default' => null,
+                                                        'subType' => null,
                                                         'required' => false,
+                                                        'default' => null,
                                                         'description' => '',
                                                         'readonly' => false,
-                                                        'sinceVersion' => NULL,
-                                                        'untilVersion' => NULL,
+                                                        'sinceVersion' => null,
+                                                        'untilVersion' => null,
                                                     ),
                                                 'bar' =>
                                                     array(
                                                         'dataType' => 'DateTime',
                                                         'actualType' => 'datetime',
-                                                        'subType' => NULL,
+                                                        'subType' => null,
                                                         'required' => false,
+                                                        'default' => null,
                                                         'description' => '',
                                                         'readonly' => true,
-                                                        'sinceVersion' => NULL,
-                                                        'untilVersion' => NULL,
-                                                        'default' => null,
+                                                        'sinceVersion' => null,
+                                                        'untilVersion' => null,
                                                     ),
                                                 'number' =>
                                                     array(
                                                         'dataType' => 'double',
                                                         'actualType' => 'float',
-                                                        'subType' => NULL,
+                                                        'subType' => null,
                                                         'required' => false,
+                                                        'default' => null,
                                                         'description' => '',
                                                         'readonly' => false,
-                                                        'sinceVersion' => NULL,
-                                                        'untilVersion' => NULL,
-                                                        'default' => null,
+                                                        'sinceVersion' => null,
+                                                        'untilVersion' => null,
                                                     ),
                                                 'arr' =>
                                                     array(
                                                         'dataType' => 'array',
                                                         'actualType' => 'collection',
-                                                        'subType' => NULL,
+                                                        'subType' => null,
                                                         'required' => false,
+                                                        'default' => null,
                                                         'description' => '',
                                                         'readonly' => false,
-                                                        'sinceVersion' => NULL,
-                                                        'untilVersion' => NULL,
-                                                        'default' => null,
+                                                        'sinceVersion' => null,
+                                                        'untilVersion' => null,
                                                     ),
                                                 'nested' =>
                                                     array(
                                                         'dataType' => 'object (JmsNested)',
                                                         'actualType' => 'model',
-                                                        'default' => null,
                                                         'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
                                                         'required' => false,
+                                                        'default' => null,
                                                         'description' => '',
                                                         'readonly' => false,
-                                                        'sinceVersion' => NULL,
-                                                        'untilVersion' => NULL,
+                                                        'sinceVersion' => null,
+                                                        'untilVersion' => null,
+                                                        'children' =>
+                                                            array(
+                                                                'foo' =>
+                                                                    array(
+                                                                        'dataType' => 'DateTime',
+                                                                        'actualType' => 'datetime',
+                                                                        'subType' => null,
+                                                                        'required' => false,
+                                                                        'default' => null,
+                                                                        'description' => '',
+                                                                        'readonly' => true,
+                                                                        'sinceVersion' => null,
+                                                                        'untilVersion' => null,
+                                                                    ),
+                                                                'bar' =>
+                                                                    array(
+                                                                        'dataType' => 'string',
+                                                                        'actualType' => 'string',
+                                                                        'subType' => null,
+                                                                        'required' => false,
+                                                                        'default' => 'baz',
+                                                                        'description' => '',
+                                                                        'readonly' => false,
+                                                                        'sinceVersion' => null,
+                                                                        'untilVersion' => null,
+                                                                    ),
+                                                                'baz' =>
+                                                                    array(
+                                                                        'dataType' => 'array of integers',
+                                                                        'actualType' => 'collection',
+                                                                        'subType' => 'integer',
+                                                                        'required' => false,
+                                                                        'default' => null,
+                                                                        'description' => 'Epic description.
+
+With multiple lines.',
+                                                                        'readonly' => false,
+                                                                        'sinceVersion' => null,
+                                                                        'untilVersion' => null,
+                                                                    ),
+                                                                'circular' =>
+                                                                    array(
+                                                                        'dataType' => 'object (JmsNested)',
+                                                                        'actualType' => 'model',
+                                                                        'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                                        'required' => false,
+                                                                        'default' => null,
+                                                                        'description' => '',
+                                                                        'readonly' => false,
+                                                                        'sinceVersion' => null,
+                                                                        'untilVersion' => null,
+                                                                    ),
+                                                                'parent' =>
+                                                                    array(
+                                                                        'dataType' => 'object (JmsTest)',
+                                                                        'actualType' => 'model',
+                                                                        'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsTest',
+                                                                        'required' => false,
+                                                                        'default' => null,
+                                                                        'description' => '',
+                                                                        'readonly' => false,
+                                                                        'sinceVersion' => null,
+                                                                        'untilVersion' => null,
+                                                                        'children' =>
+                                                                            array(
+                                                                                'foo' =>
+                                                                                    array(
+                                                                                        'dataType' => 'string',
+                                                                                        'actualType' => 'string',
+                                                                                        'subType' => null,
+                                                                                        'required' => false,
+                                                                                        'default' => null,
+                                                                                        'description' => '',
+                                                                                        'readonly' => false,
+                                                                                        'sinceVersion' => null,
+                                                                                        'untilVersion' => null,
+                                                                                    ),
+                                                                                'bar' =>
+                                                                                    array(
+                                                                                        'dataType' => 'DateTime',
+                                                                                        'actualType' => 'datetime',
+                                                                                        'subType' => null,
+                                                                                        'required' => false,
+                                                                                        'default' => null,
+                                                                                        'description' => '',
+                                                                                        'readonly' => true,
+                                                                                        'sinceVersion' => null,
+                                                                                        'untilVersion' => null,
+                                                                                    ),
+                                                                                'number' =>
+                                                                                    array(
+                                                                                        'dataType' => 'double',
+                                                                                        'actualType' => 'float',
+                                                                                        'subType' => null,
+                                                                                        'required' => false,
+                                                                                        'default' => null,
+                                                                                        'description' => '',
+                                                                                        'readonly' => false,
+                                                                                        'sinceVersion' => null,
+                                                                                        'untilVersion' => null,
+                                                                                    ),
+                                                                                'arr' =>
+                                                                                    array(
+                                                                                        'dataType' => 'array',
+                                                                                        'actualType' => 'collection',
+                                                                                        'subType' => null,
+                                                                                        'required' => false,
+                                                                                        'default' => null,
+                                                                                        'description' => '',
+                                                                                        'readonly' => false,
+                                                                                        'sinceVersion' => null,
+                                                                                        'untilVersion' => null,
+                                                                                    ),
+                                                                                'nested' =>
+                                                                                    array(
+                                                                                        'dataType' => 'object (JmsNested)',
+                                                                                        'actualType' => 'model',
+                                                                                        'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                                                        'required' => false,
+                                                                                        'default' => null,
+                                                                                        'description' => '',
+                                                                                        'readonly' => false,
+                                                                                        'sinceVersion' => null,
+                                                                                        'untilVersion' => null,
+                                                                                    ),
+                                                                                'nested_array' =>
+                                                                                    array(
+                                                                                        'dataType' => 'array of objects (JmsNested)',
+                                                                                        'actualType' => 'collection',
+                                                                                        'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                                                        'required' => false,
+                                                                                        'default' => null,
+                                                                                        'description' => '',
+                                                                                        'readonly' => false,
+                                                                                        'sinceVersion' => null,
+                                                                                        'untilVersion' => null,
+                                                                                    ),
+                                                                            ),
+                                                                    ),
+                                                                'since' =>
+                                                                    array(
+                                                                        'dataType' => 'string',
+                                                                        'actualType' => 'string',
+                                                                        'subType' => null,
+                                                                        'required' => false,
+                                                                        'default' => null,
+                                                                        'description' => '',
+                                                                        'readonly' => false,
+                                                                        'sinceVersion' => '0.2',
+                                                                        'untilVersion' => null,
+                                                                    ),
+                                                                'until' =>
+                                                                    array(
+                                                                        'dataType' => 'string',
+                                                                        'actualType' => 'string',
+                                                                        'subType' => null,
+                                                                        'required' => false,
+                                                                        'default' => null,
+                                                                        'description' => '',
+                                                                        'readonly' => false,
+                                                                        'sinceVersion' => null,
+                                                                        'untilVersion' => '0.3',
+                                                                    ),
+                                                                'since_and_until' =>
+                                                                    array(
+                                                                        'dataType' => 'string',
+                                                                        'actualType' => 'string',
+                                                                        'subType' => null,
+                                                                        'required' => false,
+                                                                        'default' => null,
+                                                                        'description' => '',
+                                                                        'readonly' => false,
+                                                                        'sinceVersion' => '0.4',
+                                                                        'untilVersion' => '0.5',
+                                                                    ),
+                                                            ),
                                                     ),
                                                 'nested_array' =>
                                                     array(
@@ -2075,111 +3981,600 @@ With multiple lines.',
                                                         'actualType' => 'collection',
                                                         'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
                                                         'required' => false,
+                                                        'default' => null,
                                                         'description' => '',
                                                         'readonly' => false,
-                                                        'sinceVersion' => NULL,
-                                                        'untilVersion' => NULL,
-                                                        'default' => null,
+                                                        'sinceVersion' => null,
+                                                        'untilVersion' => null,
                                                     ),
                                             ),
                                     ),
-                                'since' =>
-                                    array(
-                                        'dataType' => 'string',
-                                        'actualType' => 'string',
-                                        'subType' => NULL,
-                                        'required' => false,
-                                        'description' => '',
-                                        'readonly' => false,
-                                        'sinceVersion' => '0.2',
-                                        'untilVersion' => NULL,
-                                        'default' => null,
-                                    ),
-                                'until' =>
-                                    array(
-                                        'dataType' => 'string',
-                                        'actualType' => 'string',
-                                        'subType' => NULL,
-                                        'required' => false,
-                                        'description' => '',
-                                        'readonly' => false,
-                                        'sinceVersion' => NULL,
-                                        'untilVersion' => '0.3',
-                                        'default' => null,
-                                    ),
-                                'since_and_until' =>
-                                    array(
-                                        'dataType' => 'string',
-                                        'actualType' => 'string',
-                                        'subType' => NULL,
-                                        'required' => false,
-                                        'description' => '',
-                                        'readonly' => false,
-                                        'sinceVersion' => '0.4',
-                                        'untilVersion' => '0.5',
-                                        'default' => null,
-                                    ),
                             ),
-                        'https' => false,
-                        'authentication' => false,
-                        'authenticationRoles' =>
-                            array(),
-                        'deprecated' => false,
+                        ),
+                        array(
+                            'method' => 'PUT|PATCH',
+                            'uri' => '/api/other-resources/{id}.{_format}',
+                            'description' => 'Update a resource bu ID.',
+                            'requirements' =>
+                                array(
+                                    '_format' =>
+                                        array(
+                                            'requirement' => 'json|xml|html',
+                                            'dataType' => '',
+                                            'description' => '',
+                                        ),
+                                    'id' =>
+                                        array(
+                                            'requirement' => '',
+                                            'dataType' => '',
+                                            'description' => '',
+                                        ),
+                                ),
+                            'https' => false,
+                            'authentication' => false,
+                            'authenticationRoles' =>
+                                array(),
+                            'deprecated' => false,
+                        ),
                     ),
+                '/api/resources' =>
                     array(
-                        'method' => 'GET',
-                        'uri' => '/api/resources/{id}.{_format}',
-                        'description' => 'Retrieve a resource by ID.',
-                        'requirements' =>
-                            array(
-                                '_format' =>
-                                    array(
-                                        'requirement' => 'json|xml|html',
-                                        'dataType' => '',
-                                        'description' => '',
-                                    ),
-                                'id' =>
-                                    array(
-                                        'requirement' => '',
-                                        'dataType' => '',
-                                        'description' => '',
-                                    ),
-                            ),
-                        'https' => false,
-                        'authentication' => false,
-                        'authenticationRoles' =>
-                            array(),
-                        'deprecated' => false,
-                    ),
-                    array(
-                        'method' => 'DELETE',
-                        'uri' => '/api/resources/{id}.{_format}',
-                        'description' => 'Delete a resource by ID.',
-                        'requirements' =>
-                            array(
-                                '_format' =>
-                                    array(
-                                        'requirement' => 'json|xml|html',
-                                        'dataType' => '',
-                                        'description' => '',
-                                    ),
-                                'id' =>
-                                    array(
-                                        'requirement' => '',
-                                        'dataType' => '',
-                                        'description' => '',
-                                    ),
-                            ),
-                        'https' => false,
-                        'authentication' => false,
-                        'authenticationRoles' =>
-                            array(),
-                        'deprecated' => false,
-                    ),
-                ),
-        );
+                        array(
+                            'method' => 'GET',
+                            'uri' => '/api/resources.{_format}',
+                            'description' => 'List resources.',
+                            'requirements' =>
+                                array(
+                                    '_format' =>
+                                        array(
+                                            'requirement' => 'json|xml|html',
+                                            'dataType' => '',
+                                            'description' => '',
+                                        ),
+                                ),
+                            'statusCodes' =>
+                                array(
+                                    200 =>
+                                        array(
+                                            'Returned on success.',
+                                        ),
+                                    404 =>
+                                        array(
+                                            'Returned if resource cannot be found.',
+                                        ),
+                                ),
+                            'resourceDescription' => 'Operations on resource.',
+                            'https' => false,
+                            'authentication' => false,
+                            'authenticationRoles' =>
+                                array(),
+                            'deprecated' => false,
+                            'response' =>
+                                array(
+                                    'tests' =>
+                                        array(
+                                            'dataType' => 'array of objects (Test)',
+                                            'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\Test',
+                                            'actualType' => 'collection',
+                                            'readonly' => true,
+                                            'required' => true,
+                                            'default' => true,
+                                            'description' => '',
+                                            'children' =>
+                                                array(
+                                                    'a' =>
+                                                        array(
+                                                            'default' => 'nelmio',
+                                                            'actualType' => 'string',
+                                                            'subType' => NULL,
+                                                            'format' => '{length: min: foo}, {not blank}',
+                                                            'required' => true,
+                                                            'dataType' => 'string',
+                                                            'readonly' => NULL,
+                                                        ),
+                                                    'b' =>
+                                                        array(
+                                                            'default' => NULL,
+                                                            'actualType' => 'datetime',
+                                                            'subType' => NULL,
+                                                            'dataType' => 'DateTime',
+                                                            'readonly' => NULL,
+                                                            'required' => NULL,
+                                                        ),
+                                                ),
+                                        ),
+                                ),
+                        ),
+                        array(
+                            'method' => 'POST',
+                            'uri' => '/api/resources.{_format}',
+                            'description' => 'Create a new resource.',
+                            'parameters' =>
+                                array(
+                                    'a' =>
+                                        array(
+                                            'dataType' => 'string',
+                                            'actualType' => 'string',
+                                            'subType' => NULL,
+                                            'required' => true,
+                                            'description' => 'Something that describes A.',
+                                            'readonly' => false,
+                                            'default' => null,
+                                        ),
+                                    'b' =>
+                                        array(
+                                            'dataType' => 'float',
+                                            'actualType' => 'float',
+                                            'subType' => NULL,
+                                            'required' => true,
+                                            'description' => '',
+                                            'readonly' => false,
+                                            'default' => null,
+                                        ),
+                                    'c' =>
+                                        array(
+                                            'dataType' => 'choice',
+                                            'actualType' => 'choice',
+                                            'subType' => NULL,
+                                            'required' => true,
+                                            'description' => '',
+                                            'readonly' => false,
+                                            'format' => '{"x":"X","y":"Y","z":"Z"}',
+                                            'default' => null,
+                                        ),
+                                    'd' =>
+                                        array(
+                                            'dataType' => 'datetime',
+                                            'actualType' => 'datetime',
+                                            'subType' => NULL,
+                                            'required' => true,
+                                            'description' => '',
+                                            'readonly' => false,
+                                            'default' => null,
+                                        ),
+                                    'e' =>
+                                        array(
+                                            'dataType' => 'date',
+                                            'actualType' => 'date',
+                                            'subType' => NULL,
+                                            'required' => true,
+                                            'description' => '',
+                                            'readonly' => false,
+                                            'default' => null,
+                                        ),
+                                    'g' =>
+                                        array(
+                                            'dataType' => 'string',
+                                            'actualType' => 'string',
+                                            'subType' => NULL,
+                                            'required' => true,
+                                            'description' => '',
+                                            'readonly' => false,
+                                            'default' => null,
+                                        ),
+                                ),
+                            'requirements' =>
+                                array(
+                                    '_format' =>
+                                        array(
+                                            'requirement' => 'json|xml|html',
+                                            'dataType' => '',
+                                            'description' => '',
+                                        ),
+                                ),
+                            'response' =>
+                                array(
+                                    'foo' =>
+                                        array(
+                                            'dataType' => 'DateTime',
+                                            'actualType' => 'datetime',
+                                            'default' => null,
+                                            'subType' => NULL,
+                                            'required' => false,
+                                            'description' => '',
+                                            'readonly' => true,
+                                            'sinceVersion' => NULL,
+                                            'untilVersion' => NULL,
+                                        ),
+                                    'bar' =>
+                                        array(
+                                            'dataType' => 'string',
+                                            'actualType' => 'string',
+                                            'default' => 'baz',
+                                            'subType' => NULL,
+                                            'required' => false,
+                                            'description' => '',
+                                            'readonly' => false,
+                                            'sinceVersion' => NULL,
+                                            'untilVersion' => NULL,
+                                        ),
+                                    'baz' =>
+                                        array(
+                                            'dataType' => 'array of integers',
+                                            'actualType' => 'collection',
+                                            'subType' => 'integer',
+                                            'required' => false,
+                                            'description' => 'Epic description.
 
-        $this->assertEquals($expected, $result);
+With multiple lines.',
+                                            'readonly' => false,
+                                            'sinceVersion' => NULL,
+                                            'default' => null,
+                                            'untilVersion' => NULL,
+                                        ),
+                                    'circular' =>
+                                        array(
+                                            'dataType' => 'object (JmsNested)',
+                                            'actualType' => 'model',
+                                            'default' => null,
+                                            'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                            'required' => false,
+                                            'description' => '',
+                                            'readonly' => false,
+                                            'sinceVersion' => NULL,
+                                            'untilVersion' => NULL,
+                                            'children' =>
+                                                array(
+                                                    'foo' =>
+                                                        array(
+                                                            'dataType' => 'DateTime',
+                                                            'actualType' => 'datetime',
+                                                            'default' => null,
+                                                            'subType' => NULL,
+                                                            'required' => false,
+                                                            'description' => '',
+                                                            'readonly' => true,
+                                                            'sinceVersion' => NULL,
+                                                            'untilVersion' => NULL,
+                                                        ),
+                                                    'bar' =>
+                                                        array(
+                                                            'dataType' => 'string',
+                                                            'actualType' => 'string',
+                                                            'subType' => NULL,
+                                                            'default' => 'baz',
+                                                            'required' => false,
+                                                            'description' => '',
+                                                            'readonly' => false,
+                                                            'sinceVersion' => NULL,
+                                                            'untilVersion' => NULL,
+                                                        ),
+                                                    'baz' =>
+                                                        array(
+                                                            'dataType' => 'array of integers',
+                                                            'actualType' => 'collection',
+                                                            'subType' => 'integer',
+                                                            'required' => false,
+                                                            'description' => 'Epic description.
+
+With multiple lines.',
+                                                            'readonly' => false,
+                                                            'sinceVersion' => NULL,
+                                                            'untilVersion' => NULL,
+                                                            'default' => null,
+                                                        ),
+                                                    'circular' =>
+                                                        array(
+                                                            'dataType' => 'object (JmsNested)',
+                                                            'actualType' => 'model',
+                                                            'default' => null,
+                                                            'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                            'required' => false,
+                                                            'description' => '',
+                                                            'readonly' => false,
+                                                            'sinceVersion' => NULL,
+                                                            'untilVersion' => NULL,
+                                                        ),
+                                                    'parent' =>
+                                                        array(
+                                                            'dataType' => 'object (JmsTest)',
+                                                            'actualType' => 'model',
+                                                            'default' => null,
+                                                            'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsTest',
+                                                            'required' => false,
+                                                            'description' => '',
+                                                            'readonly' => false,
+                                                            'sinceVersion' => NULL,
+                                                            'untilVersion' => NULL,
+                                                            'children' =>
+                                                                array(
+                                                                    'foo' =>
+                                                                        array(
+                                                                            'dataType' => 'string',
+                                                                            'actualType' => 'string',
+                                                                            'subType' => NULL,
+                                                                            'required' => false,
+                                                                            'description' => '',
+                                                                            'readonly' => false,
+                                                                            'sinceVersion' => NULL,
+                                                                            'untilVersion' => NULL,
+                                                                            'default' => null,
+                                                                        ),
+                                                                    'bar' =>
+                                                                        array(
+                                                                            'dataType' => 'DateTime',
+                                                                            'actualType' => 'datetime',
+                                                                            'subType' => NULL,
+                                                                            'required' => false,
+                                                                            'description' => '',
+                                                                            'readonly' => true,
+                                                                            'sinceVersion' => NULL,
+                                                                            'untilVersion' => NULL,
+                                                                            'default' => null,
+                                                                        ),
+                                                                    'number' =>
+                                                                        array(
+                                                                            'dataType' => 'double',
+                                                                            'actualType' => 'float',
+                                                                            'subType' => NULL,
+                                                                            'required' => false,
+                                                                            'description' => '',
+                                                                            'readonly' => false,
+                                                                            'sinceVersion' => NULL,
+                                                                            'untilVersion' => NULL,
+                                                                            'default' => null,
+                                                                        ),
+                                                                    'arr' =>
+                                                                        array(
+                                                                            'dataType' => 'array',
+                                                                            'actualType' => 'collection',
+                                                                            'subType' => NULL,
+                                                                            'required' => false,
+                                                                            'description' => '',
+                                                                            'readonly' => false,
+                                                                            'sinceVersion' => NULL,
+                                                                            'untilVersion' => NULL,
+                                                                            'default' => null,
+                                                                        ),
+                                                                    'nested' =>
+                                                                        array(
+                                                                            'dataType' => 'object (JmsNested)',
+                                                                            'actualType' => 'model',
+                                                                            'default' => null,
+                                                                            'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                                            'required' => false,
+                                                                            'description' => '',
+                                                                            'readonly' => false,
+                                                                            'sinceVersion' => NULL,
+                                                                            'untilVersion' => NULL,
+                                                                        ),
+                                                                    'nested_array' =>
+                                                                        array(
+                                                                            'dataType' => 'array of objects (JmsNested)',
+                                                                            'actualType' => 'collection',
+                                                                            'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                                            'required' => false,
+                                                                            'description' => '',
+                                                                            'readonly' => false,
+                                                                            'sinceVersion' => NULL,
+                                                                            'untilVersion' => NULL,
+                                                                            'default' => null,
+                                                                        ),
+                                                                ),
+                                                        ),
+                                                    'since' =>
+                                                        array(
+                                                            'dataType' => 'string',
+                                                            'actualType' => 'string',
+                                                            'subType' => NULL,
+                                                            'required' => false,
+                                                            'description' => '',
+                                                            'readonly' => false,
+                                                            'sinceVersion' => '0.2',
+                                                            'untilVersion' => NULL,
+                                                            'default' => null,
+                                                        ),
+                                                    'until' =>
+                                                        array(
+                                                            'dataType' => 'string',
+                                                            'actualType' => 'string',
+                                                            'subType' => NULL,
+                                                            'required' => false,
+                                                            'description' => '',
+                                                            'readonly' => false,
+                                                            'sinceVersion' => NULL,
+                                                            'untilVersion' => '0.3',
+                                                            'default' => null,
+                                                        ),
+                                                    'since_and_until' =>
+                                                        array(
+                                                            'dataType' => 'string',
+                                                            'actualType' => 'string',
+                                                            'subType' => NULL,
+                                                            'required' => false,
+                                                            'description' => '',
+                                                            'readonly' => false,
+                                                            'sinceVersion' => '0.4',
+                                                            'untilVersion' => '0.5',
+                                                            'default' => null,
+                                                        ),
+                                                ),
+                                        ),
+                                    'parent' =>
+                                        array(
+                                            'dataType' => 'object (JmsTest)',
+                                            'actualType' => 'model',
+                                            'default' => null,
+                                            'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsTest',
+                                            'required' => false,
+                                            'description' => '',
+                                            'readonly' => false,
+                                            'sinceVersion' => NULL,
+                                            'untilVersion' => NULL,
+                                            'children' =>
+                                                array(
+                                                    'foo' =>
+                                                        array(
+                                                            'dataType' => 'string',
+                                                            'actualType' => 'string',
+                                                            'subType' => NULL,
+                                                            'default' => null,
+                                                            'required' => false,
+                                                            'description' => '',
+                                                            'readonly' => false,
+                                                            'sinceVersion' => NULL,
+                                                            'untilVersion' => NULL,
+                                                        ),
+                                                    'bar' =>
+                                                        array(
+                                                            'dataType' => 'DateTime',
+                                                            'actualType' => 'datetime',
+                                                            'subType' => NULL,
+                                                            'required' => false,
+                                                            'description' => '',
+                                                            'readonly' => true,
+                                                            'sinceVersion' => NULL,
+                                                            'untilVersion' => NULL,
+                                                            'default' => null,
+                                                        ),
+                                                    'number' =>
+                                                        array(
+                                                            'dataType' => 'double',
+                                                            'actualType' => 'float',
+                                                            'subType' => NULL,
+                                                            'required' => false,
+                                                            'description' => '',
+                                                            'readonly' => false,
+                                                            'sinceVersion' => NULL,
+                                                            'untilVersion' => NULL,
+                                                            'default' => null,
+                                                        ),
+                                                    'arr' =>
+                                                        array(
+                                                            'dataType' => 'array',
+                                                            'actualType' => 'collection',
+                                                            'subType' => NULL,
+                                                            'required' => false,
+                                                            'description' => '',
+                                                            'readonly' => false,
+                                                            'sinceVersion' => NULL,
+                                                            'untilVersion' => NULL,
+                                                            'default' => null,
+                                                        ),
+                                                    'nested' =>
+                                                        array(
+                                                            'dataType' => 'object (JmsNested)',
+                                                            'actualType' => 'model',
+                                                            'default' => null,
+                                                            'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                            'required' => false,
+                                                            'description' => '',
+                                                            'readonly' => false,
+                                                            'sinceVersion' => NULL,
+                                                            'untilVersion' => NULL,
+                                                        ),
+                                                    'nested_array' =>
+                                                        array(
+                                                            'dataType' => 'array of objects (JmsNested)',
+                                                            'actualType' => 'collection',
+                                                            'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\JmsNested',
+                                                            'required' => false,
+                                                            'description' => '',
+                                                            'readonly' => false,
+                                                            'sinceVersion' => NULL,
+                                                            'untilVersion' => NULL,
+                                                            'default' => null,
+                                                        ),
+                                                ),
+                                        ),
+                                    'since' =>
+                                        array(
+                                            'dataType' => 'string',
+                                            'actualType' => 'string',
+                                            'subType' => NULL,
+                                            'required' => false,
+                                            'description' => '',
+                                            'readonly' => false,
+                                            'sinceVersion' => '0.2',
+                                            'untilVersion' => NULL,
+                                            'default' => null,
+                                        ),
+                                    'until' =>
+                                        array(
+                                            'dataType' => 'string',
+                                            'actualType' => 'string',
+                                            'subType' => NULL,
+                                            'required' => false,
+                                            'description' => '',
+                                            'readonly' => false,
+                                            'sinceVersion' => NULL,
+                                            'untilVersion' => '0.3',
+                                            'default' => null,
+                                        ),
+                                    'since_and_until' =>
+                                        array(
+                                            'dataType' => 'string',
+                                            'actualType' => 'string',
+                                            'subType' => NULL,
+                                            'required' => false,
+                                            'description' => '',
+                                            'readonly' => false,
+                                            'sinceVersion' => '0.4',
+                                            'untilVersion' => '0.5',
+                                            'default' => null,
+                                        ),
+                                ),
+                            'https' => false,
+                            'authentication' => false,
+                            'authenticationRoles' =>
+                                array(),
+                            'deprecated' => false,
+                        ),
+                        array(
+                            'method' => 'GET',
+                            'uri' => '/api/resources/{id}.{_format}',
+                            'description' => 'Retrieve a resource by ID.',
+                            'requirements' =>
+                                array(
+                                    '_format' =>
+                                        array(
+                                            'requirement' => 'json|xml|html',
+                                            'dataType' => '',
+                                            'description' => '',
+                                        ),
+                                    'id' =>
+                                        array(
+                                            'requirement' => '',
+                                            'dataType' => '',
+                                            'description' => '',
+                                        ),
+                                ),
+                            'https' => false,
+                            'authentication' => false,
+                            'authenticationRoles' =>
+                                array(),
+                            'deprecated' => false,
+                        ),
+                        array(
+                            'method' => 'DELETE',
+                            'uri' => '/api/resources/{id}.{_format}',
+                            'description' => 'Delete a resource by ID.',
+                            'requirements' =>
+                                array(
+                                    '_format' =>
+                                        array(
+                                            'requirement' => 'json|xml|html',
+                                            'dataType' => '',
+                                            'description' => '',
+                                        ),
+                                    'id' =>
+                                        array(
+                                            'requirement' => '',
+                                            'dataType' => '',
+                                            'description' => '',
+                                        ),
+                                ),
+                            'https' => false,
+                            'authentication' => false,
+                            'authenticationRoles' =>
+                                array(),
+                            'deprecated' => false,
+                        ),
+                    ),
+            );
+        }
+
+            $this->assertEquals($expected, $result);
     }
 
     public function testFormatOne()

--- a/Tests/Formatter/SwaggerFormatterTest.php
+++ b/Tests/Formatter/SwaggerFormatterTest.php
@@ -45,54 +45,137 @@ class SwaggerFormatterTest extends WebTestCase
 
         $actual = $this->formatter->format($data, null);
 
-        $expected = array(
-            'swaggerVersion' => '1.2',
-            'apiVersion'     => '3.14',
-            'info'           =>
-                array(
-                    'title'             => 'Nelmio Swagger',
-                    'description'       => 'Testing Swagger integration.',
-                    'TermsOfServiceUrl' => 'https://github.com',
-                    'contact'           => 'user@domain.tld',
-                    'license'           => 'MIT',
-                    'licenseUrl'        => 'http://opensource.org/licenses/MIT',
-                ),
-            'authorizations' =>
-                array(
-                    'apiKey' => array(
-                        'type'    => 'apiKey',
-                        'passAs'  => 'header',
-                        'keyname' => 'access_token',
-                    )
-                ),
-            'apis'           =>
-                array(
-                    array(
-                        'path'        => '/other-resources',
-                        'description' => 'Operations on another resource.',
+        if (class_exists('Dunglas\JsonLdApiBundle\DunglasJsonLdApiBundle')) {
+            $expected = array (
+                'swaggerVersion' => '1.2',
+                'apis' =>
+                    array (
+                        0 =>
+                            array (
+                                'path' => '/other-resources',
+                                'description' => 'Operations on another resource.',
+                            ),
+                        1 =>
+                            array (
+                                'path' => '/resources',
+                                'description' => 'Operations on resource.',
+                            ),
+                        2 =>
+                            array (
+                                'path' => '/tests',
+                                'description' => NULL,
+                            ),
+                        3 =>
+                            array (
+                                'path' => '/tests',
+                                'description' => NULL,
+                            ),
+                        4 =>
+                            array (
+                                'path' => '/tests2',
+                                'description' => NULL,
+                            ),
+                        5 =>
+                            array (
+                                'path' => '/TestResource',
+                                'description' => NULL,
+                            ),
+                        6 =>
+                            array (
+                                'path' => '/others',
+                                'description' => '',
+                            ),
+                        7 =>
+                            array (
+                                'path' => '/others',
+                                'description' => '',
+                            ),
+                        8 =>
+                            array (
+                                'path' => '/others',
+                                'description' => '',
+                            ),
+                        9 =>
+                            array (
+                                'path' => '/others',
+                                'description' => '',
+                            ),
+                        10 =>
+                            array (
+                                'path' => '/others',
+                                'description' => '',
+                            ),
                     ),
-                    array(
-                        'path'        => '/resources',
-                        'description' => 'Operations on resource.',
+                'apiVersion' => '3.14',
+                'info' =>
+                    array (
+                        'title' => 'Nelmio Swagger',
+                        'description' => 'Testing Swagger integration.',
+                        'TermsOfServiceUrl' => 'https://github.com',
+                        'contact' => 'user@domain.tld',
+                        'license' => 'MIT',
+                        'licenseUrl' => 'http://opensource.org/licenses/MIT',
                     ),
-                    array(
-                        'path'        => '/tests',
-                        'description' => null,
+                'authorizations' =>
+                    array (
+                        'apiKey' =>
+                            array (
+                                'type' => 'apiKey',
+                                'passAs' => 'header',
+                                'keyname' => 'access_token',
+                            ),
                     ),
+            );
+        } else {
+            $expected = array(
+                'swaggerVersion' => '1.2',
+                'apiVersion' => '3.14',
+                'info' =>
                     array(
-                        'path'        => '/tests',
-                        'description' => null,
+                        'title' => 'Nelmio Swagger',
+                        'description' => 'Testing Swagger integration.',
+                        'TermsOfServiceUrl' => 'https://github.com',
+                        'contact' => 'user@domain.tld',
+                        'license' => 'MIT',
+                        'licenseUrl' => 'http://opensource.org/licenses/MIT',
                     ),
+                'authorizations' =>
                     array(
-                        'path'        => '/tests2',
-                        'description' => null,
+                        'apiKey' => array(
+                            'type' => 'apiKey',
+                            'passAs' => 'header',
+                            'keyname' => 'access_token',
+                        )
                     ),
+                'apis' =>
                     array(
-                        'path'        => '/TestResource',
-                        'description' => null,
+                        array(
+                            'path' => '/other-resources',
+                            'description' => 'Operations on another resource.',
+                        ),
+                        array(
+                            'path' => '/resources',
+                            'description' => 'Operations on resource.',
+                        ),
+                        array(
+                            'path' => '/tests',
+                            'description' => null,
+                        ),
+                        array(
+                            'path' => '/tests',
+                            'description' => null,
+                        ),
+                        array(
+                            'path' => '/tests2',
+                            'description' => null,
+                        ),
+                        array(
+                            'path' => '/TestResource',
+                            'description' => null,
+                        ),
                     ),
-                ),
-        );
+            );
+        }
 
         $this->assertEquals($expected, $actual);
 

--- a/Tests/Parser/DunglasJsonLdApiParserTest.php
+++ b/Tests/Parser/DunglasJsonLdApiParserTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace NelmioApiDocBundle\Tests\Parser;
+
+use Nelmio\ApiDocBundle\Tests\WebTestCase;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class DunglasJsonLdApiParserTest extends WebTestCase
+{
+    protected function setUp()
+    {
+        if (!class_exists('Dunglas\JsonLdApiBundle\DunglasJsonLdApiBundle')) {
+            $this->markTestSkipped(
+                'DunglasJsonLdApiBundle is not available.'
+            );
+        }
+    }
+
+    public function testParser()
+    {
+        $container = $this->getContainer();
+        $parser = $container->get('nelmio_api_doc.parser.dunglas_json_ld_api_parser');
+
+        $item = array('class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\Popo');
+
+        $expected = array (
+            'foo' =>
+                array (
+                    'required' => false,
+                    'description' => '',
+                    'readonly' => false,
+                    'class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\Popo',
+                    'dataType' => 'string',
+                ),
+        );
+
+        $this->assertTrue($parser->supports($item));
+        $this->assertEquals($expected, $parser->parse($item));
+    }
+}

--- a/Tests/Parser/FormTypeParserTest.php
+++ b/Tests/Parser/FormTypeParserTest.php
@@ -25,7 +25,11 @@ class FormTypeParserTest extends \PHPUnit_Framework_TestCase
         $formFactoryBuilder->addTypeExtension(new DescriptionFormTypeExtension());
         $formFactory = $formFactoryBuilder->getFormFactory();
         $formTypeParser = new FormTypeParser($formFactory);
+
+        set_error_handler(array('Nelmio\ApiDocBundle\Tests\WebTestCase', 'handleDeprecation'));
+        trigger_error('test', E_USER_DEPRECATED);
         $output = $formTypeParser->parse($typeName);
+        restore_error_handler();
 
         $this->assertEquals($expected, $output);
     }

--- a/composer.json
+++ b/composer.json
@@ -30,14 +30,17 @@
         "symfony/validator": "~2.1",
         "symfony/yaml": "~2.1",
         "symfony/form": "~2.1",
+        "symfony/serializer": "~2.7@dev",
         "friendsofsymfony/rest-bundle": "~1.0",
         "jms/serializer-bundle": ">=0.11",
+        "dunglas/json-ld-api-bundle": "dev-master",
         "sensio/framework-extra-bundle": "~3.0"
     },
     "suggest": {
         "symfony/form": "For using form definitions as input.",
         "symfony/validator": "For making use of validator information in the doc.",
         "friendsofsymfony/rest-bundle": "For making use of REST information in the doc.",
+        "dunglas/json-ld-api-bundle": "For making use of resources definitions of DunglasJsonLdApiBundle.",
         "jms/serializer": "For making use of serializer information in the doc."
     },
     "autoload": {


### PR DESCRIPTION
Adds support for https://github.com/dunglas/DunglasJsonLdApiBundle

It automatically generates the documentation from `Resource` definitions. As the bundle discourage the use of custom controllers, I've added a way to provides`ApiDoc` annotation instances without effectively annotating controllers (`AnnotationProviderInterface`).

Optimal config:
```yaml
nelmio_api_doc:
    sandbox:
        accept_type:        "application/json"
        body_format:
            formats:        [ "json" ]
            default_format: "json"
        request_format:
            formats:
                json:       "application/json"
```

TODO:
- [x] Write some tests
