### PR TITLE
Prevent error "Undefined index" when no subtype provided

### DIFF
--- a/Extractor/ApiDocExtractor.php
+++ b/Extractor/ApiDocExtractor.php
@@ -534,7 +534,7 @@ class ApiDocExtractor
     {
         foreach ($array as $name => $info) {
 
-            if (empty($info['dataType'])) {
+            if (empty($info['dataType']) && isset($info['subType'])) {
                 $array[$name]['dataType'] = $this->generateHumanReadableType($info['actualType'], $info['subType']);
             }
 


### PR DESCRIPTION
I don't know if this is intended or not, but `$info['subType']` was not defined after a clean installation. I'm using NelmioApiDocBundle with DunglasApiBundle.