### PR TITLE
DunglasApiBundle name converter support

### DIFF
--- a/Parser/DunglasApiParser.php
+++ b/Parser/DunglasApiParser.php
@@ -17,6 +17,7 @@ use Dunglas\ApiBundle\Mapping\AttributeMetadataInterface;
 use Dunglas\ApiBundle\Mapping\ClassMetadataFactoryInterface;
 use Nelmio\ApiDocBundle\DataTypes;
 use PropertyInfo\Type;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 /**
  * Use DunglasApiBundle to extract input and output information.
@@ -47,10 +48,12 @@ class DunglasApiParser implements ParserInterface
 
     public function __construct(
         ResourceCollectionInterface $resourceCollection,
-        ClassMetadataFactoryInterface $classMetadataFactory
+        ClassMetadataFactoryInterface $classMetadataFactory,
+        NameConverterInterface $nameConverter = null
     ) {
         $this->resourceCollection = $resourceCollection;
         $this->classMetadataFactory = $classMetadataFactory;
+        $this->nameConverter = $nameConverter;
     }
 
     /**
@@ -101,7 +104,11 @@ class DunglasApiParser implements ParserInterface
                 ($attributeMetadata->isReadable() && self::OUT_PREFIX === $io) ||
                 ($attributeMetadata->isWritable() && self::IN_PREFIX === $io)
             ) {
-                $data[$attributeMetadata->getName()] = $this->parseAttribute($resource, $attributeMetadata, $io);
+                $attributeName = $attributeMetadata->getName();
+                if ($this->nameConverter) {
+                    $attributeName = $this->nameConverter->normalize($attributeName);
+                }
+                $data[$attributeName] = $this->parseAttribute($resource, $attributeMetadata, $io);
             }
         }
 

--- a/Resources/config/services.dunglas_api.xml
+++ b/Resources/config/services.dunglas_api.xml
@@ -15,6 +15,7 @@
         <service id="nelmio_api_doc.parser.dunglas_api_parser" class="Nelmio\ApiDocBundle\Parser\DunglasApiParser">
             <argument type="service" id="api.resource_collection" />
             <argument type="service" id="api.mapping.class_metadata_factory" />
+            <argument type="service" id="api.name_converter" on-invalid="ignore" />
 
             <tag name="nelmio_api_doc.extractor.parser" />
         </service>

--- a/Tests/Fixtures/Model/Popo.php
+++ b/Tests/Fixtures/Model/Popo.php
@@ -25,4 +25,9 @@ class Popo
      * @var string
      */
     public $foo;
+
+    /**
+     * @var string
+     */
+    public $nameConverted;
 }

--- a/Tests/Fixtures/app/config/dunglas_api.yml
+++ b/Tests/Fixtures/app/config/dunglas_api.yml
@@ -16,6 +16,9 @@ dunglas_api:
     description: Test API
 
 services:
+    api.name_converter:
+        class: Dunglas\ApiBundle\Tests\Behat\TestBundle\Serializer\NameConverter\CustomConverter
+
     dunglas_json_ld_api.popo:
         parent:    "api.resource"
         arguments: [ "Nelmio\\ApiDocBundle\\Tests\\Fixtures\\Model\\Popo" ]

--- a/Tests/Formatter/MarkdownFormatterTest.php
+++ b/Tests/Formatter/MarkdownFormatterTest.php
@@ -680,6 +680,10 @@ foo:
 
   * type: string
 
+name_converted:
+
+  * type: string
+
 
 ### `POST` /popos ###
 
@@ -692,9 +696,18 @@ foo:
   * type: string
   * required: false
 
+name_converted:
+
+  * type: string
+  * required: false
+
 #### Response ####
 
 foo:
+
+  * type: string
+
+name_converted:
 
   * type: string
 
@@ -712,6 +725,10 @@ _Retrieves Popo resource._
 #### Response ####
 
 foo:
+
+  * type: string
+
+name_converted:
 
   * type: string
 
@@ -733,9 +750,18 @@ foo:
   * type: string
   * required: false
 
+name_converted:
+
+  * type: string
+  * required: false
+
 #### Response ####
 
 foo:
+
+  * type: string
+
+name_converted:
 
   * type: string
 

--- a/Tests/Formatter/SimpleFormatterTest.php
+++ b/Tests/Formatter/SimpleFormatterTest.php
@@ -1626,6 +1626,13 @@ And, it supports multilines until the first \'@\' char.',
                                                 'readonly' => false,
                                                 'dataType' => 'string',
                                             ),
+                                        'name_converted' =>
+                                            array (
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'dataType' => 'string',
+                                            ),
                                     ),
                                 'https' => false,
                                 'authentication' => false,
@@ -1650,10 +1657,24 @@ And, it supports multilines until the first \'@\' char.',
                                                 'readonly' => false,
                                                 'dataType' => 'string',
                                             ),
+                                        'name_converted' =>
+                                            array (
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'dataType' => 'string',
+                                            ),
                                     ),
                                 'response' =>
                                     array (
                                         'foo' =>
+                                            array (
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'dataType' => 'string',
+                                            ),
+                                        'name_converted' =>
                                             array (
                                                 'required' => false,
                                                 'description' => '',
@@ -1693,6 +1714,13 @@ And, it supports multilines until the first \'@\' char.',
                                                 'readonly' => false,
                                                 'dataType' => 'string',
                                             ),
+                                        'name_converted' =>
+                                            array (
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'dataType' => 'string',
+                                            ),
                                     ),
                                 'https' => false,
                                 'authentication' => false,
@@ -1717,6 +1745,13 @@ And, it supports multilines until the first \'@\' char.',
                                                 'readonly' => false,
                                                 'dataType' => 'string',
                                             ),
+                                        'name_converted' =>
+                                            array (
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'dataType' => 'string',
+                                            ),
                                     ),
                                 'requirements' =>
                                     array (
@@ -1730,6 +1765,13 @@ And, it supports multilines until the first \'@\' char.',
                                 'response' =>
                                     array (
                                         'foo' =>
+                                            array (
+                                                'required' => false,
+                                                'description' => '',
+                                                'readonly' => false,
+                                                'dataType' => 'string',
+                                            ),
+                                        'name_converted' =>
                                             array (
                                                 'required' => false,
                                                 'description' => '',

--- a/Tests/Parser/DunglasApiParserTest.php
+++ b/Tests/Parser/DunglasApiParserTest.php
@@ -44,6 +44,13 @@ class DunglasApiParserTest extends WebTestCase
                     'readonly' => false,
                     'dataType' => DataTypes::STRING,
                 ),
+            'name_converted' =>
+                array (
+                    'required' => false,
+                    'description' => '',
+                    'readonly' => false,
+                    'dataType' => DataTypes::STRING,
+                ),
         );
 
         $this->assertTrue($parser->supports($item));


### PR DESCRIPTION
This follows up https://github.com/dunglas/DunglasApiBundle/pull/94 were serializer name converters are properly handled when building the Json-Ld context.
Properties names should also be converted using the specified converter in the documentation & sandbox, hence this PR.

Ping @dunglas 