### PR TITLE
Usage of OUTPUT_RAW to avoid javascript syntax error when dumping HTML

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -72,7 +72,7 @@ class DumpCommand extends ContainerAwareCommand
         if ('json' === $format) {
             $output->writeln(json_encode($formattedDoc));
         } else {
-            $output->writeln($formattedDoc);
+            $output->writeln($formattedDoc, OutputInterface::OUTPUT_RAW);
         }
     }
 }


### PR DESCRIPTION
A javascript syntax error occurs when an HTML doc is dumped, in the 2.12.0 tag. The syntax error is located in jQuery. It is seems to be caused by the console component.

It is fixed by specifying the `OutputInterface::OUTPUT_RAW` option when calling the `$output->writeln()` method.

More details in issue #864.
