### PR TITLE
Change private to protected for global vars

### DIFF
--- a/Formatter/HtmlFormatter.php
+++ b/Formatter/HtmlFormatter.php
@@ -222,7 +222,7 @@ class HtmlFormatter extends AbstractFormatter
     /**
      * @return array
      */
-    private function getGlobalVars()
+    protected function getGlobalVars()
     {
         return array(
             'apiName'               => $this->apiName,


### PR DESCRIPTION
I need to extend your class, but the function "getGlobalVars" is private.