### PR TITLE
Fix DunglasJsonLdApiBundle support

### DIFF
--- a/DependencyInjection/LoadExtractorParsersPass.php
+++ b/DependencyInjection/LoadExtractorParsersPass.php
@@ -34,7 +34,7 @@ class LoadExtractorParsersPass implements CompilerPassInterface
         }
 
         // DunglasJsonLdApiBundle may or may not be installed, if it is, load that config as well
-        if ($container->hasDefinition('dunglas_json_ld_api.resources')) {
+        if ($container->hasDefinition('dunglas_json_ld_api.resource_collection')) {
             $loader->load('services.dunglas_json_ld_api.xml');
         }
     }

--- a/Extractor/AnnotationsProvider/DunglasJsonLdApiProvider.php
+++ b/Extractor/AnnotationsProvider/DunglasJsonLdApiProvider.php
@@ -12,8 +12,8 @@
 namespace Nelmio\ApiDocBundle\Extractor\AnnotationsProvider;
 
 use Doctrine\Common\Annotations\Reader;
-use Dunglas\JsonLdApiBundle\JsonLd\Resource;
-use Dunglas\JsonLdApiBundle\JsonLd\Resources;
+use Dunglas\JsonLdApiBundle\JsonLd\ResourceCollectionInterface;
+use Dunglas\JsonLdApiBundle\JsonLd\ResourceInterface;
 use Dunglas\JsonLdApiBundle\Mapping\ClassMetadataFactory;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Nelmio\ApiDocBundle\Extractor\AnnotationsProviderInterface;
@@ -26,17 +26,17 @@ use Nelmio\ApiDocBundle\Extractor\AnnotationsProviderInterface;
 class DunglasJsonLdApiProvider implements AnnotationsProviderInterface
 {
     /**
-     * @var Resources
+     * @var ResourceCollectionInterface
      */
-    private $resources;
+    private $resourceCollection;
     /**
      * @var ClassMetadataFactory
      */
     private $classMetadataFactory;
 
-    public function __construct(Resources $resources, ClassMetadataFactory $classMetadataFactory)
+    public function __construct(ResourceCollectionInterface $resourceCollection, ClassMetadataFactory $classMetadataFactory)
     {
-        $this->resources = $resources;
+        $this->resourceCollection = $resourceCollection;
         $this->classMetadataFactory = $classMetadataFactory;
     }
 
@@ -46,7 +46,10 @@ class DunglasJsonLdApiProvider implements AnnotationsProviderInterface
     public function getAnnotations()
     {
         $annotations = [];
-        foreach ($this->resources as $resource) {
+        /**
+         * @var ResourceInterface $resource
+         */
+        foreach ($this->resourceCollection as $resource) {
             $resource->getRouteCollection(); // Populate !route
 
             foreach ($resource->getCollectionOperations() as $operation) {
@@ -64,12 +67,12 @@ class DunglasJsonLdApiProvider implements AnnotationsProviderInterface
     /**
      * Builds ApiDoc annotation from DunglasJsonLdApiBundle data.
      *
-     * @param Resource $resource
-     * @param array $operation
+     * @param ResourceInterface $resource
+     * @param array             $operation
      *
      * @return ApiDoc
      */
-    private function getApiDoc(Resource $resource, array $operation)
+    private function getApiDoc(ResourceInterface $resource, array $operation)
     {
         $data = [
             'resource' => $operation['!route_path'],

--- a/Parser/DunglasJsonLdApiParser.php
+++ b/Parser/DunglasJsonLdApiParser.php
@@ -11,7 +11,8 @@
 
 namespace Nelmio\ApiDocBundle\Parser;
 
-use Dunglas\JsonLdApiBundle\JsonLd\Resources;
+use Dunglas\JsonLdApiBundle\JsonLd\ResourceCollectionInterface;
+use Dunglas\JsonLdApiBundle\JsonLd\ResourceInterface;
 use Dunglas\JsonLdApiBundle\Mapping\ClassMetadataFactory;
 use Nelmio\ApiDocBundle\DataTypes;
 
@@ -23,17 +24,17 @@ use Nelmio\ApiDocBundle\DataTypes;
 class DunglasJsonLdApiParser implements ParserInterface
 {
     /**
-     * @var Resources
+     * @var ResourceCollectionInterface
      */
-    private $resources;
+    private $resourceCollection;
     /**
      * @var ClassMetadataFactory
      */
     private $classMetadataFactory;
 
-    public function __construct(Resources $resources, ClassMetadataFactory $classMetadataFactory)
+    public function __construct(ResourceCollectionInterface $resourceCollection, ClassMetadataFactory $classMetadataFactory)
     {
-        $this->resources = $resources;
+        $this->resourceCollection = $resourceCollection;
         $this->classMetadataFactory = $classMetadataFactory;
     }
 
@@ -42,7 +43,7 @@ class DunglasJsonLdApiParser implements ParserInterface
      */
     public function supports(array $item)
     {
-        return null !== $this->resources->getResourceForEntity($item['class']);
+        return null !== $this->resourceCollection->getResourceForEntity($item['class']);
     }
 
     /**
@@ -51,9 +52,9 @@ class DunglasJsonLdApiParser implements ParserInterface
     public function parse(array $item)
     {
         /**
-         * @var $resource \Dunglas\JsonLdApiBundle\JsonLd\Resource
+         * @var $resource ResourceInterface
          */
-        $resource = $this->resources->getResourceForEntity($item['class']);
+        $resource = $this->resourceCollection->getResourceForEntity($item['class']);
         $classMetadata = $this->classMetadataFactory->getMetadataFor(
             $resource->getEntityClass(),
             $resource->getNormalizationGroups(),
@@ -85,6 +86,8 @@ class DunglasJsonLdApiParser implements ParserInterface
                 }
 
                 $data[$attribute->getName()]['dataType'] = $dataType;
+            } else {
+                $data[$attribute->getName()]['dataType'] = DataTypes::STRING;
             }
         }
 

--- a/Resources/config/services.dunglas_json_ld_api.xml
+++ b/Resources/config/services.dunglas_json_ld_api.xml
@@ -5,14 +5,14 @@
 
     <services>
         <service id="nelmio_api_doc.annotations_provider.dunglas_json_ld_api_annotation_provider" class="Nelmio\ApiDocBundle\Extractor\AnnotationsProvider\DunglasJsonLdApiProvider">
-            <argument type="service" id="dunglas_json_ld_api.resources" />
+            <argument type="service" id="dunglas_json_ld_api.resource_collection" />
             <argument type="service" id="dunglas_json_ld_api.mapping.class_metadata_factory" />
 
             <tag name="nelmio_api_doc.extractor.annotations_provider" />
         </service>
 
         <service id="nelmio_api_doc.parser.dunglas_json_ld_api_parser" class="Nelmio\ApiDocBundle\Parser\DunglasJsonLdApiParser">
-            <argument type="service" id="dunglas_json_ld_api.resources" />
+            <argument type="service" id="dunglas_json_ld_api.resource_collection" />
             <argument type="service" id="dunglas_json_ld_api.mapping.class_metadata_factory" />
 
             <tag name="nelmio_api_doc.extractor.parser" />


### PR DESCRIPTION
* Match the new bundle API
* Type now default to `string` if not automatically guessed (instead of an error before)