### PR TITLE
Implemented new ApiDocDefaults annotation to set a default section on…

### DIFF
--- a/Annotation/ApiDocDefaults.php
+++ b/Annotation/ApiDocDefaults.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Annotation;
+
+use Symfony\Component\Routing\Route;
+
+/**
+ * @Annotation
+ */
+class ApiDocDefaults
+{
+    /**
+     * Section to group actions together.
+     *
+     * @var string
+     */
+    private $section = null;
+
+    public function __construct(array $data)
+    {
+        if (isset($data['section'])) {
+            $this->section = $data['section'];
+        }
+    }
+
+    /**
+     * @param string $section
+     */
+    public function setSection($section)
+    {
+        $this->section = $section;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSection()
+    {
+        return $this->section;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        $data = array();
+
+        if ($section = $this->section) {
+            $data['section'] = $section;
+        }
+
+        return $data;
+    }
+}

--- a/Tests/Annotation/ApiDocDefaultsTest.php
+++ b/Tests/Annotation/ApiDocDefaultsTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Annotation;
+
+use Nelmio\ApiDocBundle\Annotation\ApiDoc;
+use Nelmio\ApiDocBundle\Annotation\ApiDocDefaults;
+use Nelmio\ApiDocBundle\Tests\TestCase;
+
+class ApiDocDefaultsTest extends TestCase
+{
+    public function testConstructorWithoutParams()
+    {
+        $annotation = new ApiDocDefaults(array());
+
+        $this->assertEmpty($annotation->getSection());
+    }
+
+    public function testConstructorWithSection()
+    {
+        $section = 'Blah!';
+
+        $annotation = new ApiDocDefaults(array(
+            'section' => $section,
+        ));
+
+        $this->assertSame($section, $annotation->getSection());
+    }
+
+    public function testSectionGetterAndSetter()
+    {
+        $section = 'Bar!';
+
+        $annotation = new ApiDocDefaults(array());
+        $annotation->setSection($section);
+
+        $this->assertSame($section, $annotation->getSection());
+    }
+
+    public function testToArrayWithoutDataReturnsEmptyArray()
+    {
+        $annotation = new ApiDocDefaults(array());
+
+        $this->assertSame(array(), $annotation->toArray());
+    }
+
+    public function testToArrayWithDataReturnsFilledArray()
+    {
+        $section = 'Foo';
+
+        $annotiation = new ApiDocDefaults(array());
+
+        $annotiation->setSection($section);
+
+        $this->assertSame(
+            array(
+                'section' => $section,
+            ),
+            $annotiation->toArray()
+        );
+    }
+}

--- a/Tests/Extractor/ApiDocExtractorTest.php
+++ b/Tests/Extractor/ApiDocExtractorTest.php
@@ -13,13 +13,14 @@ namespace Nelmio\ApiDocBundle\Tests\Extractor;
 
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Nelmio\ApiDocBundle\Extractor\ApiDocExtractor;
+use Nelmio\ApiDocBundle\Tests\Fixtures\Controller\ConcreteController;
 use Nelmio\ApiDocBundle\Tests\WebTestCase;
 
 class ApiDocExtractorTest extends WebTestCase
 {
     const NB_ROUTES_ADDED_BY_DUNGLAS_API_BUNDLE = 5;
 
-    private static $ROUTES_QUANTITY_DEFAULT = 33; // Routes in the default view
+    private static $ROUTES_QUANTITY_DEFAULT = 35; // Routes in the default view
     private static $ROUTES_QUANTITY_PREMIUM = 6;  // Routes in the premium view
     private static $ROUTES_QUANTITY_TEST    = 2;  // Routes in the test view
 
@@ -39,7 +40,7 @@ class ApiDocExtractorTest extends WebTestCase
         $data = $extractor->all();
         restore_error_handler();
 
-        $httpsKey = 20;
+        $httpsKey = 22;
         if (class_exists('Dunglas\ApiBundle\DunglasApiBundle')) {
             $httpsKey += self::NB_ROUTES_ADDED_BY_DUNGLAS_API_BUNDLE;
         }
@@ -369,5 +370,25 @@ class ApiDocExtractorTest extends WebTestCase
 
         $this->assertTrue(is_array($data));
         $this->assertCount($count, $data);
+    }
+
+    public function testInheritedActionGetsApiDocDefaultsAssigned()
+    {
+        $container = $this->getContainer();
+        $extractor = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
+
+        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\ConcreteController::indexAction', 'test_route_inheritance');
+
+        $this->assertSame(ConcreteController::SECTION, $annotation->getSection());
+    }
+
+    public function testInheritedActionWithOwnAttributesWillNotBeOverwritten()
+    {
+        $container = $this->getContainer();
+        $extractor = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
+
+        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\ConcreteController::ownAttributesAction', 'test_route_inheritance_own_attributes');
+
+        $this->assertSame(ConcreteController::OWN_SECTION, $annotation->getSection());
     }
 }

