### PR TITLE
[3.0] Add models support

### DIFF
--- a/ApiDocGenerator.php
+++ b/ApiDocGenerator.php
@@ -11,10 +11,10 @@
 
 namespace Nelmio\ApiDocBundle;
 
-use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
-use Nelmio\ApiDocBundle\Model\ModelRegistry;
 use EXSyst\Component\Swagger\Swagger;
 use Nelmio\ApiDocBundle\Describer\DescriberInterface;
+use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
+use Nelmio\ApiDocBundle\Model\ModelRegistry;
 use Psr\Cache\CacheItemPoolInterface;
 
 final class ApiDocGenerator

--- a/DependencyInjection/Compiler/AddModelDescribersPass.php
+++ b/DependencyInjection/Compiler/AddModelDescribersPass.php
@@ -25,6 +25,6 @@ final class AddModelDescribersPass implements CompilerPassInterface
     {
         $modelDescribers = $this->findAndSortTaggedServices('nelmio_api_doc.model_describer', $container);
 
-        $container->getDefinition('nelmio_api_doc.model_registry')->replaceArgument(0, $modelDescribers);
+        $container->getDefinition('nelmio_api_doc.generator')->replaceArgument(1, $modelDescribers);
     }
 }

--- a/DependencyInjection/Compiler/AddModelDescribersPass.php
+++ b/DependencyInjection/Compiler/AddModelDescribersPass.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the ApiDocBundle package.
+ *
+ * (c) EXSyst
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class AddModelDescribersPass implements CompilerPassInterface
+{
+    use PriorityTaggedServiceTrait;
+
+    public function process(ContainerBuilder $container)
+    {
+        $modelDescribers = $this->findAndSortTaggedServices('nelmio_api_doc.model_describer', $container);
+
+        $container->getDefinition('nelmio_api_doc.model_registry')->replaceArgument(0, $modelDescribers);
+    }
+}

--- a/DependencyInjection/Compiler/AddModelDescribersPass.php
+++ b/DependencyInjection/Compiler/AddModelDescribersPass.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the ApiDocBundle package.
+ * This file is part of the NelmioApiDocBundle package.
  *
- * (c) EXSyst
+ * (c) Nelmio
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -1,8 +1,9 @@
 <?php
