### PR TITLE
No parameter representing sub-form on compound form types

### DIFF
--- a/Parser/FormTypeParser.php
+++ b/Parser/FormTypeParser.php
@@ -175,23 +175,9 @@ class FormTypeParser implements ParserInterface
                             $subParameters = $this->parseForm($subForm, $name);
 
                             if (!empty($subParameters)) {
-                                $children = $subParameters;
-                                $config   = $subForm->getConfig();
-                                $subType  = get_class($type);
-                                $parts    = explode('\\', $subType);
-                                $bestType = sprintf('object (%s)', end($parts));
-
-                                $parameters[$name] = array(
-                                    'dataType'    => $bestType,
-                                    'actualType'  => DataTypes::MODEL,
-                                    'default'     => null,
-                                    'subType'     => $subType,
-                                    'required'    => $config->getRequired(),
-                                    'description' => ($config->getOption('description')) ? $config->getOption('description'):$config->getOption('label'),
-                                    'readonly'    => $config->getDisabled(),
-                                    'children'    => $children,
-                                );
-
+                                foreach ($subParameters as $subName => $subChildren) {
+                                    $parameters[$name.'['.$subName.']'] = $subChildren;
+                                }
                             } else {
                                 $addDefault = true;
                             }

--- a/Tests/Parser/FormTypeParserTest.php
+++ b/Tests/Parser/FormTypeParserTest.php
@@ -394,79 +394,66 @@ class FormTypeParserTest extends \PHPUnit_Framework_TestCase
             array(
                 array('class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Form\CompoundType', 'options' => array()),
                 array (
-                    'sub_form' =>
+                    'sub_form[a]' =>
                         array (
-                            'dataType' => 'object (SimpleType)',
-                            'actualType' => 'model',
-                            'subType' => 'Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Form\\SimpleType',
+                            'dataType' => 'string',
+                            'actualType' => 'string',
+                            'subType' => NULL,
+                            'default' => null,
+                            'required' => true,
+                            'description' => 'Something that describes A.',
+                            'readonly' => false,
+                        ),
+                    'sub_form[b]' =>
+                        array (
+                            'dataType' => 'float',
+                            'actualType' => 'float',
+                            'subType' => NULL,
                             'default' => null,
                             'required' => true,
                             'description' => '',
                             'readonly' => false,
-                            'children' =>
-                                array (
-                                    'a' =>
-                                        array (
-                                            'dataType' => 'string',
-                                            'actualType' => 'string',
-                                            'subType' => NULL,
-                                            'default' => null,
-                                            'required' => true,
-                                            'description' => 'Something that describes A.',
-                                            'readonly' => false,
-                                        ),
-                                    'b' =>
-                                        array (
-                                            'dataType' => 'float',
-                                            'actualType' => 'float',
-                                            'subType' => NULL,
-                                            'default' => null,
-                                            'required' => true,
-                                            'description' => '',
-                                            'readonly' => false,
-                                        ),
-                                    'c' =>
-                                        array (
-                                            'dataType' => 'choice',
-                                            'actualType' => 'choice',
-                                            'subType' => NULL,
-                                            'default' => null,
-                                            'required' => true,
-                                            'description' => '',
-                                            'readonly' => false,
-                                            'format' => '{"x":"X","y":"Y","z":"Z"}',
-                                        ),
-                                    'd' =>
-                                        array (
-                                            'dataType' => 'datetime',
-                                            'actualType' => 'datetime',
-                                            'subType' => NULL,
-                                            'default' => null,
-                                            'required' => true,
-                                            'description' => '',
-                                            'readonly' => false,
-                                        ),
-                                    'e' =>
-                                        array (
-                                            'dataType' => 'date',
-                                            'actualType' => 'date',
-                                            'subType' => NULL,
-                                            'default' => null,
-                                            'required' => true,
-                                            'description' => '',
-                                            'readonly' => false,
-                                        ),
-                                    'g' =>
-                                        array (
-                                            'dataType' => 'string',
-                                            'actualType' => 'string',
-                                            'subType' => NULL,
-                                            'default' => null,
-                                            'required' => true,
-                                            'description' => '',
-                                            'readonly' => false,
-                                        ),
-                                ),
+                        ),
+                    'sub_form[c]' =>
+                        array (
+                            'dataType' => 'choice',
+                            'actualType' => 'choice',
+                            'subType' => NULL,
+                            'default' => null,
+                            'required' => true,
+                            'description' => '',
+                            'readonly' => false,
+                            'format' => '{"x":"X","y":"Y","z":"Z"}',
+                        ),
+                    'sub_form[d]' =>
+                        array (
+                            'dataType' => 'datetime',
+                            'actualType' => 'datetime',
+                            'subType' => NULL,
+                            'default' => null,
+                            'required' => true,
+                            'description' => '',
+                            'readonly' => false,
+                        ),
+                    'sub_form[e]' =>
+                        array (
+                            'dataType' => 'date',
+                            'actualType' => 'date',
+                            'subType' => NULL,
+                            'default' => null,
+                            'required' => true,
+                            'description' => '',
+                            'readonly' => false,
+                        ),
+                    'sub_form[g]' =>
+                        array (
+                            'dataType' => 'string',
+                            'actualType' => 'string',
+                            'subType' => NULL,
+                            'default' => null,
+                            'required' => true,
+                            'description' => '',
+                            'readonly' => false,
                         ),
                     'a' =>
                         array (


### PR DESCRIPTION
On compound forms using sub form, avoid displaying an useless parameter with a type like "object (FooFormType)". Directly displays parameters of the subform instead.

Otherwise, the sandbox will display a useless field requirering an "[object (FooFormType)] Value" above the sub-form parameters themselves.