### PR TITLE
New parameters button is available when no parameters are specified

### DIFF
--- a/Resources/views/method.html.twig
+++ b/Resources/views/method.html.twig
@@ -241,8 +241,8 @@
                                         </p>
                                     {% endif %}
                                     {% endfor %}
-                                    <button type="button" class="add_parameter">New parameter</button>
                                 {% endif %}
+                                <button type="button" class="add_parameter">New parameter</button>
 
                             </fieldset>
 


### PR DESCRIPTION
This means when you don't spec out inputs but there is a need for inputs in a generic sense (pagination, api inputs like _method or such) people can add them regardless.