### PR TITLE
You should be able to mix parameter settings from other annotations ...

### DIFF
--- a/Extractor/ApiDocExtractor.php
+++ b/Extractor/ApiDocExtractor.php
@@ -283,7 +283,7 @@ class ApiDocExtractor
 
         // input (populates 'parameters' for the formatters)
         if (null !== $input = $annotation->getInput()) {
-            $parameters      = array();
+            $parameters      = $annotation->getParameters();
             $normalizedInput = $this->normalizeClassParameter($input);
 
             $supportedParsers = array();


### PR DESCRIPTION
You should be able to mix parameter settings from other annotations also from the 'parameters' section in den the apidoc. currently you can only use "parameters" or "input". 
if you try to fill from a own apidoc annotation "Nelmio\ApiDocBundle\Extractor\HandlerInterface" the parameters, they will be removed if you define an "input" section.