+
 /*
- * This file is part of the Symfony package.
+ * This file is part of the NelmioApiDocBundle package.
  *
- * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Nelmio
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -50,6 +51,7 @@ trait PriorityTaggedServiceTrait
             krsort($services);
             $services = call_user_func_array('array_merge', $services);
         }
+
         return $services;
     }
 }

--- a/Describer/DefaultDescriber.php
+++ b/Describer/DefaultDescriber.php
@@ -38,7 +38,7 @@ final class DefaultDescriber implements DescriberInterface
                 $operation = $path->getOperation($method);
 
                 // Default Response
-                if (0 === iterator_count($operation->getResponses())) {
+                if (0 === count($operation->getResponses())) {
                     $defaultResponse = $operation->getResponses()->get('default');
                     $defaultResponse->setDescription('');
                 }

--- a/Describer/ModelRegistryAwareInterface.php
+++ b/Describer/ModelRegistryAwareInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the ApiDocBundle package.
+ *
+ * (c) EXSyst
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Describer;
+
+use Nelmio\ApiDocBundle\Model\ModelRegistry;
+
+interface ModelRegistryAwareInterface
+{
+    public function setModelRegistry(ModelRegistry $modelRegistry);
+}

--- a/Describer/ModelRegistryAwareInterface.php
+++ b/Describer/ModelRegistryAwareInterface.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the ApiDocBundle package.
+ * This file is part of the NelmioApiDocBundle package.
  *
- * (c) EXSyst
+ * (c) Nelmio
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Describer/ModelRegistryAwareTrait.php
+++ b/Describer/ModelRegistryAwareTrait.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the ApiDocBundle package.
+ *
+ * (c) EXSyst
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Describer;
+
+use Nelmio\ApiDocBundle\Model\ModelRegistry;
+
+trait ModelRegistryAwareTrait
+{
+    private $modelRegistry;
+
+    public function setModelRegistry(ModelRegistry $modelRegistry)
+    {
+        $this->modelRegistry = $modelRegistry;
+    }
+}

--- a/Describer/ModelRegistryAwareTrait.php
+++ b/Describer/ModelRegistryAwareTrait.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the ApiDocBundle package.
+ * This file is part of the NelmioApiDocBundle package.
  *
- * (c) EXSyst
+ * (c) Nelmio
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Describer/RouteDescriber.php
+++ b/Describer/RouteDescriber.php
@@ -19,8 +19,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
-final class RouteDescriber implements DescriberInterface
+final class RouteDescriber implements DescriberInterface, ModelRegistryAwareInterface
 {
+    use ModelRegistryAwareTrait;
+
     private $container;
     private $routeCollection;
     private $controllerNameParser;
@@ -51,6 +53,10 @@ final class RouteDescriber implements DescriberInterface
             if ($method = $this->getReflectionMethod($route->getDefault('_controller') ?? '')) {
                 // Extract as many informations as possible about this route
                 foreach ($this->routeDescribers as $describer) {
+                    if ($describer instanceof ModelRegistryAwareInterface) {
+                        $describer->setModelRegistry($this->modelRegistry);
+                    }
+
                     $describer->describe($api, $route, $method);
                 }
             }

--- a/EXSystApiDocBundle.php
+++ b/EXSystApiDocBundle.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the NelmioApiDocBundle package.
+ * This file is part of the ApiDocBundle package.
  *
- * (c) Nelmio
+ * (c) EXSyst
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -14,10 +14,11 @@ namespace Nelmio\ApiDocBundle;
 use Nelmio\ApiDocBundle\DependencyInjection\Compiler\AddDescribersPass;
 use Nelmio\ApiDocBundle\DependencyInjection\Compiler\AddModelDescribersPass;
 use Nelmio\ApiDocBundle\DependencyInjection\Compiler\AddRouteDescribersPass;
+use Nelmio\ApiDocBundle\DependencyInjection\EXSystApiDocExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-final class NelmioApiDocBundle extends Bundle
+final class EXSystApiDocBundle extends Bundle
 {
     /**
      * {@inheritdoc}
@@ -25,7 +26,20 @@ final class NelmioApiDocBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new AddDescribersPass());
-        $container->addCompilerPass(new AddModelDescribersPass());
         $container->addCompilerPass(new AddRouteDescribersPass());
+        $container->addCompilerPass(new AddModelDescribersPass());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContainerExtension()
+    {
+        if (null === $this->extension) {
+            $this->extension = new EXSystApiDocExtension();
+        }
+        if ($this->extension) {
+            return $this->extension;
+        }
     }
 }

--- a/EXSystApiDocBundle.php
+++ b/EXSystApiDocBundle.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the ApiDocBundle package.
+ * This file is part of the NelmioApiDocBundle package.
  *
- * (c) EXSyst
+ * (c) Nelmio
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Model/Model.php
+++ b/Model/Model.php
@@ -13,9 +13,14 @@ namespace Nelmio\ApiDocBundle\Model;
 
 use Symfony\Component\PropertyInfo\Type;
 
-final class ModelOptions
+final class Model
 {
     private $type;
+
+    public function __construct(Type $type)
+    {
+        $this->type = $type;
+    }
 
     /**
      * @return Type|null
@@ -25,20 +30,8 @@ final class ModelOptions
         return $this->type;
     }
 
-    public function setType(Type $type)
-    {
-        $this->type = $type;
-    }
-
     public function getHash()
     {
         return md5(serialize($this->type));
-    }
-
-    public function validate()
-    {
-        if (null === $this->type) {
-            throw new \LogicException('The model type must be specified.');
-        }
     }
 }

--- a/Model/ModelOptions.php
+++ b/Model/ModelOptions.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the ApiDocBundle package.
+ *
+ * (c) EXSyst
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Model;
+
+use Symfony\Component\PropertyInfo\Type;
+
+final class ModelOptions
+{
+    private $type;
+
+    /**
+     * @return Type|null
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function setType(Type $type)
+    {
+        $this->type = $type;
+    }
+
+    public function getHash()
+    {
+        return md5(serialize($this->type));
+    }
+
+    public function validate()
+    {
+        if (null === $this->type) {
+            throw new \LogicException('The model type must be specified.');
+        }
+    }
+}

--- a/Model/ModelOptions.php
+++ b/Model/ModelOptions.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the ApiDocBundle package.
+ * This file is part of the NelmioApiDocBundle package.
  *
- * (c) EXSyst
+ * (c) Nelmio
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Model/ModelRegistry.php
+++ b/Model/ModelRegistry.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the ApiDocBundle package.
+ * This file is part of the NelmioApiDocBundle package.
  *
- * (c) EXSyst
+ * (c) Nelmio
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -11,11 +11,11 @@
 
 namespace Nelmio\ApiDocBundle\Model;
 
-use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
-use Nelmio\ApiDocBundle\ModelDescriber\ModelDescriberInterface;
 use EXSyst\Component\Swagger\Items;
 use EXSyst\Component\Swagger\Schema;
 use EXSyst\Component\Swagger\Swagger;
+use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
+use Nelmio\ApiDocBundle\ModelDescriber\ModelDescriberInterface;
 use Symfony\Component\PropertyInfo\Type;
 
 final class ModelRegistry
@@ -142,7 +142,7 @@ final class ModelRegistry
     {
         if (Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType()) {
             return $type->getClassName();
-        } elseif (Type::BUILTIN_TYPE_ARRAY === $type->getBuiltinType()) {
+        } elseif ($type->isCollection()) {
             if (null !== $type->getCollectionValueType()) {
                 return $this->typeToString($type->getCollectionValueType()).'[]';
             } else {

--- a/Model/ModelRegistry.php
+++ b/Model/ModelRegistry.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * This file is part of the ApiDocBundle package.
+ *
+ * (c) EXSyst
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Model;
+
+use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
+use Nelmio\ApiDocBundle\ModelDescriber\ModelDescriberInterface;
+use EXSyst\Component\Swagger\Items;
+use EXSyst\Component\Swagger\Schema;
+use EXSyst\Component\Swagger\Swagger;
+use Symfony\Component\PropertyInfo\Type;
+
+final class ModelRegistry
+{
+    private $modelDescribers = [];
+    private $options;
+    private $unregistered = [];
+    private $hashes = [];
+
+    /**
+     * @param ModelDescriberInterface[] $modelDescribers
+     */
+    public function __construct(array $modelDescribers = [])
+    {
+        $this->options = new \SplObjectStorage();
+        $this->modelDescribers = $modelDescribers;
+    }
+
+    /**
+     * @param Schema|Items $schema
+     */
+    public function register($schema): ModelOptions
+    {
+        if (!$schema instanceof Schema && !$schema instanceof Items) {
+            throw new \LogicException(sprintf('Expected %s or %s, got %s', Schema::class, Items::class, get_class($schema)));
+        }
+
+        if (!isset($this->options[$schema])) {
+            $this->unregistered[] = $schema;
+            $this->options[$schema] = new ModelOptions();
+        }
+
+        return $this->options[$schema];
+    }
+
+    /**
+     * @internal
+     */
+    public function registerModelsIn(Swagger $api)
+    {
+        while (count($this->unregistered)) {
+            $tmp = [];
+            foreach ($this->unregistered as $schema) {
+                $options = $this->options[$schema];
+                $options->validate();
+
+                $hash = $options->getHash();
+                if (isset($this->hashes[$hash])) {
+                    $schema->setRef('#/definitions/'.$this->hashes[$hash]);
+
+                    continue;
+                }
+
+                if (!isset($tmp[$hash])) {
+                    $tmp[$hash] = [$options, [/* schemas */]];
+                }
+                $tmp[$hash][1][] = $schema;
+            }
+            $this->unregistered = [];
+
+            foreach ($tmp as $hash => list($options, $schemas)) {
+                $baseSchema = new Schema();
+                $described = false;
+                foreach ($this->modelDescribers as $modelDescriber) {
+                    if ($modelDescriber instanceof ModelRegistryAwareInterface) {
+                        $modelDescriber->setModelRegistry($this);
+                    }
+                    if ($modelDescriber->supports($options)) {
+                        $described = true;
+                        $modelDescriber->describe($baseSchema, $options);
+
+                        break;
+                    }
+                }
+
+                if (!$described) {
+                    throw new \LogicException(sprintf('Schema of type "%s" can\'t be generated, no describer supports it.', $this->typeToString($options->getType())));
+                }
+
+                $name = $this->generateModelName($api, $options);
+                $this->hashes[$hash] = $name;
+                $api->getDefinitions()->set($name, $baseSchema);
+
+                foreach ($schemas as $schema) {
+                    $schema->setRef('#/definitions/'.$name);
+                }
+            }
+        }
+    }
+
+    public function __clone()
+    {
+        $this->options = new \SplObjectStorage();
+        $this->unregistered = [];
+        $this->hashes = [];
+    }
+
+    private function generateModelName(Swagger $api, ModelOptions $options): string
+    {
+        $definitions = $api->getDefinitions();
+        $base = $name = $this->getTypeShortName($options->getType());
+        $i = 1;
+        while ($definitions->has($name)) {
+            ++$i;
+            $name = $base.$i;
+        }
+
+        return $name;
+    }
+
+    private function getTypeShortName(Type $type)
+    {
+        if (null !== $type->getCollectionValueType()) {
+            return $this->getTypeShortName($type->getCollectionValueType()).'[]';
+        }
+        if (Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType()) {
+            return (new \ReflectionClass($type->getClassName()))->getShortName();
+        }
+
+        return $type->getBuiltinType();
+    }
+
+    private function typeToString(Type $type): string
+    {
+        if (Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType()) {
+            return $type->getClassName();
+        } elseif (Type::BUILTIN_TYPE_ARRAY === $type->getBuiltinType()) {
+            if (null !== $type->getCollectionValueType()) {
+                return $this->typeToString($type->getCollectionValueType()).'[]';
+            } else {
+                return 'mixed[]';
+            }
+        } else {
+            return $type->getBuiltinType();
+        }
+    }
+}

