### PR TITLE
Include Symfony 2.7 stable on Travis and improve configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,26 +13,35 @@ php:
   - nightly
   - hhvm
 
+env:
+    global:
+        - SYMFONY_DEPRECATIONS_HELPER=weak
+
 matrix:
     include:
         - php: 5.6
-          env: SYMFONY_VERSION='2.3.*'
+          env: SYMFONY_VERSION=2.3.*
         - php: 5.6
-          env: SYMFONY_VERSION='2.4.*'
+          env: SYMFONY_VERSION=2.4.*
         - php: 5.6
-          env: SYMFONY_VERSION='2.6.*'
+          env: SYMFONY_VERSION=2.6.*
         - php: 5.6
-          env: SYMFONY_VERSION='dev-master'
+          env: SYMFONY_VERSION=2.7.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.8.*@dev
+        - php: 5.6
+          env: SYMFONY_VERSION="3.0.x-dev as 2.8"
     allow_failures:
-        - php: 5.6
-          env: SYMFONY_VERSION='dev-master'
         - php: nightly
+        - env: SYMFONY_VERSION=2.8.*@dev
+        - env: SYMFONY_VERSION="3.0.x-dev as 2.8"
     fast_finish: true
 
 before_script:
     - composer self-update
-    - sh -c 'if [ "$SYMFONY_VERSION" != "dev-master" ] && [ "$SYMFONY_VERSION" != "2.6.*" ]; then sed -i "/dunglas\/api-bundle/d;/symfony\/serializer/d" composer.json; fi;'
-    - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi;'
+    - if [ "$SYMFONY_VERSION" = "2.8.*@dev" ] || [ "$SYMFONY_VERSION" = "3.0.x-dev as 2.8" ]; then SYMFONY_DEPRECATIONS_HELPER=strict; fi;
+    - if [ "$SYMFONY_VERSION" != "3.0.x-dev as 2.8" ] && [ "$SYMFONY_VERSION" != "2.7.*" ]; then sed -i "/dunglas\/api-bundle/d;/symfony\/serializer/d" composer.json; fi;
+    - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
     - composer install
 
 script: phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "friendsofsymfony/rest-bundle": "~1.0",
         "jms/serializer-bundle": ">=0.11",
         "dunglas/api-bundle": "dev-master",
-        "sensio/framework-extra-bundle": "~3.0"
+        "sensio/framework-extra-bundle": "~3.0",
+        "symfony/phpunit-bridge": "~2.7"
     },
     "suggest": {
         "symfony/form": "For using form definitions as input.",


### PR DESCRIPTION
Also added `symfony/phpunit-bridge` to handle deprecated issues with ease.

Tests will fail because of deprecation (see #636).

Route config issues are solved on #614. I'll take look for form issues on another PR.