### PR TITLE
Move the new parameters button so it's available when no parameters are specified

### DIFF
--- a/Resources/views/method.html.twig
+++ b/Resources/views/method.html.twig
@@ -241,8 +241,8 @@
                                         </p>
                                     {% endif %}
                                     {% endfor %}
-                                    <button type="button" class="add_parameter">New parameter</button>
                                 {% endif %}
+                                <button type="button" class="add_parameter">New parameter</button>
 
                             </fieldset>
 


### PR DESCRIPTION
It's just handy/useful to have this button available at all times in case you need to throw extra params through.