### PR TITLE
[ISSUE-739] ApiDoc parameters setting will override lower parameter definitions in the hierarchy

### DIFF
--- a/Extractor/ApiDocExtractor.php
+++ b/Extractor/ApiDocExtractor.php
@@ -322,6 +322,8 @@ class ApiDocExtractor
                 });
             }
 
+            // merge parameters with parameters block from ApiDoc annotation in controller method
+            $parameters = $this->mergeParameters($parameters, $annotation->getParameters());
             $annotation->setParameters($parameters);
         }
 

--- a/Tests/Extractor/ApiDocExtractorTest.php
+++ b/Tests/Extractor/ApiDocExtractorTest.php
@@ -371,4 +371,69 @@ class ApiDocExtractorTest extends WebTestCase
         $this->assertTrue(is_array($data));
         $this->assertCount($count, $data);
     }
+
+    public function testOverrideJmsAnnotationWithApiDocParameters()
+    {
+        $container  = $this->getContainer();
+        $extractor  = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
+        $annotation = $extractor->get(
+            'Nelmio\ApiDocBundle\Tests\Fixtures\Controller\TestController::overrideJmsAnnotationWithApiDocParametersAction',
+            'test_route_27'
+        );
+
+        $this->assertInstanceOf('Nelmio\ApiDocBundle\Annotation\ApiDoc', $annotation);
+
+        $array = $annotation->toArray();
+        $this->assertTrue(is_array($array['parameters']));
+
+        $this->assertEquals('string', $array['parameters']['foo']['dataType']);
+        $this->assertEquals('DateTime', $array['parameters']['bar']['dataType']);
+
+        $this->assertEquals('integer', $array['parameters']['number']['dataType']);
+        $this->assertEquals('string', $array['parameters']['number']['actualType']);
+        $this->assertEquals(null, $array['parameters']['number']['subType']);
+        $this->assertEquals(true, $array['parameters']['number']['required']);
+        $this->assertEquals('This is the new description', $array['parameters']['number']['description']);
+        $this->assertEquals(false, $array['parameters']['number']['readonly']);
+        $this->assertEquals('v3.0', $array['parameters']['number']['sinceVersion']);
+        $this->assertEquals('v4.0', $array['parameters']['number']['untilVersion']);
+
+        $this->assertEquals('object (ArrayCollection)', $array['parameters']['arr']['dataType']);
+
+        $this->assertEquals('object (JmsNested)', $array['parameters']['nested']['dataType']);
+        $this->assertEquals('integer', $array['parameters']['nested']['children']['bar']['dataType']);
+        $this->assertEquals('d+', $array['parameters']['nested']['children']['bar']['format']);
+    }
+
+    public function testJmsAnnotation()
+    {
+        $container  = $this->getContainer();
+        $extractor  = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
+        $annotation = $extractor->get(
+            'Nelmio\ApiDocBundle\Tests\Fixtures\Controller\TestController::defaultJmsAnnotations',
+            'test_route_27'
+        );
+
+        $this->assertInstanceOf('Nelmio\ApiDocBundle\Annotation\ApiDoc', $annotation);
+
+        $array = $annotation->toArray();
+        $this->assertTrue(is_array($array['parameters']));
+
+        $this->assertEquals('string', $array['parameters']['foo']['dataType']);
+        $this->assertEquals('DateTime', $array['parameters']['bar']['dataType']);
+
+        $this->assertEquals('double', $array['parameters']['number']['dataType']);
+        $this->assertEquals('float', $array['parameters']['number']['actualType']);
+        $this->assertEquals(null, $array['parameters']['number']['subType']);
+        $this->assertEquals(false, $array['parameters']['number']['required']);
+        $this->assertEquals('', $array['parameters']['number']['description']);
+        $this->assertEquals(false, $array['parameters']['number']['readonly']);
+        $this->assertEquals(null, $array['parameters']['number']['sinceVersion']);
+        $this->assertEquals(null, $array['parameters']['number']['untilVersion']);
+
+        $this->assertEquals('array', $array['parameters']['arr']['dataType']);
+
+        $this->assertEquals('object (JmsNested)', $array['parameters']['nested']['dataType']);
+        $this->assertEquals('string', $array['parameters']['nested']['children']['bar']['dataType']);
+    }
 }

--- a/Tests/Fixtures/Controller/TestController.php
+++ b/Tests/Fixtures/Controller/TestController.php
@@ -334,4 +334,55 @@ class TestController
     public function withLinkAction()
     {
     }
+
+    /**
+     * @ApiDoc(
+     *     output="Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsTest",
+     *     input={
+     *         "class" = "Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsTest"
+     *     },
+     *     parameters={
+     *          {
+     *              "name"="number",
+     *              "dataType"="integer",
+     *              "actualType"="string",
+     *              "subType"=null,
+     *              "required"=true,
+     *              "description"="This is the new description",
+     *              "readonly"=false,
+     *              "sinceVersion"="v3.0",
+     *              "untilVersion"="v4.0"
+     *          },
+     *          {
+     *              "name"="arr",
+     *              "dataType"="object (ArrayCollection)"
+     *          },
+     *          {
+     *              "name"="nested",
+     *              "dataType"="object (JmsNested)",
+     *              "children": {
+     *                  "bar": {
+     *                      "dataType"="integer",
+     *                      "format"="d+"
+     *                  }
+     *              }
+     *          }
+     *     }
+     * )
+     */
+    public function overrideJmsAnnotationWithApiDocParametersAction()
+    {
+    }
+
+    /**
+     * @ApiDoc(
+     *     output="Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsTest",
+     *     input={
+     *         "class" = "Nelmio\ApiDocBundle\Tests\Fixtures\Model\JmsTest"
+     *     }
+     * )
+     */
+    public function defaultJmsAnnotations()
+    {
+    }
 }

--- a/Tests/Fixtures/app/config/routing.yml
+++ b/Tests/Fixtures/app/config/routing.yml
@@ -225,3 +225,8 @@ test_route_26:
     path:  /z-action-with-array-request-param
     methods: [POST]
     defaults: { _controller: NelmioApiDocTestBundle:Test:zActionWithArrayRequestParamAction }
+
+test_route_27:
+    path: /api/overrride/properties
+    methods: [POST, PUT]
+    defaults: { _controller: NelmioApiDocTestBundle:Test:overrideJmsAnnotationWithApiDocPropertiesAction, _format: json }


### PR DESCRIPTION
Patch for #739