### PR TITLE
Make filters always be passed as query string parameters in sandbox requests

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -385,8 +385,10 @@
                         method = $('[name="header_method"]', this).val(),
                         self = this,
                         params = {},
+                        filters = {},
                         formData = new FormData(),
                         doubledParams = {},
+                        doubledFilters = {},
                         headers = {},
                         content = $(this).find('textarea.content').val(),
                         result_container = $('.result', $(this).parent());
@@ -471,6 +473,26 @@
 
 
 
+                    // retrieve all the filters to send
+                    $('.parameters .tuple .filter', $(this)).each(function() {
+                        var key, value;
+
+                        key = $('.key', $(this)).val();
+                        value = $('.value', $(this)).val();
+
+                        if (value) {
+                            // temporary save all additional/doubled parameters
+                            if (key in filters) {
+                                doubledFilters[key] = value;
+                            } else {
+                                filters[key] = value;
+                            }
+                        }
+                    });
+
+
+
+
                     // retrieve the additional headers to send
                     $('.headers .tuple', $(this)).each(function() {
                         var key, value;
@@ -518,6 +540,18 @@
                         endpoint = $('#api_endpoint').val();
                     }
                     {% endif %}
+
+                    //add filters as GET params and remove them from params
+                    if(method != 'GET'){
+                        for (var filterKey in $.extend({}, filters)){
+                            url += url.indexOf('?') > 0 ? '&' : '?';
+                            url += filterKey + '=' + filters[filterKey];
+
+                            if (params.hasOwnProperty(filterKey)){
+                                delete(params[filterKey]);
+                            }
+                        }
+                    }
 
                     // prepare final parameters
                     var body = {};

--- a/Resources/views/method.html.twig
+++ b/Resources/views/method.html.twig
@@ -217,7 +217,7 @@
                                 {% if data.filters is defined %}
                                     <h4>Filters</h4>
                                     {% for name, infos in data.filters %}
-                                        <p class="tuple">
+                                        <p class="tuple filter">
                                             <input type="text" class="key" value="{{ name }}" placeholder="Key" />
                                             <span>=</span>
                                             <input type="text" class="value" placeholder="{% if infos.description is defined %}{{ infos.description }}{% else %}Value{% endif %}" {% if infos.default is defined %} value="{{ infos.default }}" {% endif %}/> <span class="remove">-</span>


### PR DESCRIPTION
As described in [an issue of NelmioApiDocBundle](https://github.com/nelmio/NelmioApiDocBundle/issues/580), currently all filters are sent as POST parameters on non-GET requests in the sandbox.
I've modified the HTML templeate of the methods to be able to tell filters and parameters apart (method.html.twig) and added some code to the JavaScript making the ajax call, to append the filters to the URL if necessary.
