### PR TITLE
Remove incorrect usage of hasOption

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -47,7 +47,7 @@ class DumpCommand extends ContainerAwareCommand
 
         $routeCollection = $this->getContainer()->get('router')->getRouteCollection();
 
-        if (!$input->hasOption('format') || in_array($format, array('json'))) {
+        if ($format == 'json') {
             $formatter = $this->getContainer()->get('nelmio_api_doc.formatter.simple_formatter');
         } else {
             if (!in_array($format, $this->availableFormats)) {


### PR DESCRIPTION
`hasOption` is confusingly named, it actually checks that the option has been created, not if the user has passed the option. So in this case its always true.
Also changed a weird usage of `in_array`.