### PR TITLE
Add documentation statement about twig dependency

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -38,6 +38,14 @@ Enable the bundle's configuration in `app/config/config.yml`:
 nelmio_api_doc: ~
 ```
 
+The **NelmioApiDocBundle** requires Twig as a template engine so do not forget to enable it:
+```yaml
+# app/config/config.yml
+framework:
+    templating:
+        engines: ['twig']
+```
+
 Usage
 -----
 


### PR DESCRIPTION
I built a Symfony2 API without twig, so when I first added NelmioApiDocBundle it returned a not-rendered twig template, juste like https://github.com/nelmio/NelmioApiDocBundle/issues/350 . It took me some time to understand the issue so it might be worth a statement in the doc, to save other people's time).