--- a/ModelDescriber/CollectionModelDescriber.php
+++ b/ModelDescriber/CollectionModelDescriber.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the ApiDocBundle package.
+ * This file is part of the NelmioApiDocBundle package.
  *
- * (c) EXSyst
+ * (c) Nelmio
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -11,10 +11,10 @@
 
 namespace Nelmio\ApiDocBundle\ModelDescriber;
 
+use EXSyst\Component\Swagger\Schema;
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareTrait;
 use Nelmio\ApiDocBundle\Model\ModelOptions;
-use EXSyst\Component\Swagger\Schema;
 
 class CollectionModelDescriber implements ModelDescriberInterface, ModelRegistryAwareInterface
 {

--- a/ModelDescriber/CollectionModelDescriber.php
+++ b/ModelDescriber/CollectionModelDescriber.php
@@ -14,21 +14,22 @@ namespace Nelmio\ApiDocBundle\ModelDescriber;
 use EXSyst\Component\Swagger\Schema;
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareTrait;
-use Nelmio\ApiDocBundle\Model\ModelOptions;
+use Nelmio\ApiDocBundle\Model\Model;
 
 class CollectionModelDescriber implements ModelDescriberInterface, ModelRegistryAwareInterface
 {
     use ModelRegistryAwareTrait;
 
-    public function describe(Schema $schema, ModelOptions $options)
+    public function describe(Model $model, Schema $schema)
     {
         $schema->setType('array');
-        $this->modelRegistry->register($schema->getItems())
-            ->setType($options->getType()->getCollectionValueType());
+        $schema->getItems()->setRef(
+            $this->modelRegistry->register(new Model($model->getType()->getCollectionValueType()))
+        );
     }
 
-    public function supports(ModelOptions $options)
+    public function supports(Model $model)
     {
-        return $options->getType()->isCollection() && null !== $options->getType()->getCollectionValueType();
+        return $model->getType()->isCollection() && null !== $model->getType()->getCollectionValueType();
     }
 }

--- a/ModelDescriber/CollectionModelDescriber.php
+++ b/ModelDescriber/CollectionModelDescriber.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the ApiDocBundle package.
+ *
+ * (c) EXSyst
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\ModelDescriber;
+
+use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
+use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareTrait;
+use Nelmio\ApiDocBundle\Model\ModelOptions;
+use EXSyst\Component\Swagger\Schema;
+
+class CollectionModelDescriber implements ModelDescriberInterface, ModelRegistryAwareInterface
+{
+    use ModelRegistryAwareTrait;
+
+    public function describe(Schema $schema, ModelOptions $options)
+    {
+        $schema->setType('array');
+        $this->modelRegistry->register($schema->getItems())
+            ->setType($options->getType()->getCollectionValueType());
+    }
+
+    public function supports(ModelOptions $options)
+    {
+        return $options->getType()->isCollection() && null !== $options->getType()->getCollectionValueType();
+    }
+}

--- a/ModelDescriber/ModelDescriberInterface.php
+++ b/ModelDescriber/ModelDescriberInterface.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the ApiDocBundle package.
+ * This file is part of the NelmioApiDocBundle package.
  *
- * (c) EXSyst
+ * (c) Nelmio
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -11,8 +11,8 @@
 
 namespace Nelmio\ApiDocBundle\ModelDescriber;
 
-use Nelmio\ApiDocBundle\Model\ModelOptions;
 use EXSyst\Component\Swagger\Schema;
+use Nelmio\ApiDocBundle\Model\ModelOptions;
 
 interface ModelDescriberInterface
 {

--- a/ModelDescriber/ModelDescriberInterface.php
+++ b/ModelDescriber/ModelDescriberInterface.php
@@ -12,11 +12,10 @@
 namespace Nelmio\ApiDocBundle\ModelDescriber;
 
 use EXSyst\Component\Swagger\Schema;
-use Nelmio\ApiDocBundle\Model\ModelOptions;
+use Nelmio\ApiDocBundle\Model\Model;
 
 interface ModelDescriberInterface
 {
-    public function describe(Schema $schema, ModelOptions $options);
-
-    public function supports(ModelOptions $options);
+    public function describe(Model $model, Schema $schema);
+    public function supports(Model $model);
 }

--- a/ModelDescriber/ModelDescriberInterface.php
+++ b/ModelDescriber/ModelDescriberInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the ApiDocBundle package.
+ *
+ * (c) EXSyst
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\ModelDescriber;
+
+use Nelmio\ApiDocBundle\Model\ModelOptions;
+use EXSyst\Component\Swagger\Schema;
+
+interface ModelDescriberInterface
+{
+    public function describe(Schema $schema, ModelOptions $options);
+
+    public function supports(ModelOptions $options);
+}

--- a/ModelDescriber/ObjectModelDescriber.php
+++ b/ModelDescriber/ObjectModelDescriber.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the ApiDocBundle package.
+ * This file is part of the NelmioApiDocBundle package.
  *
- * (c) EXSyst
+ * (c) Nelmio
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -11,10 +11,10 @@
 
 namespace Nelmio\ApiDocBundle\ModelDescriber;
 
+use EXSyst\Component\Swagger\Schema;
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareTrait;
 use Nelmio\ApiDocBundle\Model\ModelOptions;
-use EXSyst\Component\Swagger\Schema;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\Type;
 

--- a/ModelDescriber/ObjectModelDescriber.php
+++ b/ModelDescriber/ObjectModelDescriber.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the ApiDocBundle package.
+ *
+ * (c) EXSyst
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\ModelDescriber;
+
+use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
+use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareTrait;
+use Nelmio\ApiDocBundle\Model\ModelOptions;
+use EXSyst\Component\Swagger\Schema;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwareInterface
+{
+    use ModelRegistryAwareTrait;
+
+    public function __construct(PropertyInfoExtractorInterface $propertyInfo)
+    {
+        $this->propertyInfo = $propertyInfo;
+    }
+
+    public function describe(Schema $schema, ModelOptions $options)
+    {
+        $schema->setType('object');
+        $properties = $schema->getProperties();
+
+        $class = $options->getType()->getClassName();
+        foreach ($this->propertyInfo->getProperties($class) as $propertyName) {
+            $types = $this->propertyInfo->getTypes($class, $propertyName);
+            if (0 === count($types)) {
+                throw new \LogicException(sprintf('The PropertyInfo component was not able to guess the type of %s::$%s', $class, $propertyName));
+            }
+            if (count($types) > 1) {
+                throw new \LogicException(sprintf('Property %s::$%s defines more than one type.', $class, $propertyName));
+            }
+
+            $this->modelRegistry->register($properties->get($propertyName))
+                ->setType($types[0]);
+        }
+    }
+
+    public function supports(ModelOptions $options)
+    {
+        return Type::BUILTIN_TYPE_OBJECT === $options->getType()->getBuiltinType();
+    }
+}

--- a/ModelDescriber/ScalarModelDescriber.php
+++ b/ModelDescriber/ScalarModelDescriber.php
@@ -12,7 +12,7 @@
 namespace Nelmio\ApiDocBundle\ModelDescriber;
 
 use EXSyst\Component\Swagger\Schema;
-use Nelmio\ApiDocBundle\Model\ModelOptions;
+use Nelmio\ApiDocBundle\Model\Model;
 use Symfony\Component\PropertyInfo\Type;
 
 class ScalarModelDescriber implements ModelDescriberInterface
@@ -23,14 +23,14 @@ class ScalarModelDescriber implements ModelDescriberInterface
         Type::BUILTIN_TYPE_STRING => 'string',
     ];
 
-    public function describe(Schema $schema, ModelOptions $options)
+    public function describe(Model $model, Schema $schema)
     {
-        $type = self::$supportedTypes[$options->getType()->getBuiltinType()];
+        $type = self::$supportedTypes[$model->getType()->getBuiltinType()];
         $schema->setType($type);
     }
 
-    public function supports(ModelOptions $options)
+    public function supports(Model $model)
     {
-        return isset(self::$supportedTypes[$options->getType()->getBuiltinType()]);
+        return isset(self::$supportedTypes[$model->getType()->getBuiltinType()]);
     }
 }

