### PR TITLE
Fix wrapping of format table row

### DIFF
--- a/Resources/public/css/screen.css
+++ b/Resources/public/css/screen.css
@@ -145,6 +145,10 @@ table tbody tr td {
   line-height: 1.3em;
 }
 
+table tbody tr td.format {
+  word-break: break-word;
+}
+
 #header {
   background-color: #89BF04;
   padding: 1%;

--- a/Resources/views/method.html.twig
+++ b/Resources/views/method.html.twig
@@ -130,7 +130,7 @@
                                     <td>{{ name }}</td>
                                     <td>{{ infos.dataType is defined ? infos.dataType : '' }}</td>
                                     <td>{{ infos.required ? 'true' : 'false' }}</td>
-                                    <td>{{ infos.format }}</td>
+                                    <td class="format">{{ infos.format }}</td>
                                     <td>{{ infos.description is defined ? infos.description|trans : ''  }}</td>
                                 </tr>
                             {% endif %}


### PR DESCRIPTION
For parameter types "array of choices" when we have very long format values, it's visible like that: 
![Before change](https://s33.postimg.org/8w4t4g4sf/Zaznaczenie_094.png)

After this PR, it will be looks like that:
![After change](https://s33.postimg.org/4q6xln8m7/Zaznaczenie_095.png)
