### PR TITLE
Change Namespace for DunglasApiProvider

### DIFF
--- a/Extractor/AnnotationsProvider/DunglasApiProvider.php
+++ b/Extractor/AnnotationsProvider/DunglasApiProvider.php
@@ -15,7 +15,7 @@ use Dunglas\ApiBundle\Api\Operation\OperationInterface;
 use Dunglas\ApiBundle\Api\ResourceCollectionInterface;
 use Dunglas\ApiBundle\Api\ResourceInterface;
 use Dunglas\ApiBundle\Hydra\ApiDocumentationBuilderInterface;
-use Dunglas\ApiBundle\Mapping\ClassMetadataFactoryInterface;
+use Dunglas\ApiBundle\Mapping\Factory\ClassMetadataFactory;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Nelmio\ApiDocBundle\Extractor\AnnotationsProviderInterface;
 use Nelmio\ApiDocBundle\Parser\DunglasApiParser;


### PR DESCRIPTION
The path of ClassMetadataFactory change on master of dunglas/DunglasApiBundle since July 29th

https://github.com/dunglas/DunglasApiBundle/commit/ed3635a1aa5f4f5848e25abf0b4230eadc37707b#diff-6af8d41bb3800a50340d17839a3481d3