### PR TITLE
Add view option to api:doc:dump command

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -11,6 +11,7 @@
 
 namespace Nelmio\ApiDocBundle\Command;
 
+use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -33,6 +34,7 @@ class DumpCommand extends ContainerAwareCommand
                 'Output format like: ' . implode(', ', $this->availableFormats),
                 $this->availableFormats[0]
             )
+            ->addOption('view', '', InputOption::VALUE_OPTIONAL, '', ApiDoc::DEFAULT_VIEW)
             ->addOption('no-sandbox', '', InputOption::VALUE_NONE)
             ->setName('api:doc:dump')
             ;
@@ -41,6 +43,8 @@ class DumpCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $format = $input->getOption('format');
+        $view = $input->getOption('view');
+
         $routeCollection = $this->getContainer()->get('router')->getRouteCollection();
 
         if (!$input->hasOption('format') || in_array($format, array('json'))) {
@@ -62,7 +66,7 @@ class DumpCommand extends ContainerAwareCommand
             $this->getContainer()->set('request', new Request(), 'request');
         }
 
-        $extractedDoc = $this->getContainer()->get('nelmio_api_doc.extractor.api_doc_extractor')->all();
+        $extractedDoc = $this->getContainer()->get('nelmio_api_doc.extractor.api_doc_extractor')->all($view);
         $formattedDoc = $formatter->format($extractedDoc);
 
         if ('json' === $format) {

--- a/Tests/Command/DumpCommandTest.php
+++ b/Tests/Command/DumpCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace NelmioApiDocBundle\Tests\Command;
+
+use Nelmio\ApiDocBundle\Tests\WebTestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\ApplicationTester;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
+class DumpCommandTest extends WebTestCase
+{
+    /**
+     * @dataProvider viewProvider
+     *
+     * @param string $view Command view option value
+     * @param array $expectedMethodsCount Expected resource methods count
+     * @param array $expectedMethodValues Expected resource method values
+     */
+    public function testDumpWithViewOption($view, array $expectedMethodsCount, array $expectedMethodValues)
+    {
+        $this->getContainer();
+
+        $application = new Application(static::$kernel);
+        $application->setCatchExceptions(false);
+        $application->setAutoExit(false);
+
+        $tester = new ApplicationTester($application);
+
+        $input = array(
+            'command' => 'api:doc:dump',
+            '--view' => $view,
+            '--format' => 'json',
+        );
+        $tester->run($input);
+
+        $display = $tester->getDisplay();
+
+        $this->assertJson($display);
+
+        $json = json_decode($display);
+
+        $accessor = PropertyAccess::createPropertyAccessor();
+
+        foreach ($expectedMethodsCount as $propertyPath => $expectedCount) {
+            $this->assertCount($expectedCount, $accessor->getValue($json, $propertyPath));
+        }
+
+        foreach ($expectedMethodValues as $propertyPath => $expectedValue) {
+            $this->assertEquals($expectedValue, $accessor->getValue($json, $propertyPath));
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public static function viewProvider()
+    {
+        return array(
+            'test' => array(
+                'test',
+                array(
+                    '/api/resources' => 1,
+                ),
+                array(
+                    '/api/resources[0].method' => 'GET',
+                    '/api/resources[0].uri' => '/api/resources.{_format}',
+                )
+            ),
+            'premium' => array(
+                'premium',
+                array(
+                    '/api/resources' => 2,
+                ),
+                array(
+                    '/api/resources[0].method' => 'GET',
+                    '/api/resources[0].uri' => '/api/resources.{_format}',
+                    '/api/resources[1].method' => 'POST',
+                    '/api/resources[1].uri' => '/api/resources.{_format}',
+                )
+            ),
+            'default' => array(
+                'default',
+                array(
+                    '/api/resources' => 4,
+                ),
+                array(
+                    '/api/resources[0].method' => 'GET',
+                    '/api/resources[0].uri' => '/api/resources.{_format}',
+                    '/api/resources[1].method' => 'POST',
+                    '/api/resources[1].uri' => '/api/resources.{_format}',
+                    '/api/resources[2].method' => 'GET',
+                    '/api/resources[2].uri' => '/api/resources/{id}.{_format}',
+                    '/api/resources[3].method' => 'DELETE',
+                    '/api/resources[3].uri' => '/api/resources/{id}.{_format}',
+                )
+            ),
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "symfony/validator": "~2.1",
         "symfony/yaml": "~2.1",
         "symfony/form": "~2.1",
+        "symfony/finder": "~2.1",
         "symfony/serializer": "~2.7@dev",
         "friendsofsymfony/rest-bundle": "~1.0",
         "jms/serializer-bundle": ">=0.11",


### PR DESCRIPTION
Add _--view_ option to _api:doc:dump_ command to be able to dump docs only for provided view.