### PR TITLE
Fix typo

### DIFF
--- a/Resources/doc/swagger-support.rst
+++ b/Resources/doc/swagger-support.rst
@@ -10,7 +10,7 @@ Annotation options
 
 A couple of properties has been added to ``@ApiDoc``:
 
-To define a **resource description*::
+To define a ``resourceDescription``:
 
     /**
      * @ApiDoc(


### PR DESCRIPTION
Could also be replaced by _resource description_ or **resource description**
