### PR TITLE
Pass children options to subform

### DIFF
--- a/Parser/FormTypeParser.php
+++ b/Parser/FormTypeParser.php
@@ -126,6 +126,7 @@ class FormTypeParser implements ParserInterface
         $parameters = array();
         foreach ($form as $name => $child) {
             $config     = $child->getConfig();
+            $options    = $config->getOptions();
             $bestType   = '';
             $actualType = null;
             $subType    = null;
@@ -171,7 +172,7 @@ class FormTypeParser implements ParserInterface
                          */
                         $addDefault = false;
                         try {
-                            $subForm       = $this->formFactory->create($type);
+                            $subForm       = $this->formFactory->create($type, null, $options);
                             $subParameters = $this->parseForm($subForm, $name);
 
                             if (!empty($subParameters)) {


### PR DESCRIPTION
Hi.
Just a little fix.
When you use a form and you pass options to a subform, into documentation, options are not transmitted.

```php
class MyFrom extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder
            ->add('name', 'text')
            ->add('title', 'text')
            ->add('media', 'media', ['with_url' => false])
        ;
    }
}
```

```php
class MediaType extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        if (true === $options['with_url']) {
            $builder
                ->add('url', 'url')
            ;
        }

        if (true === $options['with_file']) {
            $builder
                ->add('file', 'file')
            ;
        }
    }
}
```