### PR TITLE
Styles for lists inside .content

### DIFF
--- a/Resources/public/css/screen.css
+++ b/Resources/public/css/screen.css
@@ -118,6 +118,11 @@ pre {
   line-height:1.2em;
 }
 
+div.content ul, div.content ol {
+  line-height: 1.4em;
+  color: #333333;
+}
+
 table.fullwidth {
   width: 100%;
 }


### PR DESCRIPTION
Hello,

I have added styles for the ul and ol tags inside the content of an operation. You can see here the before:

![api documentation](https://cloud.githubusercontent.com/assets/680660/7768035/b872961c-0077-11e5-9b2b-88559bf11219.png)

An the after:
![api documentation2](https://cloud.githubusercontent.com/assets/680660/7768037/bb002af2-0077-11e5-8f93-e3551d1eb0ac.png)

The change is straightforward, I think that it doesn't need more explanations :)

Regards!