### PR TITLE
Fix route host with placeholder

### DIFF
--- a/Annotation/ApiDoc.php
+++ b/Annotation/ApiDoc.php
@@ -476,6 +476,11 @@ class ApiDoc
 
         if (method_exists($route, 'getHost')) {
             $this->host = $route->getHost() ? : null;
+
+            //replace route placeholders
+             foreach ($route->getDefaults() as $key => $value) {
+                $this->host = str_replace('{' . $key . '}', $value, $this->host);
+            }
         } else {
             $this->host = null;
         }

--- a/Tests/Extractor/ApiDocExtractorTest.php
+++ b/Tests/Extractor/ApiDocExtractorTest.php
@@ -19,7 +19,7 @@ class ApiDocExtractorTest extends WebTestCase
 {
     const NB_ROUTES_ADDED_BY_DUNGLAS_API_BUNDLE = 5;
 
-    private static $ROUTES_QUANTITY_DEFAULT = 33; // Routes in the default view
+    private static $ROUTES_QUANTITY_DEFAULT = 34; // Routes in the default view
     private static $ROUTES_QUANTITY_PREMIUM = 6;  // Routes in the premium view
     private static $ROUTES_QUANTITY_TEST    = 2;  // Routes in the test view
 
@@ -40,7 +40,7 @@ class ApiDocExtractorTest extends WebTestCase
         $data = $extractor->all();
         restore_error_handler();
 
-        $httpsKey = 20;
+        $httpsKey = 21;
         if (class_exists('Dunglas\ApiBundle\DunglasApiBundle')) {
             $httpsKey += self::NB_ROUTES_ADDED_BY_DUNGLAS_API_BUNDLE;
         }
@@ -69,13 +69,6 @@ class ApiDocExtractorTest extends WebTestCase
         $this->assertTrue(is_array($array1['filters']));
         $this->assertNull($a1->getInput());
 
-        $a1 = $data[7]['annotation'];
-        $array1 = $a1->toArray();
-        $this->assertTrue($a1->isResource());
-        $this->assertEquals('index action', $a1->getDescription());
-        $this->assertTrue(is_array($array1['filters']));
-        $this->assertNull($a1->getInput());
-
         $a2 = $data[8]['annotation'];
         $array2 = $a2->toArray();
         $this->assertFalse($a2->isResource());
@@ -90,12 +83,17 @@ class ApiDocExtractorTest extends WebTestCase
         $this->assertFalse(isset($array2['filters']));
         $this->assertEquals('Nelmio\ApiDocBundle\Tests\Fixtures\Form\TestType', $a2->getInput());
 
+        $a3 = $data[$httpsKey]['annotation'];
+        $this->assertTrue($a3->getHttps());
+
         $a4 = $data[11]['annotation'];
         $this->assertTrue($a4->isResource());
         $this->assertEquals('TestResource', $a4->getResource());
 
-        $a3 = $data[$httpsKey]['annotation'];
-        $this->assertTrue($a3->getHttps());
+        $a5 = $data[$httpsKey - 1]['annotation'];
+        $a5requirements = $a5->getRequirements();
+        $this->assertEquals('api.test.dev', $a5->getHost());
+        $this->assertEquals('test.dev|test.com', $a5requirements['domain']['requirement']);
     }
 
     public function testGet()

--- a/Tests/Fixtures/Controller/TestController.php
+++ b/Tests/Fixtures/Controller/TestController.php
@@ -385,4 +385,14 @@ class TestController
     public function defaultJmsAnnotations()
     {
     }
+
+    /**
+     * @ApiDoc(
+     *  description="Route with host placeholder",
+     *  views={ "default" }
+     * )
+     */
+    public function routeWithHostAction()
+    {
+    }
 }

--- a/Tests/Fixtures/app/config/default.yml
+++ b/Tests/Fixtures/app/config/default.yml
@@ -27,6 +27,10 @@ services:
         tags:
             - { name: form.type, alias: dependency_type }
 
+parameters:
+    domain_prod: test.com
+    domain_dev: test.dev
+
 #JMS Serializer config for testing JmsMetadataParser
 jms_serializer:
     handlers:

--- a/Tests/Fixtures/app/config/routing.yml
+++ b/Tests/Fixtures/app/config/routing.yml
@@ -230,3 +230,11 @@ test_route_27:
     path: /api/overrride/properties
     methods: [POST, PUT]
     defaults: { _controller: NelmioApiDocTestBundle:Test:overrideJmsAnnotationWithApiDocPropertiesAction, _format: json }
+
+test_route_28:
+    path: /route_with_host.{_format}
+    host: api.{domain}
+    methods: [GET]
+    requirements:
+        domain: "%domain_dev%|%domain_prod%"
+    defaults: { _controller: NelmioApiDocTestBundle:Test:routeWithHost, domain: "%domain_dev%", _format: json }

