### PR TITLE
Deprecation fixes in preparation for Symfony 3.0 (fixes #679).

### DIFF
--- a/Annotation/ApiDoc.php
+++ b/Annotation/ApiDoc.php
@@ -480,8 +480,10 @@ class ApiDoc
             $this->host = null;
         }
 
-        $this->uri    = $route->getPattern();
-        $this->method = $route->getRequirement('_method') ?: 'ANY';
+        $methods = $route->getMethods();
+
+        $this->uri    = $route->getPath();
+        $this->method = !empty($methods) ? implode('|', $methods) : 'ANY';
     }
 
     /**

--- a/Extractor/ApiDocExtractor.php
+++ b/Extractor/ApiDocExtractor.php
@@ -132,7 +132,7 @@ class ApiDocExtractor
                             $resources[] = $resource;
                         } else {
                             // remove format from routes used for resource grouping
-                            $resources[] = str_replace('.{_format}', '', $route->getPattern());
+                            $resources[] = str_replace('.{_format}', '', $route->getPath());
                         }
                     }
 
@@ -151,7 +151,7 @@ class ApiDocExtractor
         rsort($resources);
         foreach ($array as $index => $element) {
             $hasResource = false;
-            $pattern     = $element['annotation']->getRoute()->getPattern();
+            $pattern     = $element['annotation']->getRoute()->getPath();
 
             foreach ($resources as $resource) {
                 if (0 === strpos($pattern, $resource) || $resource === $element['annotation']->getResource()) {
@@ -170,14 +170,21 @@ class ApiDocExtractor
         $methodOrder = array('GET', 'POST', 'PUT', 'DELETE');
         usort($array, function ($a, $b) use ($methodOrder) {
             if ($a['resource'] === $b['resource']) {
-                if ($a['annotation']->getRoute()->getPattern() === $b['annotation']->getRoute()->getPattern()) {
-                    $methodA = array_search($a['annotation']->getRoute()->getRequirement('_method'), $methodOrder);
-                    $methodB = array_search($b['annotation']->getRoute()->getRequirement('_method'), $methodOrder);
+                if ($a['annotation']->getRoute()->getPath() === $b['annotation']->getRoute()->getPath()) {
+
+                    $methodsA = $a['annotation']->getRoute()->getMethods();
+                    $methodsB = $b['annotation']->getRoute()->getMethods();
+
+                    $singleMethodA = array_shift($methodsA);
+                    $singleMethodB = array_shift($methodsB);
+
+                    $methodA = array_search($singleMethodA, $methodOrder);
+                    $methodB = array_search($singleMethodB, $methodOrder);
 
                     if ($methodA === $methodB) {
                         return strcmp(
-                            $a['annotation']->getRoute()->getRequirement('_method'),
-                            $b['annotation']->getRoute()->getRequirement('_method')
+                            $singleMethodA,
+                            $singleMethodB
                         );
                     }
 
@@ -185,8 +192,8 @@ class ApiDocExtractor
                 }
 
                 return strcmp(
-                    $a['annotation']->getRoute()->getPattern(),
-                    $b['annotation']->getRoute()->getPattern()
+                    $a['annotation']->getRoute()->getPath(),
+                    $b['annotation']->getRoute()->getPath()
                 );
             }
 

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,5 +1,4 @@
 nelmio_api_doc_index:
-    pattern: /{view}
+    path: /{view}
     defaults: { _controller: NelmioApiDocBundle:ApiDoc:index, view: 'default' }
-    requirements:
-        _method: GET
+    methods: [GET]

--- a/Resources/config/swagger_routing.yml
+++ b/Resources/config/swagger_routing.yml
@@ -1,11 +1,9 @@
 nelmio_api_doc_swagger_resource_list:
-    pattern: /
+    path: /
     defaults: { _controller: NelmioApiDocBundle:ApiDoc:swagger }
-    requirements:
-        _method: GET
+    methods: [GET]
 
 nelmio_api_doc_swagger_api_declaration:
-    pattern: /{resource}
+    path: /{resource}
     defaults: { _controller: NelmioApiDocBundle:ApiDoc:swagger }
-    requirements:
-        _method: GET
+    methods: [GET]

--- a/Tests/Fixtures/app/config/routing.yml
+++ b/Tests/Fixtures/app/config/routing.yml
@@ -1,207 +1,191 @@
 test_route_1:
-    pattern:  /tests.{_format}
+    path: /tests.{_format}
     defaults: { _controller: NelmioApiDocTestBundle:Test:index, _format: json }
-    requirements:
-        _method: GET
+    methods: [GET]
 
 test_route_2:
-    pattern:  /tests.{_format}
-    host:     api.test.dev
+    path: /tests.{_format}
+    host: api.test.dev
     defaults: { _controller: NelmioApiDocTestBundle:Test:postTest, _format: json }
-    requirements:
-        _method: POST
+    methods: [POST]
 
 test_route_3:
-    pattern:  /another
+    path: /another
     defaults: { _controller: NelmioApiDocTestBundle:Test:another }
 
 test_route_4:
-    pattern:  /any/{foo}
+    path: /any/{foo}
     defaults: { _controller: NelmioApiDocTestBundle:Test:any, _format: json }
 
 test_route_5:
-    pattern:  /my-commented/{id}/{page}/{paramType}/{param}
+    path: /my-commented/{id}/{page}/{paramType}/{param}
     defaults: { _controller: NelmioApiDocTestBundle:Test:myCommented }
 
 test_route_6:
-    pattern:  /yet-another/{id}
+    path: /yet-another/{id}
     defaults: { _controller: NelmioApiDocTestBundle:Test:yetAnother }
     requirements:
         id:  \d+
 
 test_route_7:
-    pattern:  /another-post
+    path: /another-post
     defaults: { _controller: NelmioApiDocTestBundle:Test:anotherPost, _format: json }
-    requirements:
-        _method: POST
+    methods: [POST]
 
 test_route_8:
-    pattern:  /z-action-with-query-param
+    path: /z-action-with-query-param
     defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithQueryParam }
-    requirements:
-        _method: GET
+    methods: [GET]
 
 test_route_9:
-    pattern: /jms-input-test
+    path: /jms-input-test
     defaults: { _controller: NelmioApiDocTestBundle:Test:jmsInputTest }
-    requirements:
-        _method: POST
+    methods: [POST]
 
 test_route_10:
-    pattern: /jms-return-test
+    path: /jms-return-test
     defaults: { _controller: NelmioApiDocTestBundle:Test:jmsReturnTest }
-    requirements:
-        _method: GET
+    methods: [GET]
 
 test_route_11:
-    pattern:  /z-action-with-request-param
+    path: /z-action-with-request-param
     defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithRequestParam }
-    requirements:
-        _method: POST
+    methods: [POST]
 
 test_route_12:
-    pattern: /secure-route
+    path: /secure-route
     defaults: { _controller: NelmioApiDocTestBundle:Test:secureRoute }
-    requirements:
-        _scheme: https
+    schemes: [https]
 
 test_route_13:
-    pattern: /authenticated
+    path: /authenticated
     defaults: { _controller: NelmioApiDocTestBundle:Test:authenticated }
 
 test_service_route_1:
-    pattern:  /tests.{_format}
+    path: /tests.{_format}
     defaults: { _controller: nelmio.test.controller:indexAction, _format: json }
-    requirements:
-        _method: GET
+    methods: [GET]
 
 test_service_route_2:
-    pattern:  /tests.{_format}
-    host:     api.test.dev
+    path: /tests.{_format}
+    host: api.test.dev
     defaults: { _controller: nelmio.test.controller:postTestAction, _format: json }
-    requirements:
-        _method: POST
+    methods: [POST]
 
 test_service_route_3:
-    pattern:  /another
+    path: /another
     defaults: { _controller: nelmio.test.controller:anotherAction }
 
 test_service_route_4:
-    pattern:  /any
+    path: /any
     defaults: { _controller: nelmio.test.controller:anyAction, _format: json }
 
 NelmioApiDocBundle:
     resource: "@NelmioApiDocBundle/Resources/config/routing.yml"
-    prefix:   /
+    prefix: /
 
 test_route_14:
-    pattern:  /tests2.{_format}
+    path: /tests2.{_format}
     defaults: { _controller: NelmioApiDocTestBundle:Test:postTest2, _format: json }
-    requirements:
-        _method: POST
+    methods: [POST]
 
 test_route_15:
-    pattern:  /z-action-with-query-param-strict
+    path: /z-action-with-query-param-strict
     defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithQueryParamStrict }
-    requirements:
-        _method: GET
+    methods: [GET]
 
 test_route_16:
-    pattern:  /z-action-with-query-param-no-default
+    path: /z-action-with-query-param-no-default
     defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithQueryParamNoDefault }
-    requirements:
-        _method: GET
+    methods: [GET]
 
 test_route_17:
-    pattern:  /z-action-with-deprecated-indicator
+    path: /z-action-with-deprecated-indicator
     defaults: { _controller: NelmioApiDocTestBundle:Test:deprecated }
-    requirements:
-        _method: GET
+    methods: [GET]
 
 test_return_nested_output:
-    pattern: /return-nested-output
+    path: /return-nested-output
     defaults: { _controller: NelmioApiDocTestBundle:Test:jmsReturnNestedOutput, _format: json }
 
 test_return_nested_extend_output:
-    pattern: /return-nested-extend-output
+    path: /return-nested-extend-output
     defaults: { _controller: NelmioApiDocTestBundle:Test:jmsReturnNestedExtendOutput, _format: json }
 
 test_route_18:
-    pattern: /z-return-jms-and-validator-output
+    path: /z-return-jms-and-validator-output
     defaults: { _controller: NelmioApiDocTestBundle:Test:zReturnJmsAndValidationOutput }
 
 test_route_named_resource:
-    pattern:  /named-resource
+    path: /named-resource
     defaults: { _controller: NelmioApiDocTestBundle:Test:namedResource }
 
 test_route_19:
-    pattern: /z-return-selected-parsers-output
+    path: /z-return-selected-parsers-output
     defaults: { _controller: NelmioApiDocTestBundle:Test:zReturnSelectedParsersOutput }
 
 test_route_20:
-    pattern: /z-return-selected-parsers-input
+    path: /z-return-selected-parsers-input
     defaults: { _controller: NelmioApiDocTestBundle:Test:zReturnSelectedParsersInput }
 
 test_route_private:
-    pattern: /private
+    path: /private
     defaults: { _controller: NelmioApiDocTestBundle:Test:private }
 
 test_route_exclusive:
-    pattern: /exclusive
+    path: /exclusive
     defaults: { _controller: NelmioApiDocTestBundle:Test:exclusive }
 
 test_route_21:
-    pattern:  /z-action-with-constraint-requirements
+    path: /z-action-with-constraint-requirements
     defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithConstraintAsRequirements }
-    requirements:
-        _method: GET
+    methods: [GET]
 
 test_route_22:
-    pattern:  /z-action-with-nullable-request-param
+    path: /z-action-with-nullable-request-param
     defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithNullableRequestParam }
-    requirements:
-        _method: POST
+    methods: [POST]
 
 test_route_list_resource:
-    pattern: /api/resources.{_format}
+    path: /api/resources.{_format}
     defaults: { _controller: NelmioApiDocTestBundle:Resource:listResources, _format: json }
+    methods: [GET]
     requirements:
-        _method: GET
         _format: json|xml|html
 
 test_route_get_resource:
-    pattern: /api/resources/{id}.{_format}
+    path: /api/resources/{id}.{_format}
     defaults: { _controller: NelmioApiDocTestBundle:Resource:getResource, _format: json }
+    methods: [GET]
     requirements:
-        _method: GET
         _format: json|xml|html
 
 test_route_delete_resource:
-    pattern: /api/resources/{id}.{_format}
+    path: /api/resources/{id}.{_format}
     defaults: { _controller: NelmioApiDocTestBundle:Resource:deleteResource, _format: json }
+    methods: [DELETE]
     requirements:
-        _method: DELETE
         _format: json|xml|html
 
 test_route_create_resource:
-    pattern: /api/resources.{_format}
+    path: /api/resources.{_format}
     defaults: { _controller: NelmioApiDocTestBundle:Resource:createResource, _format: json }
+    methods: [POST]
     requirements:
-        _method: POST
         _format: json|xml|html
 
 test_route_list_another_resource:
-    pattern: /api/other-resources.{_format}
+    path: /api/other-resources.{_format}
     defaults: { _controller: NelmioApiDocTestBundle:Resource:listAnotherResources, _format: json }
+    methods: [GET]
     requirements:
-        _method: GET
         _format: json|xml|html
 
 test_route_update_another_resource:
-    pattern: /api/other-resources/{id}.{_format}
+    path: /api/other-resources/{id}.{_format}
     defaults: { _controller: NelmioApiDocTestBundle:Resource:updateAnotherResource, _format: json }
+    methods: [PUT, PATCH]
     requirements:
-        _method: PUT|PATCH
         _format: json|xml|html
 
 swagger_doc:
@@ -209,39 +193,35 @@ swagger_doc:
     prefix: /api-docs
 
 test_route_23:
-    pattern:  /zcached
+    path: /zcached
     defaults: { _controller: NelmioApiDocTestBundle:Test:zCached }
-    requirements:
-        _method: POST
+    methods: [POST]
 
 test_route_24:
-    pattern:  /zsecured
+    path: /zsecured
     defaults: { _controller: NelmioApiDocTestBundle:Test:zSecured }
-    requirements:
-        _method: POST
+    methods: [POST]
 
 test_required_parameters:
-    pattern: /api/other-resources/{id}.{_format}
+    path: /api/other-resources/{id}.{_format}
     defaults: { _controller: NelmioApiDocTestBundle:Resource:requiredParametersAction, _format: json }
+    methods: [POST]
     requirements:
-        _method: POST
         _format: json|xml|html
 
 test_put_disables_required_parameters:
-    pattern: /api/other-resources/{id}.{_format}
+    path: /api/other-resources/{id}.{_format}
     defaults: { _controller: NelmioApiDocTestBundle:Resource:requiredParametersAction, _format: json }
+    methods: [PUT]
     requirements:
-        _method: PUT
         _format: json|xml|html
 
 test_route_25:
-    pattern:  /with-link
+    path: /with-link
     defaults: { _controller: NelmioApiDocTestBundle:Test:withLinkAction }
-    requirements:
-        _method: GET
+    methods: [GET]
 
 test_route_26:
-    pattern:  /z-action-with-array-request-param
+    path: /z-action-with-array-request-param
     defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithArrayRequestParamAction }
-    requirements:
-        _method: POST
+    methods: [POST]


### PR DESCRIPTION
This should catch all of the deprecations in the current code and migrate them to Symfony 3 standards. The changes should maintain PHP 5.3.x compatibility as well in case anybody is still using this as far back as Symfony 2.3.

There are tests failing but they are unrelated to this change. There seemed to have been a change to the DunglasApiBundle recently that changed the output of the formatter tests, and I think those just need to be updated to match; I'll let somebody else do that who is more familiar with it, though.

Anyway, would be great to get this merged for the people experiencing deprecation problems right now. Happy to do any other related work if necessary. Thanks!