### PR TITLE
Empty string is now a valid default parameter value

### DIFF
--- a/Extractor/ApiDocExtractor.php
+++ b/Extractor/ApiDocExtractor.php
@@ -484,7 +484,11 @@ class ApiDocExtractor
                                 $v1[$name] = $value;
                             }
                         } elseif ($name == 'default') {
-                            $v1[$name] = $value ?: $v1[$name];
+                            if (isset($v1[$name])) {
+                                $v1[$name] = isset($value) ? $value : $v1[$name];
+                            } else {
+                                $v1[$name] = isset($value) ? $value : null;
+                            }
                         } else {
                             $v1[$name] = $value;
                         }

--- a/Tests/Extractor/ApiDocExtractorTest.php
+++ b/Tests/Extractor/ApiDocExtractorTest.php
@@ -436,4 +436,39 @@ class ApiDocExtractorTest extends WebTestCase
         $this->assertEquals('object (JmsNested)', $array['parameters']['nested']['dataType']);
         $this->assertEquals('string', $array['parameters']['nested']['children']['bar']['dataType']);
     }
+
+    public function testMergeParametersDefaultKeyNotExistingInFirstArray()
+    {
+        $container = $this->getContainer();
+        $extractor = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
+
+        $mergeMethod = new \ReflectionMethod('Nelmio\ApiDocBundle\Extractor\ApiDocExtractor', 'mergeParameters');
+        $mergeMethod->setAccessible(true);
+
+        $p1 = [
+            'myPropName' => [
+                'dataType'    => 'string',
+                'actualType'  => 'string',
+                'subType'     => null,
+                'required'    => null,
+                'description' => null,
+                'readonly'    => null,
+            ]
+        ];
+
+        $p2 = [
+            'myPropName' => [
+                'dataType'    => 'string',
+                'actualType'  => 'string',
+                'subType'     => null,
+                'required'    => null,
+                'description' => null,
+                'readonly'    => null,
+                'default'     => '',
+            ]
+        ];
+
+        $mergedResult = $mergeMethod->invokeArgs($extractor, [$p1, $p2]);
+        $this->assertEquals($p2, $mergedResult);
+    }
 }


### PR DESCRIPTION
Empty string is now a valid default parameter value that is successfully merged with other parameters
Preventing access of uninitialized array key 'default'
Added functional test case for mergeParameters that covers this issue