### PR TITLE
Support for Authorization header prefix

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -100,12 +100,22 @@ class Configuration implements ConfigurationInterface
                                     ->values(array('basic', 'bearer'))
                                 ->end()
                                 ->booleanNode('custom_endpoint')->defaultFalse()->end()
+                                ->scalarNode('prefix')
+                                    ->defaultNull()
+                                    ->info('Can only be set if header delivery is selected.')
+                                ->end()
                             ->end()
                             ->validate()
                                 ->ifTrue(function ($v) {
                                     return 'http' === $v['delivery'] && !$v['type'] ;
                                 })
                                 ->thenInvalid('"type" is required when using http delivery.')
+                            ->end()
+                            ->validate()
+                                ->ifTrue(function ($v) {
+                                    return 'header' !== $v['delivery'] && $v['prefix'] ;
+                                })
+                                ->thenInvalid('"prefix" can only be set when using header delivery.')
                             ->end()
                             # http_basic BC
                             ->beforeNormalization()

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -410,6 +410,8 @@ nelmio_api_doc:
             # Required if http delivery is selected.
             type:     basic         # `basic`, `bearer` are supported
 
+            prefix: ~               # set if header delivery selected only.
+
             custom_endpoint: true   # default is `false`, if `true`, your user will be able to
                                     # specify its own endpoint
 

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -552,7 +552,11 @@
                                         value = 'Bearer ' + $('#api_key').val();
                                     }
                                 } else if ('header' == authentication_delivery) {
-                                    value = $('#api_key').val();
+                                    if (authentication_prefix) {
+                                        value = authentication_prefix + ' ' + $('#api_key').val();
+                                    } else {
+                                        value = $('#api_key').val();
+                                    }
                                 }
 
                                 xhr.setRequestHeader(api_key_parameter, value);
@@ -719,6 +723,7 @@
                 }
                 {% elseif authentication and authentication.delivery == 'header' %}
                 var authentication_delivery = '{{ authentication.delivery }}';
+                var authentication_prefix = '{{ authentication.prefix|trim }}';
                 var api_key_parameter = '{{ authentication.name }}';
                 {% else %}
                 var authentication_delivery = false;


### PR DESCRIPTION
The HTTP Authorization header's value is often prefixed:

```Authorization: Bearer {token}```
or
```Authorization: CUSTOM {token}```

A [custom prefix can be set when using LexikJWTAuthenticationBundle](https://github.com/lexik/LexikJWTAuthenticationBundle/blob/master/Resources/doc/1-configuration-reference.md#full-configuration) for instance:

```yaml
# app/config/security.yml
firewalls:
    api:
        lexik_jwt:
            authorization_header:
                enabled: true
                prefix:  CUSTOM
```

This PR adds support for a prefix to the Swagger sandbox.