--- a/Tests/Fixtures/Controller/AbstractController.php
+++ b/Tests/Fixtures/Controller/AbstractController.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Fixtures\Controller;
+
+use FOS\RestBundle\Controller\Annotations\QueryParam;
+use FOS\RestBundle\Controller\Annotations\RequestParam;
+use Nelmio\ApiDocBundle\Annotation\ApiDoc;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints\Email;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+
+abstract class AbstractController
+{
+    const OWN_SECTION = 'Blah';
+
+    /**
+     * @ApiDoc(
+     *  description="index action",
+     * )
+     */
+    public function indexAction()
+    {
+        return new Response('tests');
+    }
+
+    /**
+     * @ApiDoc(
+     *  description="index action",
+     *  section="Blah",
+     * )
+     */
+    public function ownAttributesAction()
+    {
+        return new Response('test');
+    }
+}

--- a/Tests/Fixtures/Controller/ConcreteController.php
+++ b/Tests/Fixtures/Controller/ConcreteController.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle.
+ *
+ * (c) Nelmio <hello@nelm.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Fixtures\Controller;
+
+use FOS\RestBundle\Controller\Annotations\QueryParam;
+use FOS\RestBundle\Controller\Annotations\RequestParam;
+use Nelmio\ApiDocBundle\Annotation\ApiDoc;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints\Email;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Nelmio\ApiDocBundle\Annotation\ApiDocDefaults;
+
+/**
+ * @ApiDocDefaults(section="FooSection")
+ */
+class ConcreteController extends AbstractController
+{
+    const SECTION = 'FooSection';
+}

--- a/Tests/Fixtures/app/config/routing.yml
+++ b/Tests/Fixtures/app/config/routing.yml
@@ -245,3 +245,12 @@ test_route_26:
     defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithArrayRequestParamAction }
     requirements:
         _method: POST
+
+test_route_inheritance:
+    pattern: /inherticance
+    defaults: { _controller: NelmioApiDocTestBundle:Concrete:index }
+
+
+test_route_inheritance_own_attributes:
+    pattern: /inherticance_own_attributes
+    defaults: { _controller: NelmioApiDocTestBundle:Concrete:ownAttributes }