--- a/ModelDescriber/ScalarModelDescriber.php
+++ b/ModelDescriber/ScalarModelDescriber.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the ApiDocBundle package.
+ *
+ * (c) EXSyst
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\ModelDescriber;
+
+use Nelmio\ApiDocBundle\Model\ModelOptions;
+use EXSyst\Component\Swagger\Schema;
+use Symfony\Component\PropertyInfo\Type;
+
+class ScalarModelDescriber implements ModelDescriberInterface
+{
+    private static $supportedTypes = [
+        Type::BUILTIN_TYPE_INT => 'integer',
+        Type::BUILTIN_TYPE_FLOAT => 'float',
+        Type::BUILTIN_TYPE_STRING => 'string',
+    ];
+
+    public function describe(Schema $schema, ModelOptions $options)
+    {
+        $type = self::$supportedTypes[$options->getType()->getBuiltinType()];
+        $schema->setType($type);
+    }
+
+    public function supports(ModelOptions $options)
+    {
+        return isset(self::$supportedTypes[$options->getType()->getBuiltinType()]);
+    }
+}

--- a/ModelDescriber/ScalarModelDescriber.php
+++ b/ModelDescriber/ScalarModelDescriber.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the ApiDocBundle package.
+ * This file is part of the NelmioApiDocBundle package.
  *
