### PR TITLE
Fix CachingApiDocExtractor caches only first accessed view

### DIFF
--- a/Extractor/CachingApiDocExtractor.php
+++ b/Extractor/CachingApiDocExtractor.php
@@ -28,19 +28,14 @@ use Symfony\Component\Routing\RouterInterface;
 class CachingApiDocExtractor extends ApiDocExtractor
 {
     /**
-     * @var \Symfony\Component\Config\ConfigCache
-     */
-    protected $cache;
-
-    /**
      * @var string
      */
-    protected $cacheFile;
+    private $cacheFile;
 
     /**
      * @var bool
      */
-    protected $debug;
+    private $debug;
 
     /**
      * @param ContainerInterface $container
@@ -65,6 +60,7 @@ class CachingApiDocExtractor extends ApiDocExtractor
         $debug = false
     ) {
         parent::__construct($container, $router, $reader, $commentExtractor, $controllerNameParser, $handlers, $annotationsProviders);
+
         $this->cacheFile = $cacheFile;
         $this->debug = $debug;
     }
@@ -106,7 +102,7 @@ class CachingApiDocExtractor extends ApiDocExtractor
      * @param string $view
      * @return ConfigCache
      */
-    protected function getViewCache($view)
+    private function getViewCache($view)
     {
         return new ConfigCache($this->cacheFile.'.'.$view, $this->debug);
     }

--- a/Extractor/CachingApiDocExtractor.php
+++ b/Extractor/CachingApiDocExtractor.php
@@ -32,8 +32,27 @@ class CachingApiDocExtractor extends ApiDocExtractor
      */
     protected $cache;
 
+    /**
+     * @var string
+     */
     protected $cacheFile;
 
+    /**
+     * @var bool
+     */
+    protected $debug;
+
+    /**
+     * @param ContainerInterface $container
+     * @param RouterInterface $router
+     * @param Reader $reader
+     * @param DocCommentExtractor $commentExtractor
+     * @param ControllerNameParser $controllerNameParser
+     * @param array $handlers
+     * @param array $annotationsProviders
+     * @param string $cacheFile
+     * @param bool|false $debug
+     */
     public function __construct(
         ContainerInterface $container,
         RouterInterface $router,
@@ -47,12 +66,18 @@ class CachingApiDocExtractor extends ApiDocExtractor
     ) {
         parent::__construct($container, $router, $reader, $commentExtractor, $controllerNameParser, $handlers, $annotationsProviders);
         $this->cacheFile = $cacheFile;
-        $this->cache = new ConfigCache($this->cacheFile, $debug);
+        $this->debug = $debug;
     }
 
+    /**
+     * @param string $view View name
+     * @return array|mixed
+     */
     public function all($view = ApiDoc::DEFAULT_VIEW)
     {
-        if ($this->cache->isFresh() === false) {
+        $cache = $this->getViewCache($view);
+
+        if ($cache->isFresh() === false) {
 
             $resources = array();
 
@@ -67,12 +92,23 @@ class CachingApiDocExtractor extends ApiDocExtractor
             $resources = array_merge($resources, $this->router->getRouteCollection()->getResources());
 
             $data = parent::all($view);
-            $this->cache->write(serialize($data), $resources);
+
+            $cache->write(serialize($data), $resources);
 
             return $data;
         }
 
-        return unserialize(file_get_contents($this->cacheFile));
+        return unserialize(file_get_contents($cache));
 
     }
+
+    /**
+     * @param string $view
+     * @return ConfigCache
+     */
+    protected function getViewCache($view)
+    {
+        return new ConfigCache($this->cacheFile.'.'.$view, $this->debug);
+    }
+
 }

--- a/Tests/Extractor/ApiDocExtractorTest.php
+++ b/Tests/Extractor/ApiDocExtractorTest.php
@@ -47,9 +47,9 @@ class ApiDocExtractorTest extends WebTestCase
         $this->assertTrue(is_array($data));
         $this->assertCount(self::$ROUTES_QUANTITY_DEFAULT, $data);
 
-        $cacheFile = $container->getParameter('kernel.cache_dir') . '/api-doc.cache';
+        $cacheFile = $container->getParameter('kernel.cache_dir') . '/api-doc.cache.' . ApiDoc::DEFAULT_VIEW;
         $this->assertFileExists($cacheFile);
-        $this->assertEquals(file_get_contents($cacheFile), serialize($data));
+        $this->assertStringEqualsFile($cacheFile, serialize($data));
 
         foreach ($data as $key => $d) {
             $this->assertTrue(is_array($d));

--- a/Tests/Extractor/CachingApiDocExtractorTest.php
+++ b/Tests/Extractor/CachingApiDocExtractorTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Nelmio\ApiDocBundle\Tests\Extractor;
+
+use Nelmio\ApiDocBundle\Annotation\ApiDoc;
+use Nelmio\ApiDocBundle\Extractor\CachingApiDocExtractor;
+use Nelmio\ApiDocBundle\Tests\WebTestCase;
+
+class CachingApiDocExtractorTest extends WebTestCase
+{
+    /**
+     * @return array
+     */
+    public static function viewsWithoutDefaultProvider()
+    {
+        $data = ApiDocExtractorTest::dataProviderForViews();
+        // remove default view data from provider
+        array_shift($data);
+        return $data;
+    }
+
+    /**
+     * Test that every view cache is saved in its own cache file
+     *
+     * @dataProvider viewsWithoutDefaultProvider
+     * @param string $view View name
+     */
+    public function testDifferentCacheFilesAreCreatedForDifferentViews($view)
+    {
+        $container = $this->getContainer();
+        /* @var CachingApiDocExtractor $extractor */
+        $extractor = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
+        $this->assertInstanceOf('\Nelmio\ApiDocBundle\Extractor\CachingApiDocExtractor', $extractor);
+
+        set_error_handler(array($this, 'handleDeprecation'));
+        $defaultData = $extractor->all(ApiDoc::DEFAULT_VIEW);
+        $data = $extractor->all($view);
+        restore_error_handler();
+
+        $this->assertInternalType(\PHPUnit_Framework_Constraint_IsType::TYPE_ARRAY, $data);
+        $this->assertNotSameSize($defaultData, $data);
+        $this->assertNotEquals($defaultData, $data);
+
+        $cacheFile = $container->getParameter('kernel.cache_dir').'/api-doc.cache';
+
+        $expectedDefaultViewCacheFile = $cacheFile.'.'.ApiDoc::DEFAULT_VIEW;
+        $expectedViewCacheFile = $cacheFile.'.'.$view;
+
+        $this->assertFileExists($expectedDefaultViewCacheFile);
+        $this->assertFileExists($expectedViewCacheFile);
+        $this->assertFileNotEquals($expectedDefaultViewCacheFile, $expectedViewCacheFile);
+    }
+
+    /**
+     * @dataProvider \Nelmio\ApiDocBundle\Tests\Extractor\ApiDocExtractorTest::dataProviderForViews
+     * @param string $view View name to test
+     */
+    public function testCachedResultSameAsGenerated($view)
+    {
+        $container = $this->getContainer();
+        /* @var CachingApiDocExtractor $extractor */
+        $extractor = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
+        $this->assertInstanceOf('\Nelmio\ApiDocBundle\Extractor\CachingApiDocExtractor', $extractor);
+
+        $cacheFile = $container->getParameter('kernel.cache_dir').'/api-doc.cache';
+
+        $expectedViewCacheFile = $cacheFile.'.'.$view;
+
+        $this->assertFileNotExists($expectedViewCacheFile);
+
+        set_error_handler(array($this, 'handleDeprecation'));
+        $data = $extractor->all($view);
+
+        $this->assertFileExists($expectedViewCacheFile);
+
+        $cachedData = $extractor->all($view);
+        restore_error_handler();
+
+        $this->assertInternalType(\PHPUnit_Framework_Constraint_IsType::TYPE_ARRAY, $data);
+        $this->assertInternalType(\PHPUnit_Framework_Constraint_IsType::TYPE_ARRAY, $cachedData);
+        $this->assertSameSize($data, $cachedData);
+        $this->assertEquals($data, $cachedData);
+    }
+}


### PR DESCRIPTION
This PR fixes issue when caching is enabled and _CachingApiDocExtractor_ saves cache only for the first view accessed. When other api doc views are requested same cache file with api doc data is used instead of creating and using different cache files for different views.