### PR TITLE
Added xhrFields: { withCredentials: true } to ajaxOptions

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -537,6 +537,7 @@
                     var data = content.length ? content : body;
                     var ajaxOptions = {
                         url: (url.indexOf('http')!=0?endpoint:'') + url,
+                        xhrFields: { withCredentials: true },
                         type: method,
                         data: data,
                         headers: headers,


### PR DESCRIPTION
Added xhrFields: { withCredentials: true } to ajaxOptions to enable browser authentication for cross origin API requests (CORS). This is needed when the sandbox API request is re-directed (HTTP/1.1 307) and sub-sequently challenged for credentials (HTTP/1.1 401).