### PR TITLE
Fixed the links to some doc articles

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -87,13 +87,16 @@ The main problem with documentation is to keep it up to date. That's why the
 really easy to document an API method. The following chapters will help you
 setup your API documentation:
 
-* `The ApiDoc() Annotation <the-apidoc-annotation.rst>`_
-* `Multiple API Documentation ("Views") <multiple-api-doc.rst>`_
-* `Other Bundle Annotations <other-bundle-annotations.rst>`_
-* `Swagger Support <swagger-support.rst>`_
-* `DunglasApiBundle Support <dunglasapibundle.rst>`_
-* `Sandbox <sandbox.rst>`_
-* `Commands <commands.rst>`_
+.. toctree::
+    :maxdepth: 1
+
+    the-apidoc-annotation
+    multiple-api-doc
+    other-bundle-annotations
+    swagger-support
+    dunglasapibundle
+    sandbox
+    commands
 
 Web Interface
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Some users have reported us that the links to other articles in this section are broken: http://symfony.com/doc/master/bundles/NelmioApiDocBundle/index.html#usage  I recommend to use a `toctree` directive because it's easier to maintain (for example the titles of the articles are updated automatically if they change).