### PR TITLE
Allow sending empty file data

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -443,6 +443,9 @@
                             key = $('.key', $(this)).val();
                             if ($('.value', $(this)).attr('type') === 'file' ) {
                                 value = $('.value', $(this)).prop('files')[0];
+                                if(!value) {
+                                    value = new File([], '');
+                                }
                             } else {
                                 value = $('.value', $(this)).val();
                             }


### PR DESCRIPTION
When using Vich uploader bundle null file value is used for preventing existing resource. If there is no file value, resource will be deleted. 