### PR TITLE
Fix deprecated forms setDefaultOptions method

### DIFF
--- a/Form/Extension/DescriptionFormTypeExtension.php
+++ b/Form/Extension/DescriptionFormTypeExtension.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class DescriptionFormTypeExtension extends AbstractTypeExtension
@@ -37,8 +38,15 @@ class DescriptionFormTypeExtension extends AbstractTypeExtension
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Remove it when bumping requirements to Symfony 2.7+
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'description' => '',


### PR DESCRIPTION
This PR fixes deprecated notices since SF 2.7.

Symfony 2.3+ BC kept.