### PR TITLE
Add navigation index for resources

### DIFF
--- a/Resources/views/resources.html.twig
+++ b/Resources/views/resources.html.twig
@@ -1,6 +1,13 @@
 {% extends "NelmioApiDocBundle::layout.html.twig" %}
 
 {% block content %}
+    <div id="summary">
+        <ul>
+            {% for section, sections in resources  %}
+                <li><a href="#section-{{ section }}">{{ section }}</a></li>
+            {% endfor %}
+        </ul>
+    </div>
     {% for section, sections in resources  %}
         {% if section != '_others' %}
             <li class="section{{ defaultSectionsOpened? ' active':'' }}">
@@ -13,6 +20,7 @@
                 <ul class="section-list" {% if not defaultSectionsOpened %}style="display: none"{% endif %}>
         {% endif %}
         {% for resource, methods in sections %}
+            <a id="section-{{ section }}"></a>
             <li class="resource">
                 <div class="heading">
                     {% if section == '_others' and resource != 'others' %}


### PR DESCRIPTION
When I have a very rich API with many methods, the navigation between sections involves a lot of scrolling.

So I propose to add an index at the top of the page. Of course this will also require some styling (in my case, I fixed it at the bottom right of the page).

Thank you for any comments that may improve this PR.