### PR TITLE
Fix parameters return when JMS @Groups are used.

### DIFF
--- a/Parser/ValidationParser.php
+++ b/Parser/ValidationParser.php
@@ -61,6 +61,10 @@ class ValidationParser implements ParserInterface, PostParserInterface
      */
     public function supports(array $input)
     {
+        if ($input['groups']){
+            return false;
+        }
+
         $className = $input['class'];
 
         return $this->factory->hasMetadataFor($className);


### PR DESCRIPTION
In special cases parameters returns do not match with JMS groups setting. 
See https://github.com/nelmio/NelmioApiDocBundle/issues/525#issuecomment-210201397