### PR TITLE
Update ApiDocExtractor.php

### DIFF
--- a/Extractor/ApiDocExtractor.php
+++ b/Extractor/ApiDocExtractor.php
@@ -324,9 +324,9 @@ class ApiDocExtractor
 
             if ('PATCH' === $annotation->getMethod()) {
                 // All parameters are optional with PATCH (update)
-                array_walk($parameters, function ($val, $key) use (&$parameters) {
+                foreach ($parameters as $key => $val) {
                     $parameters[$key]['required'] = false;
-                });
+                }
             }
 
             // merge parameters with parameters block from ApiDoc annotation in controller method


### PR DESCRIPTION
[The original code](https://github.com/nelmio/NelmioApiDocBundle/commit/cca97cf6af060a5bd3d61e6c83554425e097ee13#diff-d29530867a19f2c302d4fadcfcd23e48R224) doesn't seem to do anything with `$parameters` because `$parameters` is not declared in the function scope, so basically you are creating a new `$parameters` in function scope and not do anything with it. `array_walk` is suppose to modify the `$val` by reference. So basically this has been broken for more than a year until [this commit](https://github.com/nelmio/NelmioApiDocBundle/commit/f625d9671c9a7a4cd886949755a33e74f656a497). Now the new code is still really confusing and possibly slower than a normal foreach. I guess `array_walk` has been left in because of the original code.

This would yet be another implementation of the same

``` php
                $parameters = array_map(function($item) {
                    $item['required'] = false;
                    return $item;
                }, $parameters);
```
