### PR TITLE
Change visibility of markdownParser property to protected

### DIFF
--- a/Twig/Extension/MarkdownExtension.php
+++ b/Twig/Extension/MarkdownExtension.php
@@ -6,7 +6,7 @@ use Michelf\MarkdownExtra;
 
 class MarkdownExtension extends \Twig_Extension
 {
-    private $markdownParser;
+    protected $markdownParser;
 
     public function __construct()
     {


### PR DESCRIPTION
The `MarkdownExtra` class has quite some settings, but with the current setup, it's very cumbersome to set them.

The easiest way to achieve this, is by extending the `MarkdownExtension` and setting the properties directly on the instance referenced by `markdownParser`. Moving the `MarkdownExtra` instance to the DI makes no sense currently, because it doesn't really provide nice setters/getters and requires closures at some point.

So I see no point in the `markdownParser` property being private.
- If it stays private, I have to make my own class property and instance of the `MarkdownExtra` class. 
- If I want to override the `MarkdownExtension` right now, I have to copy more code, which could be avoided by extending the MarkdownExtension class and having access to the `markdownParser` property.