- * (c) EXSyst
+ * (c) Nelmio
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -11,8 +11,8 @@
 
 namespace Nelmio\ApiDocBundle\ModelDescriber;
 
-use Nelmio\ApiDocBundle\Model\ModelOptions;
 use EXSyst\Component\Swagger\Schema;
+use Nelmio\ApiDocBundle\Model\ModelOptions;
 use Symfony\Component\PropertyInfo\Type;
 
 class ScalarModelDescriber implements ModelDescriberInterface

--- a/Resources/config/api_platform.xml
+++ b/Resources/config/api_platform.xml
@@ -8,7 +8,7 @@
             <argument type="service" id="nelmio_api_doc.describers.api_platform.documentation" />
             <argument type="service" id="api_platform.swagger.normalizer.documentation" />
 
-            <tag name="nelmio_api_doc.describer" priority="-200" />
+            <tag name="nelmio_api_doc.describer" priority="-100" />
         </service>
 
         <service id="nelmio_api_doc.describers.api_platform.documentation" class="ApiPlatform\Core\Documentation\Documentation" public="false">

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -6,13 +6,17 @@
     <services>
         <service id="nelmio_api_doc.generator" class="Nelmio\ApiDocBundle\ApiDocGenerator">
             <argument type="collection" />
+            <argument type="service" id="nelmio_api_doc.model_registry" />
         </service>
 
