### PR TITLE
Allow custom ApiDoc annotation

### DIFF
--- a/Extractor/ApiDocExtractor.php
+++ b/Extractor/ApiDocExtractor.php
@@ -122,7 +122,7 @@ class ApiDocExtractor
             }
 
             if ($method = $this->getReflectionMethod($route->getDefault('_controller'))) {
-                $annotation = $this->reader->getMethodAnnotation($method, self::ANNOTATION_CLASS);
+                $annotation = $this->reader->getMethodAnnotation($method, static::ANNOTATION_CLASS);
                 if (
                     $annotation && !in_array($annotation->getSection(), $excludeSections) &&
                     (in_array($view, $annotation->getViews()) || (0 === count($annotation->getViews()) && $view === ApiDoc::DEFAULT_VIEW))
@@ -255,7 +255,7 @@ class ApiDocExtractor
     public function get($controller, $route)
     {
         if ($method = $this->getReflectionMethod($controller)) {
-            if ($annotation = $this->reader->getMethodAnnotation($method, self::ANNOTATION_CLASS)) {
+            if ($annotation = $this->reader->getMethodAnnotation($method, static::ANNOTATION_CLASS)) {
                 if ($route = $this->router->getRouteCollection()->get($route)) {
                     return $this->extractData($annotation, $route, $method);
                 }


### PR DESCRIPTION
When we override templates, we sometimes need project related informations to appear in the documentation. So the **ApiDoc** annotation is not sufficient : we need to add variables to this class.

Solution : create a child class of ApiDoc. Then we also need to create a child class of the **ApiDocExtractor** to override the **ANNOTATION_CLASS** constant. And here comes the problem.

`self::ANNOTATION_CLASS` does not support inheritance
`static:ANNOTATION_CLASS` does

I think it could be a good improvement to help creating more complete documentations, with more project related details.

Thanks.