### PR TITLE
Fix deprecated FormType::setDefaultOptions usage

### DIFF
--- a/Form/Extension/DescriptionFormTypeExtension.php
+++ b/Form/Extension/DescriptionFormTypeExtension.php
@@ -46,6 +46,9 @@ class DescriptionFormTypeExtension extends AbstractTypeExtension
         $this->configureOptions($resolver);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(

--- a/Tests/Fixtures/Form/DependencyType.php
+++ b/Tests/Fixtures/Form/DependencyType.php
@@ -13,6 +13,7 @@ namespace Nelmio\ApiDocBundle\Tests\Fixtures\Form;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class DependencyType extends AbstractType
@@ -32,9 +33,19 @@ class DependencyType extends AbstractType
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritdoc}
+     *
+     * @deprecated Remove it when bumping requirements to Symfony 2.7+
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\Test',

--- a/Tests/Fixtures/Form/EntityType.php
+++ b/Tests/Fixtures/Form/EntityType.php
@@ -14,15 +14,25 @@ namespace Nelmio\ApiDocBundle\Tests\Fixtures\Form;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class EntityType extends AbstractType
 {
-
     /**
-     * {@inheritdoc}
+     * {@inheritdoc}
+     *
+     * @deprecated Remove it when bumping requirements to Symfony 2.7+
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\EntityTest',

--- a/Tests/Fixtures/Form/ImprovedTestType.php
+++ b/Tests/Fixtures/Form/ImprovedTestType.php
@@ -5,6 +5,7 @@ namespace Nelmio\ApiDocBundle\Tests\Fixtures\Form;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class ImprovedTestType extends AbstractType
@@ -31,9 +32,19 @@ class ImprovedTestType extends AbstractType
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritdoc}
+     *
+     * @deprecated Remove it when bumping requirements to Symfony 2.7+
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\ImprovedTest',

--- a/Tests/Fixtures/Form/RequireConstructionType.php
+++ b/Tests/Fixtures/Form/RequireConstructionType.php
@@ -13,6 +13,7 @@ namespace Nelmio\ApiDocBundle\Tests\Fixtures\Form;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class RequireConstructionType extends AbstractType
@@ -38,9 +39,19 @@ class RequireConstructionType extends AbstractType
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritdoc}
+     *
+     * @deprecated Remove it when bumping requirements to Symfony 2.7+
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\Test',

--- a/Tests/Fixtures/Form/TestType.php
+++ b/Tests/Fixtures/Form/TestType.php
@@ -13,6 +13,7 @@ namespace Nelmio\ApiDocBundle\Tests\Fixtures\Form;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class TestType extends AbstractType
@@ -31,9 +32,19 @@ class TestType extends AbstractType
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritdoc}
+     *
+     * @deprecated Remove it when bumping requirements to Symfony 2.7+
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Nelmio\ApiDocBundle\Tests\Fixtures\Model\Test',


### PR DESCRIPTION
Related to #636.

Symfony 2.3+ BC kept.

Failing test about routing configuration are fixed in #614.