-        <!-- Extractors -->
+        <service id="nelmio_api_doc.model_registry" class="Nelmio\ApiDocBundle\Model\ModelRegistry" public="false">
+            <argument type="collection" />
+        </service>
+
+        <!-- Describers -->
         <service id="nelmio_api_doc.describers.route.filtered_route_collection_builder" class="Nelmio\ApiDocBundle\Routing\FilteredRouteCollectionBuilder" public="false">
             <argument type="collection" /> <!-- Path patterns -->
         </service>
-
 
         <service id="nelmio_api_doc.describers.route" class="Nelmio\ApiDocBundle\Describer\RouteDescriber" public="false">
             <argument type="service" id="service_container" />
@@ -36,9 +40,24 @@
             <tag name="nelmio_api_doc.describer" priority="-1000" />
         </service>
 
-        <!-- Routing Extractors -->
+        <!-- Routing Describers -->
         <service id="nelmio_api_doc.route_describers.route_metadata" class="Nelmio\ApiDocBundle\RouteDescriber\RouteMetadataDescriber" public="false">
             <tag name="nelmio_api_doc.route_describer" priority="-100" />
+        </service>
+
+        <!-- Model Describers -->
+        <service id="nelmio_api_doc.model_describers.object" class="Nelmio\ApiDocBundle\ModelDescriber\ObjectModelDescriber" public="false">
+            <argument type="service" id="property_info" />
+
+            <tag name="nelmio_api_doc.model_describer" />
+        </service>
+
+        <service id="nelmio_api_doc.model_describers.collection" class="Nelmio\ApiDocBundle\ModelDescriber\CollectionModelDescriber" public="false">
+            <tag name="nelmio_api_doc.model_describer" />
+        </service>
+
+        <service id="nelmio_api_doc.model_describers.scalar" class="Nelmio\ApiDocBundle\ModelDescriber\ScalarModelDescriber" public="false">
+            <tag name="nelmio_api_doc.model_describer" />
         </service>
     </services>
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -5,12 +5,8 @@
 
     <services>
         <service id="nelmio_api_doc.generator" class="Nelmio\ApiDocBundle\ApiDocGenerator">