--- a/Tests/Formatter/MarkdownFormatterTest.php
+++ b/Tests/Formatter/MarkdownFormatterTest.php
@@ -1052,6 +1052,22 @@ related[b]:
 MARKDOWN;
         } else {
             $expected = <<<MARKDOWN
+#Blah #
+
+### `ANY` /inherticance_own_attributes ###
+
+_index action_
+
+
+
+# FooSection #
+
+### `ANY` /inherticance ###
+
+_index action_
+
+
+
 ## /api/other-resources ##
 
 ### `GET` /api/other-resources.{_format} ###

--- a/Tests/Formatter/MarkdownFormatterTest.php
+++ b/Tests/Formatter/MarkdownFormatterTest.php
@@ -1052,7 +1052,7 @@ related[b]:
 MARKDOWN;
         } else {
             $expected = <<<MARKDOWN
-#Blah #
+# Blah #
 
 ### `ANY` /inherticance_own_attributes ###
 

--- a/Tests/Formatter/MarkdownFormatterTest.php
+++ b/Tests/Formatter/MarkdownFormatterTest.php
@@ -27,6 +27,22 @@ class MarkdownFormatterTest extends WebTestCase
 
         if (class_exists('Dunglas\ApiBundle\DunglasApiBundle')) {
 $expected = <<<MARKDOWN
+# Blah #
+
+### `ANY` /inherticance_own_attributes ###
+
+_index action_
+
+
+
+# FooSection #
+
+### `ANY` /inherticance ###
+
+_index action_
+
+
+
 # Popo #
 
 ### `GET` /popos ###

--- a/Tests/Formatter/SimpleFormatterTest.php
+++ b/Tests/Formatter/SimpleFormatterTest.php
@@ -2770,6 +2770,32 @@ With multiple lines.',
                                 'deprecated' => false,
                             ),
                         4 =>
+                            array (
+                                'method' => 'ANY',
+                                'uri' => '/inherticance',
+                                'description' => 'index action',
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                                'section' => 'FooSection',
+                            ),
+                        5 =>
+                            array (
+                                'method' => 'ANY',
+                                'uri' => '/inherticance_own_attributes',
+                                'description' => 'index action',
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                                'section' => 'Blah',
+                            ),
+                        6 =>
                             array(
                                 'method' => 'POST',
                                 'uri' => '/jms-input-test',
@@ -3030,7 +3056,7 @@ With multiple lines.',
                                 'authenticationRoles' => array(),
                                 'deprecated' => false,
                             ),
-                        5 =>
+                        7 =>
                             array(
                                 'method' => 'GET',
                                 'uri' => '/jms-return-test',
@@ -3063,7 +3089,7 @@ With multiple lines.',
                                 'authenticationRoles' => array(),
                                 'deprecated' => false,
                             ),
-                        6 =>
+                        8 =>
                             array(
                                 'method' => 'ANY',
                                 'uri' => '/my-commented/{id}/{page}/{paramType}/{param}',
@@ -3102,7 +3128,7 @@ And, it supports multilines until the first \'@\' char.',
                                 'authenticationRoles' => array(),
                                 'deprecated' => false,
                             ),
-                        7 =>
+                        9 =>
                             array(
                                 'method' => 'ANY',
                                 'uri' => '/return-nested-output',
@@ -3362,7 +3388,7 @@ With multiple lines.',
                                             ),
                                     ),
                             ),
-                        8 =>
+                        10 =>
                             array(
                                 'method' => 'ANY',
                                 'uri' => '/secure-route',
@@ -3371,7 +3397,7 @@ With multiple lines.',
                                 'authenticationRoles' => array(),
                                 'deprecated' => false,
                             ),
-                        9 =>
+                        11 =>
                             array(
                                 'method' => 'ANY',
                                 'uri' => '/yet-another/{id}',
@@ -3389,7 +3415,7 @@ With multiple lines.',
                                 'authenticationRoles' => array(),
                                 'deprecated' => false,
                             ),
-                        10 =>
+                        12 =>
                             array(
                                 'method' => 'GET',
                                 'uri' => '/z-action-with-deprecated-indicator',
@@ -3398,7 +3424,7 @@ With multiple lines.',
                                 'authenticationRoles' => array(),
                                 'deprecated' => true,
                             ),
-                        11 =>
+                        13 =>
                             array(
                                 'method' => 'POST',
                                 'uri' => '/z-action-with-nullable-request-param',
@@ -3419,7 +3445,7 @@ With multiple lines.',
                                 'authenticationRoles' => array(),
                                 'deprecated' => false,
                             ),
-                        12 =>
+                        14 =>
                             array(
                                 'method' => 'GET',
                                 'uri' => '/z-action-with-query-param',
@@ -3437,7 +3463,7 @@ With multiple lines.',
                                 'authenticationRoles' => array(),
                                 'deprecated' => false,
                             ),
-                        13 =>
+                        15 =>
                             array(
                                 'method' => 'GET',
                                 'uri' => '/z-action-with-query-param-no-default',
@@ -3454,7 +3480,7 @@ With multiple lines.',
                                 'authenticationRoles' => array(),
                                 'deprecated' => false,
                             ),
-                        14 =>
+                        16 =>
                             array(
                                 'method' => 'GET',
                                 'uri' => '/z-action-with-query-param-strict',
@@ -3472,7 +3498,7 @@ With multiple lines.',
                                 'authenticationRoles' => array(),
                                 'deprecated' => false,
                             ),
-                        15 =>
+                        17 =>
                             array(
                                 'method' => 'POST',
                                 'uri' => '/z-action-with-request-param',
@@ -3493,7 +3519,7 @@ With multiple lines.',
                                 'authenticationRoles' => array(),
                                 'deprecated' => false,
                             ),