--- a/Tests/Formatter/testFormat-result-no-dunglas.markdown
+++ b/Tests/Formatter/testFormat-result-no-dunglas.markdown
@@ -733,6 +733,19 @@ nested_array[]:
   * type: array of objects (JmsNested)
 
 
+### `GET` /route_with_host.{_format} ###
+
+_Route with host placeholder_
+
+#### Requirements ####
+
+**domain**
+
+  - Requirement: test.dev|test.com
+**_format**
+
+
+
 ### `ANY` /secure-route ###
 
 

--- a/Tests/Formatter/testFormat-result-no-dunglas.php
+++ b/Tests/Formatter/testFormat-result-no-dunglas.php
@@ -1855,17 +1855,49 @@ With multiple lines.',
       'deprecated' => false,
     ),
     8 =>
+      array (
+        'method' => 'GET',
+        'uri' => '/route_with_host.{_format}',
+        'host' => 'api.test.dev',
+        'description' => 'Route with host placeholder',
+        'requirements' =>
+        array (
+          'domain' =>
+          array (
+              'requirement' => 'test.dev|test.com',
+              'dataType' => '',
+              'description' => '',
+          ),
+        '_format' =>
+          array (
+            'requirement' => '',
+            'dataType' => '',
+            'description' => '',
+          ),
+      ),
+      'views' =>
+      array (
+          0 => 'default',
+      ),
+      'https' => false,
+      'authentication' => false,
+      'authenticationRoles' =>
+          array (
+          ),
+      'deprecated' => false,
+    ),
+    9 =>
     array (
       'method' => 'ANY',
       'uri' => '/secure-route',
       'https' => true,
       'authentication' => false,
       'authenticationRoles' =>
-      array (
-      ),
+        array (
+        ),
       'deprecated' => false,
     ),
-    9 =>
+    10 =>
     array (
       'method' => 'ANY',
       'uri' => '/yet-another/{id}',
@@ -1885,7 +1917,7 @@ With multiple lines.',
       ),
       'deprecated' => false,
     ),
-    10 =>
+    11 =>
     array (
       'method' => 'GET',
       'uri' => '/z-action-with-deprecated-indicator',
@@ -1896,7 +1928,7 @@ With multiple lines.',
       ),
       'deprecated' => true,
     ),
-    11 =>
+    12 =>
     array (
       'method' => 'POST',
       'uri' => '/z-action-with-nullable-request-param',
@@ -1919,7 +1951,7 @@ With multiple lines.',
       ),
       'deprecated' => false,
     ),
-    12 =>
+    13 =>
     array (
       'method' => 'GET',
       'uri' => '/z-action-with-query-param',
@@ -1939,7 +1971,7 @@ With multiple lines.',
       ),
       'deprecated' => false,
     ),
-    13 =>
+    14 =>
     array (
       'method' => 'GET',
       'uri' => '/z-action-with-query-param-no-default',
@@ -1958,7 +1990,7 @@ With multiple lines.',
       ),
       'deprecated' => false,
     ),
-    14 =>
+    15 =>
     array (
       'method' => 'GET',
       'uri' => '/z-action-with-query-param-strict',
@@ -1978,7 +2010,7 @@ With multiple lines.',
       ),
       'deprecated' => false,
     ),
-    15 =>
+    16 =>
     array (
       'method' => 'POST',
       'uri' => '/z-action-with-request-param',
@@ -2001,7 +2033,7 @@ With multiple lines.',
       ),
       'deprecated' => false,
     ),
-    16 =>
+    17 =>
     array (
       'method' => 'ANY',
       'uri' => '/z-return-jms-and-validator-output',
@@ -2101,7 +2133,7 @@ With multiple lines.',
       ),
       'deprecated' => false,
     ),
-    17 =>
+    18 =>
     array (
       'method' => 'ANY',
       'uri' => '/z-return-selected-parsers-input',
@@ -2155,7 +2187,7 @@ With multiple lines.',
       ),
       'deprecated' => false,
     ),
-    18 =>
+    19 =>
     array (
       'method' => 'ANY',
       'uri' => '/z-return-selected-parsers-output',
@@ -2255,7 +2287,7 @@ With multiple lines.',
       ),
       'deprecated' => false,
     ),
-    19 =>
+    20 =>
     array (
       'method' => 'POST',
       'uri' => '/zcached',
@@ -2267,7 +2299,7 @@ With multiple lines.',
       ),
       'deprecated' => false,
     ),
