### PR TITLE
Added 'Expand All / Collapse All' control to the Documentation view

### DIFF
--- a/Resources/public/css/screen.css
+++ b/Resources/public/css/screen.css
@@ -181,6 +181,20 @@ table tbody tr td {
   font-size: 0.9em;
 }
 
+#expand_collapse_options {
+    margin: 0px 40px 20px 0px;
+    text-align: right;
+}
+
+#expand_collapse_options a {
+    text-decoration: none;
+    margin-left: 10px;
+}
+
+#expand_collapse_options a:hover {
+    text-decoration: underline;
+}
+
 .section {
     padding: 5px 20px;
     border-bottom: 1px solid #ddd;

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -51,6 +51,12 @@
             <br style="clear: both;" />
         </div>
         {% include motdTemplate %}
+        <div id="expand_collapse_options">
+            <div class="actions">
+                <a id="action-expand-all" href="#">Expand All</a>
+                <a id="action-collapse-all" href="#">Collapse All</a>
+            </div>
+        </div>
         <div class="container" id="resources_container">
             <ul id="resources">
                 {% block content %}{% endblock %}
@@ -145,6 +151,16 @@
                 }
                 $(section).find('ul').slideDown('fast');
                 $(section).find('.operation > .content').slideDown('fast');
+            });
+            
+            $('#action-expand-all').on('click', function(){
+                $('#resources li').addClass('active');
+                $('#resources li ul.section-list').css('display','block');
+            });
+
+            $('#action-collapse-all').on('click', function(){
+                $('#resources li').removeClass('active');
+                $('#resources li ul.section-list').css('display','none');
             });
 
             {% if enableSandbox %}


### PR DESCRIPTION
Hi, we have a rather large API so I decided to add this control and now sharing it here in case the project leads are interested. Its a pretty handy feature and lets you expand and collapse all api end points in the docs easily.

It's a JavaScript / CSS change. Nothing touched in PHP.