-                        16 =>
+                        18 =>
                             array(
                                 'method' => 'ANY',
                                 'uri' => '/z-return-jms-and-validator-output',
@@ -3580,7 +3606,7 @@ With multiple lines.',
                                 ),
                                 'authenticationRoles' => array(),
                             ),
-                        17 =>
+                        19 =>
                             array(
                                 'method' => "ANY",
                                 'uri' => "/z-return-selected-parsers-input",
@@ -3628,7 +3654,7 @@ With multiple lines.',
                                         ),
                                     )
                             ),
-                        18 =>
+                        20 =>
                             array(
                                 'method' => "ANY",
                                 'uri' => "/z-return-selected-parsers-output",
@@ -3715,7 +3741,7 @@ With multiple lines.',
                                 ),
                                 'authenticationRoles' => array(),
                             ),
-                        19 =>
+                        21 =>
                             array(
                                 'cache' => 60,
                                 'method' => 'POST',
@@ -3725,7 +3751,7 @@ With multiple lines.',
                                 'authenticationRoles' => array(),
                                 'deprecated' => false
                             ),
-                        20 =>
+                        22 =>
                             array(
                                 'authentication' => true,
                                 'method' => 'POST',

--- a/Tests/Formatter/SimpleFormatterTest.php
+++ b/Tests/Formatter/SimpleFormatterTest.php
@@ -1271,6 +1271,32 @@ With multiple lines.',
                             ),
                         4 =>
                             array (
+                                'method' => 'ANY',
+                                'uri' => '/inherticance',
+                                'description' => 'index action',
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                                'section' => 'FooSection',
+                            ),
+                        5 =>
+                            array (
+                                'method' => 'ANY',
+                                'uri' => '/inherticance_own_attributes',
+                                'description' => 'index action',
+                                'https' => false,
+                                'authentication' => false,
+                                'authenticationRoles' =>
+                                    array (
+                                    ),
+                                'deprecated' => false,
+                                'section' => 'Blah',
+                            ),
+                        6 =>
+                            array (
                                 'method' => 'POST',
                                 'uri' => '/jms-input-test',
                                 'description' => 'Testing JMS',
@@ -1532,7 +1558,7 @@ With multiple lines.',
                                     ),
                                 'deprecated' => false,
                             ),
-                        5 =>
+                        7 =>
                             array (
                                 'method' => 'GET',
                                 'uri' => '/jms-return-test',
@@ -1570,7 +1596,7 @@ With multiple lines.',
                                     ),
                                 'deprecated' => false,
                             ),
-                        6 =>
+                        8 =>
                             array (
                                 'method' => 'ANY',
                                 'uri' => '/my-commented/{id}/{page}/{paramType}/{param}',
@@ -1611,7 +1637,7 @@ And, it supports multilines until the first \'@\' char.',
                                     ),
                                 'deprecated' => false,
                             ),
-                        7 =>
+                        9 =>
                             array (
                                 'method' => 'GET',
                                 'uri' => '/popos',
@@ -1636,7 +1662,7 @@ And, it supports multilines until the first \'@\' char.',
                                 'resourceDescription' => 'Popo',
                                 'section' => 'Popo',
                             ),
-                        8 =>
+                        10 =>
                             array (
                                 'method' => 'POST',
                                 'uri' => '/popos',
@@ -1671,7 +1697,7 @@ And, it supports multilines until the first \'@\' char.',
                                 'resourceDescription' => 'Popo',
                                 'section' => 'Popo',
                             ),
-                        9 =>
+                        11 =>
                             array (
                                 'method' => 'GET',
                                 'uri' => '/popos/{id}',
@@ -1705,7 +1731,7 @@ And, it supports multilines until the first \'@\' char.',
                                 'resourceDescription' => 'Popo',
                                 'section' => 'Popo',
                             ),
-                        10 =>
+                        12 =>
                             array (
                                 'method' => 'PUT',
                                 'uri' => '/popos/{id}',
@@ -1749,7 +1775,7 @@ And, it supports multilines until the first \'@\' char.',
                                 'resourceDescription' => 'Popo',
                                 'section' => 'Popo',
                             ),
