### PR TITLE
Fixed minor RST syntax issues in docs

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -97,6 +97,9 @@ setup your API documentation:
     dunglasapibundle
     sandbox
     commands
+    configuration-in-depth
+    configuration-reference
+    faq
 
 Web Interface
 ~~~~~~~~~~~~~

--- a/Resources/doc/swagger-support.rst
+++ b/Resources/doc/swagger-support.rst
@@ -10,7 +10,7 @@ Annotation options
 
 A couple of properties has been added to ``@ApiDoc``:
 
-To define a **resource description*::
+To define a **resource description**::
 
     /**
      * @ApiDoc(


### PR DESCRIPTION
This fixes #836 and the new doc build errors reported by symfony.com [here](http://symfony.com/doc/build_errors)