### PR TITLE
Added translation to description

### DIFF
--- a/Resources/views/method.html.twig
+++ b/Resources/views/method.html.twig
@@ -131,7 +131,7 @@
                                     <td>{{ infos.dataType is defined ? infos.dataType : '' }}</td>
                                     <td>{{ infos.required ? 'true' : 'false' }}</td>
                                     <td>{{ infos.format }}</td>
-                                    <td>{{ infos.description is defined ? infos.description : ''  }}</td>
+                                    <td>{{ infos.description is defined ? infos.description|trans : ''  }}</td>
                                 </tr>
                             {% endif %}
                         {% endfor %}


### PR DESCRIPTION
The labels of a field are usually translated. But this does not happen in the documentation.