### PR TITLE
Added recursive parsing of subtypes

### DIFF
--- a/Parser/ValidationParser.php
+++ b/Parser/ValidationParser.php
@@ -200,6 +200,8 @@ class ValidationParser implements ParserInterface, PostParserInterface
             case 'Type':
                 if (isset($this->typeMap[$constraint->type])) {
                     $vparams['actualType'] = $this->typeMap[$constraint->type];
+                } else {
+                    $vparams['children'] = $this->doParse($constraint->type, $visited);
                 }
                 $vparams['dataType'] = $constraint->type;
                 break;


### PR DESCRIPTION
This change makes it possible for the parser to handle validation constraints specified on subtypes referenced in `@Assert\Type` annotations.
