### PR TITLE
Add the commas to the prettified JSON

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -319,7 +319,7 @@
                     prettifiedJsonString = prettifiedJsonString.replace(/(\{|\[)\n/g, function(match, sectionOpenCharacter) {
                         return getJsonCollapseHtml(sectionOpenCharacter) + '<span class="json-collapse-content">\n';
                     });
-                    return prettifiedJsonString.replace(/([^\[][\}\]]),?\n/g, '$1</span>\n');
+                    return prettifiedJsonString.replace(/([^\[][\}\]])(,)?\n/g, '$1$2</span>\n');
                 };
 
                 var prettifyResponse = function(text) {

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -319,7 +319,7 @@
                     prettifiedJsonString = prettifiedJsonString.replace(/(\{|\[)\n/g, function(match, sectionOpenCharacter) {
                         return getJsonCollapseHtml(sectionOpenCharacter) + '<span class="json-collapse-content">\n';
                     });
-                    return prettifiedJsonString.replace(/([^\[][\}\]])(,)?\n/g, '$1$2</span>\n');
+                    return prettifiedJsonString.replace(/([^\[][\}\]],?)\n/g, '$1</span>\n');
                 };
 
                 var prettifyResponse = function(text) {


### PR DESCRIPTION
I recently came across that when copying the prettified response there were no comma separating the elements. This solves this problem.