### PR TITLE
`required` entry in swagger model description

### DIFF
--- a/Swagger/ModelRegistry.php
+++ b/Swagger/ModelRegistry.php
@@ -199,7 +199,9 @@ class ModelRegistry
             }
 
             $model['properties'] = $properties;
-            $model['required'] = $required;
+            if( !empty($required) ){
+                $model['required'] = $required;
+            }
             $this->models[$id] = $model;
         }
 


### PR DESCRIPTION
When generating from ApiDoc and JMSSerializer, Swagger does not want `required` array in model if the array is empty.
After converting output into swagger 2.0, the swagger editor actually raise errors if `required` is an empty array (example below). I guess it should not be there if it's empty.

```
"AppBundle.Model.Redirect.Redirect": {
      "description": "some description",
      "properties": {
        "source": {
          "type": "string",
          "description": "string"
        },
        "destination": {
          "type": "string",
          "description": "string"
        }
      },
      "required": []
}
```