### PR TITLE
Handle "array" parameter in FOSRestBundle QueryParam or RequestParam

### DIFF
--- a/Extractor/Handler/FosRestHandler.php
+++ b/Extractor/Handler/FosRestHandler.php
@@ -33,7 +33,7 @@ class FosRestHandler implements HandlerInterface
                 $requirements = $this->handleRequirements($annot->requirements);
                 $data = array(
                     'required'    => $annot->strict && $annot->nullable === false && $annot->default === null,
-                    'dataType'    => $requirements,
+                    'dataType'    => $requirements.($annot->array ? '[]' : ''),
                     'actualType'  => $this->inferType($requirements),
                     'subType'     => null,
                     'description' => $annot->description,
@@ -46,19 +46,19 @@ class FosRestHandler implements HandlerInterface
             } elseif ($annot instanceof QueryParam) {
                 if ($annot->strict && $annot->nullable === false && $annot->default === null) {
                     $annotation->addRequirement($annot->name, array(
-                        'requirement'   => $this->handleRequirements($annot->requirements),
+                        'requirement'   => $this->handleRequirements($annot->requirements).($annot->array ? '[]' : ''),
                         'dataType'      => '',
                         'description'   => $annot->description,
                     ));
                 } elseif ($annot->default !== null) {
                     $annotation->addFilter($annot->name, array(
-                        'requirement'   => $this->handleRequirements($annot->requirements),
+                        'requirement'   => $this->handleRequirements($annot->requirements).($annot->array ? '[]' : ''),
                         'description'   => $annot->description,
                         'default'   => $annot->default,
                     ));
                 } else {
                     $annotation->addFilter($annot->name, array(
-                        'requirement'   => $this->handleRequirements($annot->requirements),
+                        'requirement'   => $this->handleRequirements($annot->requirements).($annot->array ? '[]' : ''),
                         'description'   => $annot->description,
                     ));
                 }

--- a/Tests/Extractor/Handler/FosRestHandlerTest.php
+++ b/Tests/Extractor/Handler/FosRestHandlerTest.php
@@ -156,4 +156,22 @@ class FosRestHandlerTest extends WebTestCase
 
         $this->assertArrayNotHasKey('default', $parameter);
     }
+
+    public function testPostWithArrayRequestParam()
+    {
+        $container  = $this->getContainer();
+        $extractor  = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
+        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\TestController::zActionWithArrayRequestParamAction', 'test_route_26');
+
+        $this->assertNotNull($annotation);
+
+        $parameters = $annotation->getParameters();
+        $this->assertCount(1, $parameters);
+        $this->assertArrayHasKey('param1', $parameters);
+
+        $parameter = $parameters['param1'];
+
+        $this->assertArrayHasKey('dataType', $parameter);
+        $this->assertEquals('string[]', $parameter['dataType']);
+    }
 }

--- a/Tests/Fixtures/Controller/TestController.php
+++ b/Tests/Fixtures/Controller/TestController.php
@@ -191,6 +191,14 @@ class TestController
 
     /**
      * @ApiDoc()
+     * @RequestParam(name="param1", requirements="string", array=true)
+     */
+    public function zActionWithArrayRequestParamAction()
+    {
+    }
+
+    /**
+     * @ApiDoc()
      */
     public function secureRouteAction()
     {

--- a/Tests/Fixtures/app/config/routing.yml
+++ b/Tests/Fixtures/app/config/routing.yml
@@ -239,3 +239,9 @@ test_route_25:
     defaults: { _controller: NelmioApiDocTestBundle:Test:withLinkAction }
     requirements:
         _method: GET
+
+test_route_26:
+    pattern:  /z-action-with-array-request-param
+    defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithArrayRequestParamAction }
+    requirements:
+        _method: POST


### PR DESCRIPTION
It allows to display `[]` after a requirement when `array` is defined. 

Not a big fan of the duplication of `$annot->array` test, but was not fan of modifying `handleRequirements` for accepting the annotation directly (and not only the parameter)