-            <argument type="collection" />
-            <argument type="service" id="nelmio_api_doc.model_registry" />
-        </service>
-
-        <service id="nelmio_api_doc.model_registry" class="Nelmio\ApiDocBundle\Model\ModelRegistry" public="false">
-            <argument type="collection" />
+            <argument type="collection" /> <!-- Describers -->
+            <argument type="collection" /> <!-- Model Describers -->
         </service>
 
         <!-- Describers -->
@@ -33,7 +29,7 @@
             <argument type="service" id="controller_name_converter" />
             <argument type="collection" />
 
-            <tag name="nelmio_api_doc.describer" priority="-100" />
+            <tag name="nelmio_api_doc.describer" priority="-400" />
         </service>
 
         <service id="nelmio_api_doc.describers.default" class="Nelmio\ApiDocBundle\Describer\DefaultDescriber" public="false">
@@ -42,7 +38,7 @@
 
         <!-- Routing Describers -->
         <service id="nelmio_api_doc.route_describers.route_metadata" class="Nelmio\ApiDocBundle\RouteDescriber\RouteMetadataDescriber" public="false">
-            <tag name="nelmio_api_doc.route_describer" priority="-100" />
+            <tag name="nelmio_api_doc.route_describer" priority="-300" />
         </service>
 
         <!-- Model Describers -->

--- a/Resources/config/swagger_php.xml
+++ b/Resources/config/swagger_php.xml
@@ -7,7 +7,7 @@
         <service id="nelmio_api_doc.describers.swagger_php" class="Nelmio\ApiDocBundle\Describer\SwaggerPhpDescriber" public="false">
             <argument>%kernel.root_dir%</argument>
 
-            <tag name="nelmio_api_doc.describer" priority="-300" />
+            <tag name="nelmio_api_doc.describer" priority="-200" />
         </service>
     </services>
 

--- a/RouteDescriber/NelmioAnnotationDescriber.php
+++ b/RouteDescriber/NelmioAnnotationDescriber.php
@@ -12,11 +12,11 @@
 namespace Nelmio\ApiDocBundle\RouteDescriber;
 
 use Doctrine\Common\Annotations\Reader;
-use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
-use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareTrait;
 use EXSyst\Component\Swagger\Parameter;
 use EXSyst\Component\Swagger\Swagger;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
+use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
+use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareTrait;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Routing\Route;
 

--- a/RouteDescriber/NelmioAnnotationDescriber.php
+++ b/RouteDescriber/NelmioAnnotationDescriber.php
@@ -17,6 +17,7 @@ use EXSyst\Component\Swagger\Swagger;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareTrait;
+use Nelmio\ApiDocBundle\Model\Model;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Routing\Route;
 
@@ -100,15 +101,17 @@ final class NelmioAnnotationDescriber implements RouteDescriberInterface, ModelR
             $input = $annotation->getInput();
             if (null !== $input) {
                 list($type) = $this->normalizeModel($input);
-                $this->modelRegistry->register($operation->getParameters()->get('input', 'body')->getSchema())
-                    ->setType($type);
+                $operation->getParameters()->get('input', 'body')->getSchema()->setRef(
+                    $this->modelRegistry->register(new Model($type))
+                );
             }
 
             // Outputs
             foreach ($annotation->getResponseMap() as $statusCode => $output) {
                 list($type) = $this->normalizeModel($output);
-                $this->modelRegistry->register($responses->get($statusCode)->getSchema())
-                    ->setType($type);
+                $responses->get($statusCode)->getSchema()->setRef(
+                    $this->modelRegistry->register(new Model($type))
+                );
             }
         }
     }

--- a/Tests/Functional/Controller/ApiController.php
+++ b/Tests/Functional/Controller/ApiController.php
@@ -11,6 +11,8 @@
 
 namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
 
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\Dummy;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\User;
 use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\RequestParam;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
@@ -40,7 +42,13 @@ class ApiController
     /**
      * @Route("/nelmio/{foo}", methods={"POST"})
      * @ApiDoc(
-     *   description="This action is described."
+     *   description="This action is described.",
+     *   input={"class"=Dummy::class},
+     *   output=User::class,
+     *   statusCodes={
+     *      200="Returned when successful",
+     *      403="Returned when the user is not authorized to say hello"
+     *   }
      * )
      */
     public function nelmioAction()

--- a/Tests/Functional/Controller/ApiController.php
+++ b/Tests/Functional/Controller/ApiController.php
@@ -11,11 +11,11 @@
 
 namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
 
