### PR TITLE
Fix error: Key "statusCodes" for array with keys...

### DIFF
--- a/Resources/views/method.html.twig
+++ b/Resources/views/method.html.twig
@@ -179,7 +179,7 @@
                             <td>
                                 <h4>
                                     {{ status_code }}
-                                    {% if data.statusCodes[status_code] is defined %}
+                                    {% if data.statusCodes is defined and data.statusCodes[status_code] is defined %}
                                         - {{ data.statusCodes[status_code]|join(', ') }}
                                     {% endif %}
                                 </h4>


### PR DESCRIPTION
Fixes:

> _Key "statusCodes" for array with keys "method, uri, description, documentation, filters, requirements, parsedResponseMap, https, authentication, authenticationRoles, deprecated, id" does not exist in NelmioApiDocBundle::method.html.twig at line 182._

Sample:

```
/**
 * Retrieves the list of categories (paginated) based on criteria.
 *
 * @ApiDoc(
 *  resource=true,
 *  output={"class"="Sonata\DatagridBundle\Pager\PagerInterface", "groups"={"sonata_api_read"}}
 * )
 *
 *
 * @QueryParam(name="page", requirements="\d+", default="1", description="Page for category list pagination")
 * @QueryParam(name="count", requirements="\d+", default="10", description="Number of categories by page")
 * @QueryParam(name="enabled", requirements="0|1", nullable=true, strict=true, description="Enabled/Disabled categories filter")
 * @QueryParam(name="context", requirements="\S+", nullable=true, strict=true, description="Context of categories")
 *
 * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
 *
 * @param ParamFetcherInterface $paramFetcher
 *
 * @return PagerInterface
 */   
```