### PR TITLE
Fix deprecated route options

### DIFF
--- a/Annotation/ApiDoc.php
+++ b/Annotation/ApiDoc.php
@@ -480,8 +480,8 @@ class ApiDoc
             $this->host = null;
         }
 
-        $this->uri    = $route->getPattern();
-        $this->method = $route->getRequirement('_method') ?: 'ANY';
+        $this->uri    = $route->getPath();
+        $this->method = $route->getMethods() ? implode('|', $route->getMethods()) : 'ANY';
     }
 
     /**

--- a/Extractor/ApiDocExtractor.php
+++ b/Extractor/ApiDocExtractor.php
@@ -132,7 +132,7 @@ class ApiDocExtractor
                             $resources[] = $resource;
                         } else {
                             // remove format from routes used for resource grouping
-                            $resources[] = str_replace('.{_format}', '', $route->getPattern());
+                            $resources[] = str_replace('.{_format}', '', $route->getPath());
                         }
                     }
 
@@ -151,10 +151,10 @@ class ApiDocExtractor
         rsort($resources);
         foreach ($array as $index => $element) {
             $hasResource = false;
-            $pattern     = $element['annotation']->getRoute()->getPattern();
+            $path        = $element['annotation']->getRoute()->getPath();
 
             foreach ($resources as $resource) {
-                if (0 === strpos($pattern, $resource) || $resource === $element['annotation']->getResource()) {
+                if (0 === strpos($path, $resource) || $resource === $element['annotation']->getResource()) {
                     $array[$index]['resource'] = $resource;
 
                     $hasResource = true;
@@ -170,14 +170,14 @@ class ApiDocExtractor
         $methodOrder = array('GET', 'POST', 'PUT', 'DELETE');
         usort($array, function ($a, $b) use ($methodOrder) {
             if ($a['resource'] === $b['resource']) {
-                if ($a['annotation']->getRoute()->getPattern() === $b['annotation']->getRoute()->getPattern()) {
-                    $methodA = array_search($a['annotation']->getRoute()->getRequirement('_method'), $methodOrder);
-                    $methodB = array_search($b['annotation']->getRoute()->getRequirement('_method'), $methodOrder);
+                if ($a['annotation']->getRoute()->getPath() === $b['annotation']->getRoute()->getPath()) {
+                    $methodA = array_search($a['annotation']->getRoute()->getMethods(), $methodOrder);
+                    $methodB = array_search($b['annotation']->getRoute()->getMethods(), $methodOrder);
 
                     if ($methodA === $methodB) {
                         return strcmp(
-                            $a['annotation']->getRoute()->getRequirement('_method'),
-                            $b['annotation']->getRoute()->getRequirement('_method')
+                            implode('|', $a['annotation']->getRoute()->getMethods()),
+                            implode('|', $b['annotation']->getRoute()->getMethods())
                         );
                     }
 
@@ -185,8 +185,8 @@ class ApiDocExtractor
                 }
 
                 return strcmp(
-                    $a['annotation']->getRoute()->getPattern(),
-                    $b['annotation']->getRoute()->getPattern()
+                    $a['annotation']->getRoute()->getPath(),
+                    $b['annotation']->getRoute()->getPath()
                 );
             }
 

--- a/Formatter/SwaggerFormatter.php
+++ b/Formatter/SwaggerFormatter.php
@@ -567,17 +567,17 @@ class SwaggerFormatter implements FormatterInterface
     /**
      * Strips the base path from a URL path.
      *
-     * @param $path
+     * @param $basePath
      * @return mixed
      */
-    protected function stripBasePath($path)
+    protected function stripBasePath($basePath)
     {
         if ('/' === $this->basePath) {
-            return $path;
+            return $basePath;
         }
 
-        $pattern = sprintf('#^%s#', preg_quote($this->basePath));
-        $subPath = preg_replace($pattern, '', $path);
+        $path = sprintf('#^%s#', preg_quote($this->basePath));
+        $subPath = preg_replace($path, '', $basePath);
 
         return $subPath;
     }

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,5 +1,4 @@
 nelmio_api_doc_index:
-    pattern: /{view}
+    path: /{view}
+    methods: [GET]
     defaults: { _controller: NelmioApiDocBundle:ApiDoc:index, view: 'default' }
-    requirements:
-        _method: GET

--- a/Resources/config/swagger_routing.yml
+++ b/Resources/config/swagger_routing.yml
@@ -1,11 +1,9 @@
 nelmio_api_doc_swagger_resource_list:
-    pattern: /
+    path: /
+    methods: [GET]
     defaults: { _controller: NelmioApiDocBundle:ApiDoc:swagger }
-    requirements:
-        _method: GET
 
 nelmio_api_doc_swagger_api_declaration:
-    pattern: /{resource}
+    path: /{resource}
+    methods: [GET]
     defaults: { _controller: NelmioApiDocBundle:ApiDoc:swagger }
-    requirements:
-        _method: GET

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -228,8 +228,8 @@ class YourType extends AbstractType
 ```
 
 The bundle will also get information from the routing definition
-(`requirements`, `pattern`, etc), so to get the best out of it you should
-define strict _method requirements etc.
+(`requirements`, `path`, etc), so to get the best out of it you should
+define strict methods requirements etc.
 
 ### Multiple API Documentation ("Views")
 

--- a/Tests/Command/DumpCommandTest.php
+++ b/Tests/Command/DumpCommandTest.php
@@ -88,9 +88,9 @@ class DumpCommandTest extends WebTestCase
                     '/api/resources[0].uri' => '/api/resources.{_format}',
                     '/api/resources[1].method' => 'POST',
                     '/api/resources[1].uri' => '/api/resources.{_format}',
-                    '/api/resources[2].method' => 'GET',
+                    '/api/resources[2].method' => 'DELETE',
                     '/api/resources[2].uri' => '/api/resources/{id}.{_format}',
-                    '/api/resources[3].method' => 'DELETE',
+                    '/api/resources[3].method' => 'GET',
                     '/api/resources[3].uri' => '/api/resources/{id}.{_format}',
                 )
             ),

--- a/Tests/Extractor/ApiDocExtractorTest.php
+++ b/Tests/Extractor/ApiDocExtractorTest.php
@@ -145,7 +145,7 @@ class ApiDocExtractorTest extends WebTestCase
         $this->assertNull($data);
     }
 
-    public function testGetWithInvalidPattern()
+    public function testGetWithInvalidPath()
     {
         $container = $this->getContainer();
         $extractor = $container->get('nelmio_api_doc.extractor.api_doc_extractor');

--- a/Tests/Fixtures/app/config/routing.yml
+++ b/Tests/Fixtures/app/config/routing.yml
@@ -1,207 +1,191 @@
 test_route_1:
-    pattern:  /tests.{_format}
+    path: /tests.{_format}
+    methods: [GET]
     defaults: { _controller: NelmioApiDocTestBundle:Test:index, _format: json }
-    requirements:
-        _method: GET
 
 test_route_2:
-    pattern:  /tests.{_format}
-    host:     api.test.dev
+    path: /tests.{_format}
+    host: api.test.dev
+    methods: [POST]
     defaults: { _controller: NelmioApiDocTestBundle:Test:postTest, _format: json }
-    requirements:
-        _method: POST
 
 test_route_3:
-    pattern:  /another
+    path: /another
     defaults: { _controller: NelmioApiDocTestBundle:Test:another }
 
 test_route_4:
-    pattern:  /any/{foo}
+    path: /any/{foo}
     defaults: { _controller: NelmioApiDocTestBundle:Test:any, _format: json }
 
 test_route_5:
-    pattern:  /my-commented/{id}/{page}/{paramType}/{param}
+    path: /my-commented/{id}/{page}/{paramType}/{param}
     defaults: { _controller: NelmioApiDocTestBundle:Test:myCommented }
 
 test_route_6:
-    pattern:  /yet-another/{id}
+    path: /yet-another/{id}
     defaults: { _controller: NelmioApiDocTestBundle:Test:yetAnother }
     requirements:
         id:  \d+
 
 test_route_7:
-    pattern:  /another-post
+    path: /another-post
+    methods: [POST]
     defaults: { _controller: NelmioApiDocTestBundle:Test:anotherPost, _format: json }
-    requirements:
-        _method: POST
 
 test_route_8:
-    pattern:  /z-action-with-query-param
+    path: /z-action-with-query-param
+    methods: [GET]
     defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithQueryParam }
-    requirements:
-        _method: GET
 
 test_route_9:
-    pattern: /jms-input-test
+    path: /jms-input-test
+    methods: [POST]
     defaults: { _controller: NelmioApiDocTestBundle:Test:jmsInputTest }
-    requirements:
-        _method: POST
 
 test_route_10:
-    pattern: /jms-return-test
+    path: /jms-return-test
+    methods: [GET]
     defaults: { _controller: NelmioApiDocTestBundle:Test:jmsReturnTest }
-    requirements:
-        _method: GET
 
 test_route_11:
-    pattern:  /z-action-with-request-param
+    path: /z-action-with-request-param
+    methods: [POST]
     defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithRequestParam }
-    requirements:
-        _method: POST
 
 test_route_12:
-    pattern: /secure-route
+    path: /secure-route
+    schemes: [https]
     defaults: { _controller: NelmioApiDocTestBundle:Test:secureRoute }
-    requirements:
-        _scheme: https
 
 test_route_13:
-    pattern: /authenticated
+    path: /authenticated
     defaults: { _controller: NelmioApiDocTestBundle:Test:authenticated }
 
 test_service_route_1:
-    pattern:  /tests.{_format}
+    path: /tests.{_format}
+    methods: [GET]
     defaults: { _controller: nelmio.test.controller:indexAction, _format: json }
-    requirements:
-        _method: GET
 
 test_service_route_2:
-    pattern:  /tests.{_format}
-    host:     api.test.dev
+    path: /tests.{_format}
+    host: api.test.dev
+    methods: [POST]
     defaults: { _controller: nelmio.test.controller:postTestAction, _format: json }
-    requirements:
-        _method: POST
 
 test_service_route_3:
-    pattern:  /another
+    path: /another
     defaults: { _controller: nelmio.test.controller:anotherAction }
 
 test_service_route_4:
-    pattern:  /any
+    path: /any
     defaults: { _controller: nelmio.test.controller:anyAction, _format: json }
 
 NelmioApiDocBundle:
     resource: "@NelmioApiDocBundle/Resources/config/routing.yml"
-    prefix:   /
+    prefix: /
 
 test_route_14:
-    pattern:  /tests2.{_format}
+    path: /tests2.{_format}
+    methods: [POST]
     defaults: { _controller: NelmioApiDocTestBundle:Test:postTest2, _format: json }
-    requirements:
-        _method: POST
 
 test_route_15:
-    pattern:  /z-action-with-query-param-strict
+    path: /z-action-with-query-param-strict
+    methods: [GET]
     defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithQueryParamStrict }
-    requirements:
-        _method: GET
 
 test_route_16:
-    pattern:  /z-action-with-query-param-no-default
+    path: /z-action-with-query-param-no-default
+    methods: [GET]
     defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithQueryParamNoDefault }
-    requirements:
-        _method: GET
 
 test_route_17:
-    pattern:  /z-action-with-deprecated-indicator
+    path: /z-action-with-deprecated-indicator
+    methods: [GET]
     defaults: { _controller: NelmioApiDocTestBundle:Test:deprecated }
-    requirements:
-        _method: GET
 
 test_return_nested_output:
-    pattern: /return-nested-output
+    path: /return-nested-output
     defaults: { _controller: NelmioApiDocTestBundle:Test:jmsReturnNestedOutput, _format: json }
 
 test_return_nested_extend_output:
-    pattern: /return-nested-extend-output
+    path: /return-nested-extend-output
     defaults: { _controller: NelmioApiDocTestBundle:Test:jmsReturnNestedExtendOutput, _format: json }
 
 test_route_18:
-    pattern: /z-return-jms-and-validator-output
+    path: /z-return-jms-and-validator-output
     defaults: { _controller: NelmioApiDocTestBundle:Test:zReturnJmsAndValidationOutput }
 
 test_route_named_resource:
-    pattern:  /named-resource
+    path: /named-resource
     defaults: { _controller: NelmioApiDocTestBundle:Test:namedResource }
 
 test_route_19:
-    pattern: /z-return-selected-parsers-output
+    path: /z-return-selected-parsers-output
     defaults: { _controller: NelmioApiDocTestBundle:Test:zReturnSelectedParsersOutput }
 
 test_route_20:
-    pattern: /z-return-selected-parsers-input
+    path: /z-return-selected-parsers-input
     defaults: { _controller: NelmioApiDocTestBundle:Test:zReturnSelectedParsersInput }
 
 test_route_private:
-    pattern: /private
+    path: /private
     defaults: { _controller: NelmioApiDocTestBundle:Test:private }
 
 test_route_exclusive:
-    pattern: /exclusive
+    path: /exclusive
     defaults: { _controller: NelmioApiDocTestBundle:Test:exclusive }
 
 test_route_21:
-    pattern:  /z-action-with-constraint-requirements
+    path: /z-action-with-constraint-requirements
+    methods: [GET]
     defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithConstraintAsRequirements }
-    requirements:
-        _method: GET
 
 test_route_22:
-    pattern:  /z-action-with-nullable-request-param
+    path: /z-action-with-nullable-request-param
+    methods: [POST]
     defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithNullableRequestParam }
-    requirements:
-        _method: POST
 
 test_route_list_resource:
-    pattern: /api/resources.{_format}
+    path: /api/resources.{_format}
+    methods: [GET]
     defaults: { _controller: NelmioApiDocTestBundle:Resource:listResources, _format: json }
     requirements:
-        _method: GET
         _format: json|xml|html
 
 test_route_get_resource:
-    pattern: /api/resources/{id}.{_format}
+    path: /api/resources/{id}.{_format}
+    methods: [GET]
     defaults: { _controller: NelmioApiDocTestBundle:Resource:getResource, _format: json }
     requirements:
-        _method: GET
         _format: json|xml|html
 
 test_route_delete_resource:
-    pattern: /api/resources/{id}.{_format}
+    path: /api/resources/{id}.{_format}
+    methods: [DELETE]
     defaults: { _controller: NelmioApiDocTestBundle:Resource:deleteResource, _format: json }
     requirements:
-        _method: DELETE
         _format: json|xml|html
 
 test_route_create_resource:
-    pattern: /api/resources.{_format}
+    path: /api/resources.{_format}
+    methods: [POST]
     defaults: { _controller: NelmioApiDocTestBundle:Resource:createResource, _format: json }
     requirements:
-        _method: POST
         _format: json|xml|html
 
 test_route_list_another_resource:
-    pattern: /api/other-resources.{_format}
+    path: /api/other-resources.{_format}
+    methods: [GET]
     defaults: { _controller: NelmioApiDocTestBundle:Resource:listAnotherResources, _format: json }
     requirements:
-        _method: GET
         _format: json|xml|html
 
 test_route_update_another_resource:
-    pattern: /api/other-resources/{id}.{_format}
+    path: /api/other-resources/{id}.{_format}
+    methods: [PUT, PATCH]
     defaults: { _controller: NelmioApiDocTestBundle:Resource:updateAnotherResource, _format: json }
     requirements:
-        _method: PUT|PATCH
         _format: json|xml|html
 
 swagger_doc:
@@ -209,39 +193,35 @@ swagger_doc:
     prefix: /api-docs
 
 test_route_23:
-    pattern:  /zcached
+    path: /zcached
+    methods: [POST]
     defaults: { _controller: NelmioApiDocTestBundle:Test:zCached }
-    requirements:
-        _method: POST
 
 test_route_24:
-    pattern:  /zsecured
+    path: /zsecured
+    methods: [POST]
     defaults: { _controller: NelmioApiDocTestBundle:Test:zSecured }
-    requirements:
-        _method: POST
 
 test_required_parameters:
-    pattern: /api/other-resources/{id}.{_format}
+    path: /api/other-resources/{id}.{_format}
+    methods: [POST]
     defaults: { _controller: NelmioApiDocTestBundle:Resource:requiredParametersAction, _format: json }
     requirements:
-        _method: POST
         _format: json|xml|html
 
 test_put_disables_required_parameters:
-    pattern: /api/other-resources/{id}.{_format}
+    path: /api/other-resources/{id}.{_format}
+    methods: [PUT]
     defaults: { _controller: NelmioApiDocTestBundle:Resource:requiredParametersAction, _format: json }
     requirements:
-        _method: PUT
         _format: json|xml|html
 
 test_route_25:
-    pattern:  /with-link
+    path: /with-link
+    methods: [GET]
     defaults: { _controller: NelmioApiDocTestBundle:Test:withLinkAction }
-    requirements:
-        _method: GET
 
 test_route_26:
-    pattern:  /z-action-with-array-request-param
+    path:  /z-action-with-array-request-param
+    methods: [POST]
     defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithArrayRequestParamAction }
-    requirements:
-        _method: POST

--- a/Tests/Formatter/MarkdownFormatterTest.php
+++ b/Tests/Formatter/MarkdownFormatterTest.php
@@ -426,9 +426,9 @@ since_and_until:
   * versions: >=0.4,<=0.5
 
 
-### `GET` /api/resources/{id}.{_format} ###
+### `DELETE` /api/resources/{id}.{_format} ###
 
-_Retrieve a resource by ID._
+_Delete a resource by ID._
 
 #### Requirements ####
 
@@ -439,9 +439,9 @@ _Retrieve a resource by ID._
 
 
 
-### `DELETE` /api/resources/{id}.{_format} ###
+### `GET` /api/resources/{id}.{_format} ###
 
-_Delete a resource by ID._
+_Retrieve a resource by ID._
 
 #### Requirements ####
 

--- a/Tests/Formatter/SimpleFormatterTest.php
+++ b/Tests/Formatter/SimpleFormatterTest.php
@@ -866,9 +866,9 @@ With multiple lines.',
                             ),
                         2 =>
                             array (
-                                'method' => 'GET',
+                                'method' => 'DELETE',
                                 'uri' => '/api/resources/{id}.{_format}',
-                                'description' => 'Retrieve a resource by ID.',
+                                'description' => 'Delete a resource by ID.',
                                 'requirements' =>
                                     array (
                                         '_format' =>
@@ -893,9 +893,9 @@ With multiple lines.',
                             ),
                         3 =>
                             array (
-                                'method' => 'DELETE',
+                                'method' => 'GET',
                                 'uri' => '/api/resources/{id}.{_format}',
-                                'description' => 'Delete a resource by ID.',
+                                'description' => 'Retrieve a resource by ID.',
                                 'requirements' =>
                                     array (
                                         '_format' =>
@@ -1673,6 +1673,30 @@ And, it supports multilines until the first \'@\' char.',
                             ),
                         9 =>
                             array (
+                                'method' => 'DELETE',
+                                'uri' => '/popos/{id}',
+                                'description' => 'Deletes the Popo resource.',
+                                'documentation' => 'Deletes an element of the collection.',
+                                'requirements' =>
+                                    array (
+                                        'id' =>
+                                            array (
+                                                'dataType' => 'string',
+                                                'description' => '',
+                                                'requirement' => '',
+                                            ),
+                                    ),
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                                'resourceDescription' => 'Popo',
+                                'section' => 'Popo',
+                            ),
+                        10 =>
+                            array (
                                 'method' => 'GET',
                                 'uri' => '/popos/{id}',
                                 'description' => 'Retrieves Popo resource.',
@@ -1705,7 +1729,7 @@ And, it supports multilines until the first \'@\' char.',
                                 'resourceDescription' => 'Popo',
                                 'section' => 'Popo',
                             ),
-                        10 =>
+                        11 =>
                             array (
                                 'method' => 'PUT',
                                 'uri' => '/popos/{id}',
@@ -1738,30 +1762,6 @@ And, it supports multilines until the first \'@\' char.',
                                                 'description' => '',
                                                 'readonly' => false,
                                                 'dataType' => 'string',
-                                            ),
-                                    ),
-                                'https' => false,
-                                'authentication' => false,
-                                'authenticationRoles' =>
-                                    array (
-                                    ),
-                                'deprecated' => false,
-                                'resourceDescription' => 'Popo',
-                                'section' => 'Popo',
-                            ),
-                        11 =>
-                            array (
-                                'method' => 'DELETE',
-                                'uri' => '/popos/{id}',
-                                'description' => 'Deletes the Popo resource.',
-                                'documentation' => 'Deletes an element of the collection.',
-                                'requirements' =>
-                                    array (
-                                        'id' =>
-                                            array (
-                                                'dataType' => 'string',
-                                                'description' => '',
-                                                'requirement' => '',
                                             ),
                                     ),
                                 'https' => false,

--- a/Tests/Formatter/SwaggerFormatterTest.php
+++ b/Tests/Formatter/SwaggerFormatterTest.php
@@ -338,11 +338,10 @@ class SwaggerFormatterTest extends WebTestCase
                                 'path'       => '/resources/{id}.{_format}',
                                 'operations' =>
                                     array(
-
                                         array(
-                                            'method'           => 'GET',
-                                            'summary'          => 'Retrieve a resource by ID.',
-                                            'nickname'         => 'get_resources',
+                                            'method'           => 'DELETE',
+                                            'summary'          => 'Delete a resource by ID.',
+                                            'nickname'         => 'delete_resources',
                                             'parameters'       =>
                                                 array(
 
@@ -369,9 +368,9 @@ class SwaggerFormatterTest extends WebTestCase
                                                 array(),
                                         ),
                                         array(
-                                            'method'           => 'DELETE',
-                                            'summary'          => 'Delete a resource by ID.',
-                                            'nickname'         => 'delete_resources',
+                                            'method'           => 'GET',
+                                            'summary'          => 'Retrieve a resource by ID.',
+                                            'nickname'         => 'get_resources',
                                             'parameters'       =>
                                                 array(
 

--- a/change
+++ b/change
@@ -35,3 +35,4 @@
 * Fixed: endpoint is undefined in sandbox when custom_endpoint is disabled
 * Fixed: the wrong endpoint value check when no endpoint is set in config
 * Fixed: Swagger commands
+* Fixed: Deprecated usage of routes configuration since Symfony 2.2


### PR DESCRIPTION
This PR fix deprecated routing config throwing related errors:

> The "pattern" is deprecated since version 2.2 and will be removed in 3.0. Use the "path" option in the route definition instead.

> The "_method" requirement is deprecated since version 2.2 and will be removed in 3.0. Use the setMethods() method instead or the "methods" option in the route definition.

> The "_scheme" requirement is deprecated since version 2.2 and will be removed in 3.0. Use the setSchemes() method instead or the "schemes" option in the route definition.

We have to bump `symfony/framework-bundle` to `~2.2` version. Not a big deal because 2.1 is not maintained anymore.