-                        11 =>
+                        13 =>
                             array (
                                 'method' => 'DELETE',
                                 'uri' => '/popos/{id}',
@@ -1773,7 +1799,7 @@ And, it supports multilines until the first \'@\' char.',
                                 'resourceDescription' => 'Popo',
                                 'section' => 'Popo',
                             ),
-                        12 =>
+                        14 =>
                             array (
                                 'method' => 'ANY',
                                 'uri' => '/return-nested-output',
@@ -2035,7 +2061,7 @@ With multiple lines.',
                                     ),
                                 'deprecated' => false,
                             ),
-                        13 =>
+                        15 =>
                             array (
                                 'method' => 'ANY',
                                 'uri' => '/secure-route',
@@ -2046,7 +2072,7 @@ With multiple lines.',
                                     ),
                                 'deprecated' => false,
                             ),
-                        14 =>
+                        16 =>
                             array (
                                 'method' => 'ANY',
                                 'uri' => '/yet-another/{id}',
@@ -2066,7 +2092,7 @@ With multiple lines.',
                                     ),
                                 'deprecated' => false,
                             ),
-                        15 =>
+                        17 =>
                             array (
                                 'method' => 'GET',
                                 'uri' => '/z-action-with-deprecated-indicator',
@@ -2077,7 +2103,7 @@ With multiple lines.',
                                     ),
                                 'deprecated' => true,
                             ),
-                        16 =>
+                        18 =>
                             array (
                                 'method' => 'POST',
                                 'uri' => '/z-action-with-nullable-request-param',
@@ -2100,7 +2126,7 @@ With multiple lines.',
                                     ),
                                 'deprecated' => false,
                             ),
-                        17 =>
+                        19 =>
                             array (
                                 'method' => 'GET',
                                 'uri' => '/z-action-with-query-param',
@@ -2120,7 +2146,7 @@ With multiple lines.',
                                     ),
                                 'deprecated' => false,
                             ),
-                        18 =>
+                        20 =>
                             array (
                                 'method' => 'GET',
                                 'uri' => '/z-action-with-query-param-no-default',
@@ -2139,7 +2165,7 @@ With multiple lines.',
                                     ),
                                 'deprecated' => false,
                             ),
-                        19 =>
+                        21 =>
                             array (
                                 'method' => 'GET',
                                 'uri' => '/z-action-with-query-param-strict',
@@ -2159,7 +2185,7 @@ With multiple lines.',
                                     ),
                                 'deprecated' => false,
                             ),
-                        20 =>
+                        22 =>
                             array (
                                 'method' => 'POST',
                                 'uri' => '/z-action-with-request-param',
@@ -2182,7 +2208,7 @@ With multiple lines.',
                                     ),
                                 'deprecated' => false,
                             ),
-                        21 =>
+                        23 =>
                             array (
                                 'method' => 'ANY',
                                 'uri' => '/z-return-jms-and-validator-output',
@@ -2282,7 +2308,7 @@ With multiple lines.',
                                     ),
                                 'deprecated' => false,
                             ),
-                        22 =>
+                        24 =>
                             array (
                                 'method' => 'ANY',
                                 'uri' => '/z-return-selected-parsers-input',
@@ -2336,7 +2362,7 @@ With multiple lines.',
                                     ),
                                 'deprecated' => false,
                             ),
-                        23 =>
+                        25 =>
                             array (
                                 'method' => 'ANY',
                                 'uri' => '/z-return-selected-parsers-output',
@@ -2436,7 +2462,7 @@ With multiple lines.',
                                     ),
                                 'deprecated' => false,
                             ),
-                        24 =>
+                        26 =>
                             array (
                                 'method' => 'POST',
                                 'uri' => '/zcached',
@@ -2448,7 +2474,7 @@ With multiple lines.',
                                     ),
                                 'deprecated' => false,
                             ),
-                        25 =>
+                        27 =>
                             array (
                                 'method' => 'POST',
                                 'uri' => '/zsecured',


### PR DESCRIPTION
… class level which will be used e.g. by actions of an inherited abstract class

This commit solves the issue that the section attribute can not be used when defining actions in an abstract controller and inherting them in the concrete one.

Basically, you can now add a ApiDocDefaults annotation to the concrete class to define the section.

This is a quick and easy solution to an annoying issue and can be extended to support other default values than section at any time.