### PR TITLE
Status codes were added to Markdown

### DIFF
--- a/Formatter/MarkdownFormatter.php
+++ b/Formatter/MarkdownFormatter.php
@@ -123,6 +123,19 @@ class MarkdownFormatter extends AbstractFormatter
                 $markdown .= "\n";
             }
         }
+        
+        if (isset($data['statusCodes'])) {
+            $markdown .= "#### Status Codes ####\n\n";
+            foreach ($data['statusCodes'] as $httpCode => $descriptions) {
+                $markdown .= sprintf("%s:\n\n", $httpCode);
+
+                foreach ($descriptions as $description) {
+                    $markdown .= sprintf("  * %s\n", $description);
+                }
+
+                $markdown .= "\n";
+            }
+        }
 
         return $markdown;
     }


### PR DESCRIPTION
Unfortunately before it was not possible to see status codes in Markdown format.
It's work in progress, because I've not updated unit tests yet. Any suggestions are welcome.