### PR TITLE
Introduced default-value parameter to JsonSerializableParser

### DIFF
--- a/Parser/JsonSerializableParser.php
+++ b/Parser/JsonSerializableParser.php
@@ -59,7 +59,8 @@ class JsonSerializableParser implements ParserInterface
             'subType' => null,
             'required' => null,
             'description' => null,
-            'readonly' => null
+            'readonly' => null,
+            'default' => is_scalar($item) ? $item : null,
         );
 
         if ($type == 'object' && $item instanceof \JsonSerializable) {

--- a/Tests/Parser/JsonSerializableParserTest.php
+++ b/Tests/Parser/JsonSerializableParserTest.php
@@ -46,13 +46,15 @@ class JsonSerializableParserTest extends \PHPUnit_Framework_TestCase
             array(
                 'property' => 'id',
                 'expected' => array(
-                    'dataType' => 'integer'
+                    'dataType' => 'integer',
+                    'default'  => 123
                 )
             ),
             array(
                 'property' => 'name',
                 'expected' => array(
-                    'dataType' => 'string'
+                    'dataType' => 'string',
+                    'default'  => 'My name',
                 )
             ),
             array(
@@ -66,7 +68,8 @@ class JsonSerializableParserTest extends \PHPUnit_Framework_TestCase
                             'subType' => null,
                             'required' => null,
                             'description' => null,
-                            'readonly' => null
+                            'readonly' => null,
+                            'default' => null,
                         )
                     )
                 )


### PR DESCRIPTION
JSP is now able to set a default value for scalar types
This makes merging the parser result with other parser results easier
and gives some additional info when creating docs