### PR TITLE
Options for form were not passed through

### DIFF
--- a/Parser/FormTypeParser.php
+++ b/Parser/FormTypeParser.php
@@ -306,16 +306,16 @@ class FormTypeParser implements ParserInterface
         return $refl->newInstance();
     }
 
-    private function createForm($item)
+    private function createForm($item, $data = null, array $options = [])
     {
         if ($this->implementsType($item)) {
             $type = $this->getTypeInstance($item);
 
-            return $this->formFactory->create($type);
+            return $this->formFactory->create($type, $data, $options);
         }
 
         try {
-            return $this->formFactory->create($item);
+            return $this->formFactory->create($item, $data, $options);
         } catch (UnexpectedTypeException $e) {
             // nothing
         } catch (InvalidArgumentException $e) {


### PR DESCRIPTION
With current master I noticed, that options given in an annotation are not passed through to the form instance any more. This worked for me since recent composer update. For me, this small change seems to solve the problem.

Just to give a little more detail, my annotation for a controller looked like this one:

    /**
     * @ApiDoc(
     *     section = "Current User",
     *     input = {
     *         "class" = "AppBundle\Form\User\AddressForm",
     *         "options" = {"disableTransformer" = true},
     *         "name" = ""
     *     },
     *     statusCodes = {
     *         201 = "Address created"
     *     }
     * )
     */