### PR TITLE
Updated PhpDocHandler::handle()

### DIFF
--- a/Annotation/ApiDoc.php
+++ b/Annotation/ApiDoc.php
@@ -276,8 +276,8 @@ class ApiDoc
             }
         }
 
-        if (isset($data['https'])) {
-            $this->https = $data['https'];
+        if (isset($data['https']) && null !== $https = filter_var($data['https'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)) {
+            $this->https = $https;
         }
 
         if (isset($data['resourceDescription'])) {

--- a/Extractor/Handler/PhpDocHandler.php
+++ b/Extractor/Handler/PhpDocHandler.php
@@ -61,8 +61,8 @@ class PhpDocHandler implements HandlerInterface
             }
         }
 
-        if (method_exists($route, 'getSchemes')) {
-            $annotation->setHttps(in_array('https', $route->getSchemes()));
+        if (method_exists($route, 'getSchemes') && $schemes = $route->getSchemes()) {
+            $annotation->setHttps(in_array('https', $schemes));
         }
 
         $paramDocs = array();

--- a/Tests/Extractor/ApiDocExtractorTest.php
+++ b/Tests/Extractor/ApiDocExtractorTest.php
@@ -19,7 +19,7 @@ class ApiDocExtractorTest extends WebTestCase
 {
     const NB_ROUTES_ADDED_BY_DUNGLAS_API_BUNDLE = 5;
 
-    private static $ROUTES_QUANTITY_DEFAULT = 33; // Routes in the default view
+    private static $ROUTES_QUANTITY_DEFAULT = 36; // Routes in the default view
     private static $ROUTES_QUANTITY_PREMIUM = 6;  // Routes in the premium view
     private static $ROUTES_QUANTITY_TEST    = 2;  // Routes in the test view
 

--- a/Tests/Fixtures/Controller/TestController.php
+++ b/Tests/Fixtures/Controller/TestController.php
@@ -334,4 +334,13 @@ class TestController
     public function withLinkAction()
     {
     }
+
+    /**
+     * @ApiDoc(
+     *     https="true"
+     * )
+     */
+    public function requiredHttpsSchemeAction()
+    {
+    }
 }

--- a/Tests/Fixtures/app/config/routing.yml
+++ b/Tests/Fixtures/app/config/routing.yml
@@ -245,3 +245,19 @@ test_route_26:
     defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithArrayRequestParamAction }
     requirements:
         _method: POST
+
+test_route_27:
+    path:  /zz-https-required
+    defaults: { _controller: NelmioApiDocTestBundle:Test:requiredHttpsScheme }
+    requirements:
+        _scheme: https
+
+test_route_28:
+    path:  /zz-http-required
+    defaults: { _controller: NelmioApiDocTestBundle:Test:requiredHttpsScheme }
+    requirements:
+        _scheme: http
+
+test_route_29:
+    path:  /zz-https-not-required
+    defaults: { _controller: NelmioApiDocTestBundle:Test:requiredHttpsScheme }

--- a/Tests/Formatter/MarkdownFormatterTest.php
+++ b/Tests/Formatter/MarkdownFormatterTest.php
@@ -1033,6 +1033,18 @@ related[b]:
 
 
 ### `POST` /zsecured ###
+
+
+
+### `ANY` /zz-http-required ###
+
+
+
+### `ANY` /zz-https-not-required ###
+
+
+
+### `ANY` /zz-https-required ###
 MARKDOWN;
         } else {
             $expected = <<<MARKDOWN
@@ -1958,6 +1970,18 @@ related[b]:
 
 
 ### `POST` /zsecured ###
+
+
+
+### `ANY` /zz-http-required ###
+
+
+
+### `ANY` /zz-https-not-required ###
+
+
+
+### `ANY` /zz-https-required ###
 MARKDOWN;
         }
 

--- a/Tests/Formatter/SimpleFormatterTest.php
+++ b/Tests/Formatter/SimpleFormatterTest.php
@@ -2459,6 +2459,39 @@ With multiple lines.',
                                     ),
                                 'deprecated' => false,
                             ),
+                        26 =>
+                            array (
+                                'method' => 'ANY',
+                                'uri' => '/zz-http-required',
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        27 =>
+                            array (
+                                'method' => 'ANY',
+                                'uri' => '/zz-https-not-required',
+                                'https' => true,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
+                        28 =>
+                            array (
+                                'method' => 'ANY',
+                                'uri' => '/zz-https-required',
+                                'https' => true,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                            ),
                     ),
             );
         } else {
@@ -3707,7 +3740,34 @@ With multiple lines.',
                                 'https' => false,
                                 'authenticationRoles' => array(),
                                 'deprecated' => false
-                            )
+                            ),
+                        21 =>
+                            array (
+                                'method' => 'ANY',
+                                'uri' => '/zz-http-required',
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
+                            ),
+                        22 =>
+                            array (
+                                'method' => 'ANY',
+                                'uri' => '/zz-https-not-required',
+                                'https' => true,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
+                            ),
+                        23 =>
+                            array (
+                                'method' => 'ANY',
+                                'uri' => '/zz-https-required',
+                                'https' => true,
+                                'authentication' => false,
+                                'authenticationRoles' => array(),
+                                'deprecated' => false,
+                            ),
                     ),
                 '/tests2' =>
                     array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #608
| License       | MIT
| Doc PR        |

Updated ```PhpDocHandler::handle()``` in order to override ```ApiDoc::$https```
only when ```Route::$schemes``` is not empty.

**TODO:**
- [x] Fix tests

Fixes #608.