### PR TITLE
composer: allow min PHP 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         }
     ],
     "require": {
+        "php": ">=5.4",
         "symfony/twig-bundle": "~2.3",
         "symfony/framework-bundle": "~2.3",
         "symfony/console": "~2.3",


### PR DESCRIPTION
According to Travis, the min supported version is 5.4