### PR TITLE
Fix Array to string conversion error on array requirements

### DIFF
--- a/Extractor/Handler/FosRestHandler.php
+++ b/Extractor/Handler/FosRestHandler.php
@@ -83,6 +83,10 @@ class FosRestHandler implements HandlerInterface
             return substr($class, strrpos($class, '\\')+1);
         }
 
+        if (is_array($requirements) && isset($requirements['rule'])) {
+            return (string) $requirements['rule'];
+        }
+
         return (string) $requirements;
     }
 

--- a/Tests/Extractor/Handler/FosRestHandlerTest.php
+++ b/Tests/Extractor/Handler/FosRestHandlerTest.php
@@ -175,4 +175,18 @@ class FosRestHandlerTest extends WebTestCase
         $this->assertArrayHasKey('dataType', $parameter);
         $this->assertEquals('string[]', $parameter['dataType']);
     }
+
+    public function testWithRequestParamArrayRequirements()
+    {
+        $container  = $this->getContainer();
+        $extractor  = $container->get('nelmio_api_doc.extractor.api_doc_extractor');
+        $annotation = $extractor->get('Nelmio\ApiDocBundle\Tests\Fixtures\Controller\TestController::routeWithQueryParamArrayRequirementsAction', 'test_route_29');
+
+        $this->assertNotNull($annotation);
+        $filters = $annotation->getFilters();
+
+        $this->assertArrayHasKey('param1', $filters);
+        $this->assertArrayHasKey('requirement', $filters['param1']);
+        $this->assertEquals('regexp', $filters['param1']['requirement']);
+    }
 }

--- a/Tests/Fixtures/Controller/TestController.php
+++ b/Tests/Fixtures/Controller/TestController.php
@@ -398,4 +398,12 @@ class TestController
     public function routeWithHostAction()
     {
     }
+
+    /**
+     * @ApiDoc()
+     * @QueryParam(name="param1", requirements={"rule": "regexp", "error_message": "warning"}, description="Param1 description.")
+     */
+    public function routeWithQueryParamArrayRequirementsAction()
+    {
+    }
 }

--- a/Tests/Fixtures/app/config/routing.yml
+++ b/Tests/Fixtures/app/config/routing.yml
@@ -238,3 +238,8 @@ test_route_28:
     requirements:
         domain: "%domain_dev%|%domain_prod%"
     defaults: { _controller: NelmioApiDocTestBundle:Test:routeWithHost, domain: "%domain_dev%", _format: json }
+
+test_route_29:
+    path: /z-query-param-array-requirements
+    methods: [GET]
+    defaults: { _controller: NelmioApiDocTestBundle:Test:routeWithQueryParamArrayRequirementsAction }


### PR DESCRIPTION
FOSRestBundle QueryParam annotation allow array as a requirement, with keys "rule" and "error_message".

Fix https://github.com/nelmio/NelmioApiDocBundle/issues/773
See https://github.com/FriendsOfSymfony/FOSRestBundle/pull/1015