### PR TITLE
Fix ApiDocExtractor to accept callable classes as controllers

### DIFF
--- a/Extractor/ApiDocExtractor.php
+++ b/Extractor/ApiDocExtractor.php
@@ -211,14 +211,20 @@ class ApiDocExtractor
         if (preg_match('#(.+)::([\w]+)#', $controller, $matches)) {
             $class = $matches[1];
             $method = $matches[2];
-        } elseif (preg_match('#(.+):([\w]+)#', $controller, $matches)) {
-            $controller = $matches[1];
-            $method = $matches[2];
+        } else {
+            if (preg_match('#(.+):([\w]+)#', $controller, $matches)) {
+                $controller = $matches[1];
+                $method = $matches[2];
+            }
+
             if ($this->container->has($controller)) {
                 $this->container->enterScope('request');
                 $this->container->set('request', new Request(), 'request');
                 $class = ClassUtils::getRealClass(get_class($this->container->get($controller)));
                 $this->container->leaveScope('request');
+                if (!isset($method) && method_exists($class, '__invoke')) {
+                    $method = '__invoke';
+                }
             }
         }
 


### PR DESCRIPTION
This patch allows the parser to properly obtain the `\ReflectionMethod` from a controller when declared as a service not specifying a method name but using a callable class instead.

http://symfony.com/doc/current/cookbook/controller/service.html#defining-the-controller-as-a-service
> 2.6: If your controller service implements the __invoke method, you can simply refer to the service id (app.hello_controller). 

Also, related to https://github.com/dunglas/DunglasApiBundle/issues/219

Failing tests aren't related AFAIK.