-use Nelmio\ApiDocBundle\Tests\Functional\Entity\Dummy;
-use Nelmio\ApiDocBundle\Tests\Functional\Entity\User;
 use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\RequestParam;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\Dummy;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\User;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 
 /**

--- a/Tests/Functional/Entity/Dummy.php
+++ b/Tests/Functional/Entity/Dummy.php
@@ -42,11 +42,6 @@ class Dummy
      */
     private $name;
 
-    /**
-     * @var array
-     */
-    private $foo;
-
     public function getId(): int
     {
         return $this->id;
@@ -63,10 +58,6 @@ class Dummy
     }
 
     public function hasRole(string $role)
-    {
-    }
-
-    public function setFoo(array $foo = null)
     {
     }
 }

--- a/Tests/Functional/Entity/User.php
+++ b/Tests/Functional/Entity/User.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the ApiDocBundle package.
+ *
+ * (c) EXSyst
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
+
+/**
+ * @author Guilhem N. <egetick@gmail.com>
+ */
+class User
+{
+    public function addUsers(User $user)
+    {
+    }
+
+    public function setDummy(Dummy $dummy)
+    {
+    }
+}

--- a/Tests/Functional/Entity/User.php
+++ b/Tests/Functional/Entity/User.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the ApiDocBundle package.
+ * This file is part of the NelmioApiDocBundle package.
  *
- * (c) EXSyst
+ * (c) Nelmio
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Model/ModelRegistryTest.php
+++ b/Tests/Model/ModelRegistryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Model;
+
+use EXSyst\Component\Swagger\Schema;
+use EXSyst\Component\Swagger\Swagger;
+use Nelmio\ApiDocBundle\Model\ModelRegistry;
+use Symfony\Component\PropertyInfo\Type;
+
+class ModelRegistryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider unsupportedTypesProvider
+     */
+    public function testUnsupportedTypeException(Type $type, string $stringType)
+    {
+        $this->setExpectedException('\LogicException', sprintf('Schema of type "%s" can\'t be generated, no describer supports it.', $stringType));
+
+        $registry = new ModelRegistry();
+        $registry->register(new Schema())
+            ->setType($type);
+        $registry->registerModelsIn(new Swagger());
+    }
+
+    public function unsupportedTypesProvider()
+    {
+        return [
+            [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true), 'mixed[]'],
+            [new Type(Type::BUILTIN_TYPE_OBJECT, false, self::class), self::class],
+        ];
+    }
+}

--- a/Tests/Model/ModelRegistryTest.php
+++ b/Tests/Model/ModelRegistryTest.php
@@ -13,6 +13,7 @@ namespace Nelmio\ApiDocBundle\Tests\Model;
 
 use EXSyst\Component\Swagger\Schema;
 use EXSyst\Component\Swagger\Swagger;
+use Nelmio\ApiDocBundle\Model\Model;
 use Nelmio\ApiDocBundle\Model\ModelRegistry;
 use Symfony\Component\PropertyInfo\Type;
 
@@ -25,10 +26,9 @@ class ModelRegistryTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('\LogicException', sprintf('Schema of type "%s" can\'t be generated, no describer supports it.', $stringType));
 
-        $registry = new ModelRegistry();
-        $registry->register(new Schema())
-            ->setType($type);
-        $registry->registerModelsIn(new Swagger());
+        $registry = new ModelRegistry([], new Swagger());
+        $registry->register(new Model($type));
+        $registry->registerDefinitions();
     }
 
     public function unsupportedTypesProvider()

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": "~7.0|~7.1",
         "symfony/framework-bundle": "^2.8|^3.0",
+        "symfony/property-info": "^2.8|^3.0",
         "exsyst/swagger": "~0.2.2"
     },
     "require-dev": {


### PR DESCRIPTION
This PR adds model support based on a ModelRegistry. 
The registry is injected in the describers implementing `ModelRegistryAwareInterface`. Then the describers register a schema in the registry, this schema will then be replaced by a reference to the model generated by the model describers:
```php
class MyDescriber implements DescriberInterface, ModelRegistryAwareInterface
{
    use ModelRegistryAwareTrait;

    public function describe(Swagger $api)
    {
        $schema = $api->getPaths()->get('/my-route/')
            ->getOperation('get')->getResponses()->get('200')->getSchema()
            ->setRef(
                $this->modelRegistry->register(new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)))
            );
    }
}
```

will result to:
```yml
paths:
    /my-route/:
        get:
            responses:
                200: { $ref: '#/definitions/Dummy' }
definitions:
    Dummy:
        // ...
```