### PR TITLE
Links from index.rst to the other doc files

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -87,13 +87,13 @@ The main problem with documentation is to keep it up to date. That's why the
 really easy to document an API method. The following chapters will help you
 setup your API documentation:
 
-* the-apidoc-annotation
-* multiple-api-doc
-* other-bundle-annotations
-* swagger-support
-* dunglasapibundle
-* sandbox
-* commands
+* `The ApiDoc() Annotation <the-apidoc-annotation.rst>`_
+* `Multiple API Documentation ("Views") <multiple-api-doc.rst>`_
+* `Other Bundle Annotations <other-bundle-annotations.rst>`_
+* `Swagger Support <swagger-support.rst>`_
+* `DunglasApiBundle Support <dunglasapibundle.rst>`_
+* `Sandbox <sandbox.rst>`_
+* `Commands <commands.rst>`_
 
 Web Interface
 ~~~~~~~~~~~~~


### PR DESCRIPTION
I've added links to index.rst so the other doc files can be accessible directly, instead of hunting them down by hand in the doc directory.

This should also fix http://symfony.com/doc/current/bundles/NelmioApiDocBundle/index.html which, without the links, is a bit useless.