### PR TITLE
revert fix "LINK workaround for firefox"

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -471,7 +471,6 @@
 
 
 
-
                     // retrieve the additional headers to send
                     $('.headers .tuple', $(this)).each(function() {
                         var key, value;

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -520,12 +520,6 @@
                     }
                     {% endif %}
 
-                    // Workaround for Firefox bug and a thereby resulting nginx incompatibility
-                    if (method == "LINK") {
-                        method = "POST";
-                        params._method = "LINK";
-                    }
-
                     // prepare final parameters
                     var body = {};
                     if(bodyFormat == 'json' && method != 'GET') {


### PR DESCRIPTION
Reverts a previous fix for Firefox which is causing issues with Chrome and which is not necessary anymore for Firefox because they fixed the issue (https://bugzilla.mozilla.org/show_bug.cgi?id=477578)

Also Fixes #621