### PR TITLE
Added pipe to escaped symbols of jQuery selector

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -86,7 +86,7 @@
             };
 
             $(window).load(function() {
-                var id = getHash().substr(1).replace( /([:\.\[\]\{\}])/g, "\\$1");
+                var id = getHash().substr(1).replace( /([:\.\[\]\{\}|])/g, "\\$1");
                 var elem = $('#' + id);
                 if (elem.length) {
                     setTimeout(function() {


### PR DESCRIPTION
Pipe symbol needs to be escaped in jQuery selector.
This symbol is added when multiple methods are allowed for a route.
e.g /api/doc#get|post--...