### PR TITLE
Check for deprecated method enterScope() in DumpCommand

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -61,7 +61,7 @@ class DumpCommand extends ContainerAwareCommand
             $formatter->setEnableSandbox(false);
         }
 
-        if ('html' === $format) {
+        if ('html' === $format && method_exists($this->getContainer(), 'enterScope')) {
             $this->getContainer()->enterScope('request');
             $this->getContainer()->set('request', new Request(), 'request');
         }


### PR DESCRIPTION
The dump command uses ContainerInterface::enterScope, which was deprecated in Symfony 2.8 and removed in 3.0.