### PR TITLE
Sandbox - don't set Content-Type header when form contains a file type

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -391,13 +391,7 @@
                     // set default bodyFormat
                     var bodyFormat = $('#body_format').val() || '{{ defaultBodyFormat }}';
 
-                    if(!('Content-type' in headers)) {
-                        if (bodyFormat == 'form') {
-                            headers['Content-type'] = 'application/x-www-form-urlencoded';
-                        } else {
-                            headers['Content-type'] = 'application/json';
-                        }
-                    }
+                    
 
                     var hasFileTypes = false;
                     $('.parameters .tuple_type', $(this)).each(function() {
@@ -405,6 +399,14 @@
                             hasFileTypes = true;
                         }
                     });
+                    
+                    if(!hasFileTypes && !('Content-type' in headers)) {
+                        if (bodyFormat == 'form') {
+                            headers['Content-type'] = 'application/x-www-form-urlencoded';
+                        } else {
+                            headers['Content-type'] = 'application/json';
+                        }
+                    }
 
                     if (hasFileTypes && method != 'POST') {
                         alert("Sorry, you can only submit files via POST.");


### PR DESCRIPTION
Setting Content-Type manually when a file is present breaks the multipart request as request boundary is never appended. FormData will automatically append Content-Type=multipart/form-data with the correct multipart boundary if it contains at least one file, so simply omitting the Content-Type fixes this issue