### PR TITLE
Markdown generation bugfix.

### DIFF
--- a/Formatter/MarkdownFormatter.php
+++ b/Formatter/MarkdownFormatter.php
@@ -42,7 +42,7 @@ class MarkdownFormatter extends AbstractFormatter
             $markdown .= "#### Requirements ####\n\n";
 
             foreach ($data['requirements'] as $name => $infos) {
-                $markdown .= sprintf("**%s**\n\n", $name);
+                $markdown .= sprintf("\n**%s**\n", $name);
 
                 if (!empty($infos['requirement'])) {
                     $markdown .= sprintf("  - Requirement: %s\n", $infos['requirement']);


### PR DESCRIPTION
Hello, 

There is a small bug in the markdown generation. With the current version, there is no "\n" before any parameter so the markdown isn't properly generated if a function as at least 2 parameters and  these parameters have requirements.

In my file generated before that fix, I have this section wich is obviously wrong (group is my 2nd parameter)

///////////////////////////////////////

#### Requirements ####

**_format**

  - Requirement: json|xml
**group**

///////////////////////////////////

After my fix it looks like below

/////////////////////////////////////

#### Requirements ####


**_format**
  - Requirement: json|xml

**group**

////////////////////////////////////////

Everything is displayed properly after that (in my case a least).