### PR TITLE
Fixed link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For documentation, see:
 
     Resources/doc/
 
-[Read the documentation](https://github.com/nelmio/NelmioApiDocBundle/blob/master/Resources/doc/index.md)
+[Read the documentation](https://github.com/nelmio/NelmioApiDocBundle/blob/master/Resources/doc/index.rst)
 
 
 Contributing


### PR DESCRIPTION
Link to ApiDoc documentation is now with ReST format instead of Markdown