### PR TITLE
Fixed bug with wrong form parsing when several custom inner types exist

### DIFF
--- a/Parser/FormTypeParser.php
+++ b/Parser/FormTypeParser.php
@@ -263,6 +263,11 @@ class FormTypeParser implements ParserInterface
                          */
                         $addDefault = false;
                         try {
+
+                            if (isset($subForm)) {
+                                unset($subForm);
+                            }
+
                             if (LegacyFormHelper::hasBCBreaks()) {
                                 try {
                                     $subForm = $this->formFactory->create(get_class($type), null, $options);


### PR DESCRIPTION
Fix to issue
https://github.com/nelmio/NelmioApiDocBundle/issues/798

There is a loop, and if there are few iterations, the previously defined $subForm variable causes wrong behaviour
