### PR TITLE
allow multi-line return description based on multi-line comments

### DIFF
--- a/Resources/views/method.html.twig
+++ b/Resources/views/method.html.twig
@@ -156,7 +156,7 @@
                                 <td>{{ name }}</td>
                                 <td>{{ infos.dataType }}</td>
                                 <td>{% include 'NelmioApiDocBundle:Components:version.html.twig' with {'sinceVersion': infos.sinceVersion, 'untilVersion': infos.untilVersion} only %}</td>
-                                <td>{{ infos.description }}</td>
+                                <td>{{ infos.description|nl2br }}</td>
                             </tr>
                         {% endfor %}
                     </tbody>


### PR DESCRIPTION
I had a small problem where my output class had larger descriptions of data members like this for example:

    /**
     * Returned on error (status code 400, 403)
     * 400 - Pre-processing error occurred (see message)
     * 403 - Authorization failure occurred (see message)
     * 1050 - API Key is invalid
     * @MongoDB\String @MongoDB\Index(unique=true, order="asc")
     * @Expose
     * @Groups({"User"})
     * @Type("string")
     */
    protected $code;

I wanted that to display nicely in the "Description" of the Return section on separate lines, so just added the twig filter, otherwise the \n's were just being directly put in the description in the output.