-    20 =>
+    21 =>
     array (
       'method' => 'POST',
       'uri' => '/zsecured',

--- a/Tests/Formatter/testFormat-result.markdown
+++ b/Tests/Formatter/testFormat-result.markdown
@@ -817,6 +817,19 @@ nested_array[]:
   * type: array of objects (JmsNested)
 
 
+### `GET` /route_with_host.{_format} ###
+
+_Route with host placeholder_
+
+#### Requirements ####
+
+**domain**
+
+  - Requirement: test.dev|test.com
+**_format**
+
+
+
 ### `ANY` /secure-route ###
 
 

--- a/Tests/Formatter/testFormat-result.php
+++ b/Tests/Formatter/testFormat-result.php
@@ -2010,6 +2010,38 @@ With multiple lines.',
                 ),
             13 =>
                 array (
+                    'method' => 'GET',
+                    'uri' => '/route_with_host.{_format}',
+                    'host' => 'api.test.dev',
+                    'description' => 'Route with host placeholder',
+                    'requirements' =>
+                        array (
+                            'domain' =>
+                                array (
+                                    'requirement' => 'test.dev|test.com',
+                                    'dataType' => '',
+                                    'description' => '',
+                                ),
+                            '_format' =>
+                                array (
+                                    'requirement' => '',
+                                    'dataType' => '',
+                                    'description' => '',
+                                ),
+                        ),
+                    'views' =>
+                        array (
+                            0 => 'default',
+                        ),
+                    'https' => false,
+                    'authentication' => false,
+                    'authenticationRoles' =>
+                        array (
+                        ),
+                    'deprecated' => false,
+                ),
+            14 =>
+                array (
                     'method' => 'ANY',
                     'uri' => '/secure-route',
                     'https' => true,
@@ -2019,7 +2051,7 @@ With multiple lines.',
                         ),
                     'deprecated' => false,
                 ),
-            14 =>
+            15 =>
                 array (
                     'method' => 'ANY',
                     'uri' => '/yet-another/{id}',
@@ -2039,7 +2071,7 @@ With multiple lines.',
                         ),
                     'deprecated' => false,
                 ),
-            15 =>
+            16 =>
                 array (
                     'method' => 'GET',
                     'uri' => '/z-action-with-deprecated-indicator',
@@ -2050,7 +2082,7 @@ With multiple lines.',
                         ),
                     'deprecated' => true,
                 ),
-            16 =>
+            17 =>
                 array (
                     'method' => 'POST',
                     'uri' => '/z-action-with-nullable-request-param',
@@ -2073,7 +2105,7 @@ With multiple lines.',
                         ),
                     'deprecated' => false,
                 ),
-            17 =>
+            18 =>
                 array (
                     'method' => 'GET',
                     'uri' => '/z-action-with-query-param',
@@ -2093,7 +2125,7 @@ With multiple lines.',
                         ),
                     'deprecated' => false,
                 ),
-            18 =>
+            19 =>
                 array (
                     'method' => 'GET',
                     'uri' => '/z-action-with-query-param-no-default',
@@ -2112,7 +2144,7 @@ With multiple lines.',
                         ),
                     'deprecated' => false,
                 ),
-            19 =>
+            20 =>
                 array (
                     'method' => 'GET',
                     'uri' => '/z-action-with-query-param-strict',
@@ -2132,7 +2164,7 @@ With multiple lines.',
                         ),
                     'deprecated' => false,
                 ),
-            20 =>
+            21 =>
                 array (
                     'method' => 'POST',
                     'uri' => '/z-action-with-request-param',
@@ -2155,7 +2187,7 @@ With multiple lines.',
                         ),
                     'deprecated' => false,
                 ),
-            21 =>
+            22 =>
                 array (
                     'method' => 'ANY',
                     'uri' => '/z-return-jms-and-validator-output',
@@ -2255,7 +2287,7 @@ With multiple lines.',
                         ),
                     'deprecated' => false,
                 ),
-            22 =>
+            23 =>
                 array (
                     'method' => 'ANY',
                     'uri' => '/z-return-selected-parsers-input',
@@ -2309,7 +2341,7 @@ With multiple lines.',
                         ),
                     'deprecated' => false,
                 ),
-            23 =>
+            24 =>
                 array (
                     'method' => 'ANY',
                     'uri' => '/z-return-selected-parsers-output',
@@ -2409,7 +2441,7 @@ With multiple lines.',
                         ),
                     'deprecated' => false,
                 ),
-            24 =>
+            25 =>
                 array (
                     'method' => 'POST',
                     'uri' => '/zcached',
@@ -2421,7 +2453,7 @@ With multiple lines.',
                         ),
                     'deprecated' => false,
                 ),
-            25 =>
+            26 =>
                 array (
                     'method' => 'POST',
                     'uri' => '/zsecured',


### PR DESCRIPTION
I have a routing file:
```yml
api_v1:
    resource: "@ApiBundle/Resources/config/routing.yml"
    prefix:   /v1
    host:     api.{domain}
    defaults:
        domain: "%domain%"
    requirements:
        domain: "%domain%"
```

Currently documentation looks like this:
![route](https://cloud.githubusercontent.com/assets/154553/11051259/f481579e-874d-11e5-9f99-3776f52811b1.png)

After this PR placeholder is replacement by default parameter:

![route2](https://cloud.githubusercontent.com/assets/154553/11051284/272d94f0-874e-11e5-89eb-a0137be25fa1.png)