### PR TITLE
Use the response map in the html view

### DIFF
--- a/Annotation/ApiDoc.php
+++ b/Annotation/ApiDoc.php
@@ -675,6 +675,10 @@ class ApiDoc
             $data['response'] = $response;
         }
 
+        if ($parsedResponseMap = $this->parsedResponseMap) {
+            $data['parsedResponseMap'] = $parsedResponseMap;
+        }
+
         if ($statusCodes = $this->statusCodes) {
             $data['statusCodes'] = $statusCodes;
         }

--- a/Formatter/AbstractFormatter.php
+++ b/Formatter/AbstractFormatter.php
@@ -129,6 +129,12 @@ abstract class AbstractFormatter implements FormatterInterface
             $annotation['response'] = $this->compressNestedParameters($annotation['response']);
         }
 
+        if (isset($annotation['parsedResponseMap'])) {
+            foreach ($annotation['parsedResponseMap'] as $statusCode => &$data) {
+                $data['model'] = $this->compressNestedParameters($data['model']);
+            }
+        }
+
         $annotation['id'] = strtolower($annotation['method']).'-'.str_replace('/', '-', $annotation['uri']);
 
         return $annotation;

--- a/Formatter/SimpleFormatter.php
+++ b/Formatter/SimpleFormatter.php
@@ -30,7 +30,10 @@ class SimpleFormatter extends AbstractFormatter
     {
         $array = array();
         foreach ($collection as $coll) {
-            $array[$coll['resource']][] = $coll['annotation']->toArray();
+            $annotationArray = $coll['annotation']->toArray();
+            unset($annotationArray['parsedResponseMap']);
+
+            $array[$coll['resource']][] = $annotationArray;
         }
 
         return $array;

--- a/Resources/views/method.html.twig
+++ b/Resources/views/method.html.twig
@@ -139,27 +139,39 @@
                 </table>
             {% endif %}
 
-            {% if data.response is defined and data.response is not empty %}
+            {% if data.parsedResponseMap is defined and data.parsedResponseMap is not empty %}
                 <h4>Return</h4>
                 <table class='fullwidth'>
                     <thead>
-                        <tr>
-                            <th>Parameter</th>
-                            <th>Type</th>
-                            <th>Versions</th>
-                            <th>Description</th>
-                        </tr>
+                    <tr>
+                        <th>Parameter</th>
+                        <th>Type</th>
+                        <th>Versions</th>
+                        <th>Description</th>
+                    </tr>
                     </thead>
+                {% for status_code, response in data.parsedResponseMap %}
                     <tbody>
-                        {% for name, infos in data.response %}
-                            <tr>
-                                <td>{{ name }}</td>
-                                <td>{{ infos.dataType }}</td>
-                                <td>{% include 'NelmioApiDocBundle:Components:version.html.twig' with {'sinceVersion': infos.sinceVersion, 'untilVersion': infos.untilVersion} only %}</td>
-                                <td>{{ infos.description }}</td>
-                            </tr>
-                        {% endfor %}
+                        <tr>
+                            <td>
+                                <h4>
+                                    {{ status_code }}
+                                    {% if data.statusCodes[status_code] is defined %}
+                                        - {{ data.statusCodes[status_code]|join(', ') }}
+                                    {% endif %}
+                                </h4>
+                            </td>
+                        </tr>
+                    {% for name, infos in response.model %}
+                        <tr>
+                            <td>{{ name }}</td>
+                            <td>{{ infos.dataType }}</td>
+                            <td>{% include 'NelmioApiDocBundle:Components:version.html.twig' with {'sinceVersion': infos.sinceVersion, 'untilVersion': infos.untilVersion} only %}</td>
+                            <td>{{ infos.description }}</td>
+                        </tr>
+                    {% endfor %}
                     </tbody>
+                {% endfor %}
                 </table>
             {% endif %}
 


### PR DESCRIPTION
This PR adds an HTML view for the response map configuration.

Related issue:  #789

## Result:

![result_map2](https://cloud.githubusercontent.com/assets/776488/12571770/dd8f2dee-c3e4-11e5-9537-9c644f6a2476.png)

## Config

```php
    /**
     * @ApiDoc(
     *     description = "Registers a new user",
     *     section = "User",
     *     https = true,
     *     authentication = false,
     *     input = {
     *         "class" = RegistrationType::class,
     *         "name" = ""
     *     },
     *     statusCodes = {
     *         200 = "Success.",
     *         400 = "Validation failed."
     *     },
     *     responseMap = {
     *         200 = {
     *             "class" = User::class,
     *             "parsers" = {
     *                 JmsMetadataParser::class
     *             }
     *         },
     *         400 = {
     *             "class" = RegistrationType::class,
     *             "form_errors" = true,
     *             "name" = ""
     *         },
     *     }
     * )
     */
```