### PR TITLE
[3.0] Allow implicit operations with SwaggerPhp annotations

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -2,7 +2,7 @@
 
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
-    ->exclude('tests/Fixtures/app/cache')
+    ->exclude('Tests/Functional/cache')
 ;
 
 return PhpCsFixer\Config::create()
@@ -11,14 +11,14 @@ return PhpCsFixer\Config::create()
         'ordered_imports' => true,
         'phpdoc_order' => true,
         'header_comment' => [
-            'header' => <<<COMMENT
+            'header' => <<<HEADER
 This file is part of the NelmioApiDocBundle package.
 
 (c) Nelmio
 
 For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
-COMMENT
+HEADER
         ],
     ])
     ->setFinder($finder)

--- a/DependencyInjection/Compiler/AddRouteDescribersPass.php
+++ b/DependencyInjection/Compiler/AddRouteDescribersPass.php
@@ -22,6 +22,6 @@ class AddRouteDescribersPass implements CompilerPassInterface
     {
         $routeDescribers = $this->findAndSortTaggedServices('nelmio_api_doc.route_describer', $container);
 
-        $container->getDefinition('nelmio_api_doc.describers.route')->replaceArgument(3, $routeDescribers);
+        $container->getDefinition('nelmio_api_doc.describers.route')->replaceArgument(2, $routeDescribers);
     }
 }

--- a/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -1,8 +1,9 @@
 <?php
+
 /*
- * This file is part of the Symfony package.
+ * This file is part of the NelmioApiDocBundle package.
  *
- * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Nelmio
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -50,6 +51,7 @@ trait PriorityTaggedServiceTrait
             krsort($services);
             $services = call_user_func_array('array_merge', $services);
         }
+
         return $services;
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -8,6 +8,11 @@
             <argument type="collection" />
         </service>
 
+        <service id="nelmio_api_doc.controller_reflector" class="Nelmio\ApiDocBundle\Util\ControllerReflector" public="false">
+            <argument type="service" id="service_container" />
+            <argument type="service" id="controller_name_converter" />
+        </service>
+
         <!-- Extractors -->
         <service id="nelmio_api_doc.describers.route.filtered_route_collection_builder" class="Nelmio\ApiDocBundle\Routing\FilteredRouteCollectionBuilder" public="false">
             <argument type="collection" /> <!-- Path patterns -->
@@ -15,7 +20,6 @@
 
 
         <service id="nelmio_api_doc.describers.route" class="Nelmio\ApiDocBundle\Describer\RouteDescriber" public="false">
-            <argument type="service" id="service_container" />
             <argument type="service">
                 <service class="Symfony\Component\Routing\RouteCollection">
                     <factory service="nelmio_api_doc.describers.route.filtered_route_collection_builder" method="filter" />
@@ -26,7 +30,7 @@
                     </argument>
                 </service>
             </argument>
-            <argument type="service" id="controller_name_converter" />
+            <argument type="service" id="nelmio_api_doc.controller_reflector" />
             <argument type="collection" />
 
             <tag name="nelmio_api_doc.describer" priority="-100" />

--- a/Resources/config/swagger_php.xml
+++ b/Resources/config/swagger_php.xml
@@ -6,8 +6,20 @@
     <services>
         <service id="nelmio_api_doc.describers.swagger_php" class="Nelmio\ApiDocBundle\Describer\SwaggerPhpDescriber" public="false">
             <argument>%kernel.root_dir%</argument>
+            <call method="setOperationResolver">
+              <argument type="service" id="nelmio_api_doc.describers.swagger_php.operation_resolver" />
+            </call>
 
             <tag name="nelmio_api_doc.describer" priority="-300" />
+        </service>
+
+        <service id="nelmio_api_doc.describers.swagger_php.operation_resolver" class="Nelmio\ApiDocBundle\SwaggerPhp\OperationResolver" public="false">
+            <argument type="service">
+                <service class="Symfony\Component\Routing\RouteCollection">
+                    <factory service="router" method="getRouteCollection" />
+                </service>
+            </argument>
+            <argument type="service" id="nelmio_api_doc.controller_reflector" />
         </service>
     </services>
 

--- a/SwaggerPhp/OperationResolver.php
+++ b/SwaggerPhp/OperationResolver.php
@@ -1,0 +1,195 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\SwaggerPhp;
+
+use EXSyst\Component\Swagger\Swagger;
+use Nelmio\ApiDocBundle\Util\ControllerReflector;
+use Swagger\Analysis;
+use Swagger\Annotations as SWG;
+use Swagger\Context;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Automatically resolves the {@link SWG\Operation} linked to
+ * {@link SWG\Response}, {@link SWG\Parameter} and
+ * {@link SWG\ExternalDocumentation} annotations.
+ *
+ * @internal
+ */
+final class OperationResolver
+{
+    private $routeCollection;
+    private $controllerReflector;
+
+    private $controllerMap;
+
+    public function __construct(RouteCollection $routeCollection, ControllerReflector $controllerReflector)
+    {
+        $this->routeCollection = $routeCollection;
+        $this->controllerReflector = $controllerReflector;
+    }
+
+    public function __invoke(Analysis $analysis)
+    {
+        $this->resolveOperationsPath($analysis);
+        $this->createImplicitOperations($analysis);
+    }
+
+    private function resolveOperationsPath(Analysis $analysis)
+    {
+        $operations = $analysis->getAnnotationsOfType(SWG\Operation::class);
+        foreach ($operations as $operation) {
+            if (null !== $operation->path || $operation->_context->not('method')) {
+                continue;
+            }
+
+            $paths = $this->getPaths($operation->_context, $operation->method);
+            if (0 === count($paths)) {
+                continue;
+            }
+
+            // Define the path of the first annotation
+            $operation->path = array_pop($paths);
+
+            // If there are other paths, clone the annotation
+            foreach ($paths as $path) {
+                $alias = clone $operation;
+                $alias->path = $path;
+
+                $analysis->addAnnotation($alias, $alias->_context);
+            }
+        }
+    }
+
+    private function createImplicitOperations(Analysis $analysis)
+    {
+        $annotations = array_merge($analysis->getAnnotationsOfType(SWG\Response::class), $analysis->getAnnotationsOfType(SWG\Parameter::class), $analysis->getAnnotationsOfType(SWG\ExternalDocumentation::class));
+        $map = [];
+        foreach ($annotations as $annotation) {
+            $context = $annotation->_context;
+            if ($context->not('method')) {
+                continue;
+            }
+
+            $class = $this->getClass($context);
+            $method = $context->method;
+
+            $id = $class.'|'.$method;
+            if (!isset($map[$id])) {
+                $map[$id] = [];
+            }
+
+            $map[$id][] = $annotation;
+        }
+
+        $operationAnnotations = [
+            'get' => SWG\Get::class,
+            'post' => SWG\Post::class,
+            'put' => SWG\Put::class,
+            'patch' => SWG\Patch::class,
+            'delete' => SWG\Delete::class,
+            'options' => SWG\Options::class,
+            'head' => SWG\Head::class,
+        ];
+        foreach ($map as $id => $annotations) {
+            $context = $annotations[0]->_context;
+            $httpMethods = $this->getHttpMethods($context);
+            foreach ($httpMethods as $httpMethod => $paths) {
+                $annotationClass = $operationAnnotations[$httpMethod];
+                foreach ($paths as $path => $v) {
+                    $operation = new $annotationClass(['path' => $path, 'value' => $annotations], $context);
+                    $analysis->addAnnotation($operation, $context);
+                }
+            }
+
+            foreach ($annotations as $annotation) {
+                $analysis->annotations->detach($annotation);
+            }
+        }
+    }
+
+    private function getPaths(Context $context, string $httpMethod): array
+    {
+        $httpMethods = $this->getHttpMethods($context);
+        if (!isset($httpMethods[$httpMethod])) {
+            return [];
+        }
+
+        return array_keys($httpMethods[$httpMethod]);
+    }
+
+    private function getHttpMethods(Context $context)
+    {
+        if (null === $this->controllerMap) {
+            $this->buildMap();
+        }
+
+        $class = $this->getClass($context);
+        $method = $context->method;
+
+        // Checks if a route corresponds to this method
+        if (!isset($this->controllerMap[$class][$method])) {
+            return [];
+        }
+
+        return $this->controllerMap[$class][$method];
+    }
+
+    private function getClass(Context $context)
+    {
+        return ltrim($context->namespace.'\\'.$context->class, '\\');
+    }
+
+    private function buildMap()
+    {
+        $this->controllerMap = [];
+        foreach ($this->routeCollection->all() as $route) {
+            if (!$route->hasDefault('_controller')) {
+                continue;
+            }
+
+            $controller = $route->getDefault('_controller');
+            if ($callable = $this->controllerReflector->getReflectionClassAndMethod($controller)) {
+                list($class, $method) = $callable;
+                $class = $class->name;
+                $method = $method->name;
+
+                if (!isset($this->controllerMap[$class])) {
+                    $this->controllerMap[$class] = [];
+                }
+                if (!isset($this->controllerMap[$class][$method])) {
+                    $this->controllerMap[$class][$method] = [];
+                }
+
+                $httpMethods = $route->getMethods() ?: Swagger::$METHODS;
+                foreach ($httpMethods as $httpMethod) {
+                    $httpMethod = strtolower($httpMethod);
+                    if (!isset($this->controllerMap[$class][$method][$httpMethod])) {
+                        $this->controllerMap[$class][$method][$httpMethod] = [];
+                    }
+
+                    $path = $this->normalizePath($route->getPath());
+                    $this->controllerMap[$class][$method][$httpMethod][$path] = true;
+                }
+            }
+        }
+    }
+
+    private function normalizePath(string $path)
+    {
+        if (substr($path, -10) === '.{_format}') {
+            $path = substr($path, 0, -10);
+        }
+
+        return $path;
+    }
+}

--- a/Tests/Describer/RouteDescriberTest.php
+++ b/Tests/Describer/RouteDescriberTest.php
@@ -14,6 +14,7 @@ namespace Nelmio\ApiDocBundle\Tests\Describer;
 use EXSyst\Component\Swagger\Swagger;
 use Nelmio\ApiDocBundle\Describer\RouteDescriber;
 use Nelmio\ApiDocBundle\RouteDescriber\RouteDescriberInterface;
+use Nelmio\ApiDocBundle\Util\ControllerReflector;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Routing\Route;
@@ -38,9 +39,11 @@ class RouteDescriberTest extends AbstractDescriberTest
         $this->routeDescriber = $this->createMock(RouteDescriberInterface::class);
         $this->routes = new RouteCollection();
         $this->describer = new RouteDescriber(
-            new Container(),
             $this->routes,
-            $this->createMock(ControllerNameParser::class),
+            new ControllerReflector(
+                new Container(),
+                $this->createMock(ControllerNameParser::class)
+            ),
             [$this->routeDescriber]
         );
     }

--- a/Tests/Fixtures/SwaggerPhp/Api.php
+++ b/Tests/Fixtures/SwaggerPhp/Api.php
@@ -11,14 +11,14 @@
 
 namespace Nelmio\ApiDocBundle\Tests\Functional\Fixtures\SwaggerPhp;
 
-use Swagger\Annotations\Info as InfoAnnotation;
+use Swagger\Annotations\Info;
 
 /**
- * @InfoAnnotation(
+ * @Info(
  *   title="My Awesome App",
  *   version="1.3"
  * )
  */
-class Info
+class Api
 {
 }

--- a/Tests/Functional/Controller/ApiController.php
+++ b/Tests/Functional/Controller/ApiController.php
@@ -15,12 +15,37 @@ use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\RequestParam;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Swagger\Annotations as SWG;
 
 /**
  * @Route("/api")
  */
 class ApiController
 {
+    /**
+     * @Route("/swagger", methods={"GET"})
+     * @Route("/swagger2", methods={"GET"})
+     * @SWG\Get(
+     *     @SWG\Response(response="201", description="An example resource")
+     * )
+     */
+    public function swaggerAction()
+    {
+    }
+
+    /**
+     * @Route("/swagger/implicit", methods={"GET", "POST"})
+     * @SWG\Response(response="201", description="Operation automatically detected")
+     * @SWG\Parameter(
+     *     name="foo",
+     *     in="query",
+     *     description="This is a parameter"
+     * )
+     */
+    public function implicitSwaggerAction()
+    {
+    }
+
     /**
      * @Route("/test/{user}", methods={"GET"}, schemes={"https"}, requirements={"user"="/foo/"})
      */

--- a/Util/ControllerReflector.php
+++ b/Util/ControllerReflector.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Util;
+
+use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @internal
+ */
+final class ControllerReflector
+{
+    private $container;
+    private $controllerNameParser;
+
+    public function __construct(ContainerInterface $container, ControllerNameParser $controllerNameParser)
+    {
+        $this->container = $container;
+        $this->controllerNameParser = $controllerNameParser;
+    }
+
+    /**
+     * Returns the ReflectionMethod for the given controller string.
+     *
+     * @param string $controller
+     *
+     * @return \ReflectionMethod|null
+     */
+    public function getReflectionMethod(string $controller)
+    {
+        $callable = $this->getClassAndMethod($controller);
+        if (null === $callable) {
+            return;
+        }
+
+        list($class, $method) = $callable;
+        try {
+            return new \ReflectionMethod($class, $method);
+        } catch (\ReflectionException $e) {
+            // In case we can't reflect the controller, we just
+            // ignore the route
+        }
+    }
+
+    public function getReflectionClassAndMethod(string $controller)
+    {
+        $callable = $this->getClassAndMethod($controller);
+        if (null === $callable) {
+            return;
+        }
+
+        list($class, $method) = $callable;
+        try {
+            return [new \ReflectionClass($class), new \ReflectionMethod($class, $method)];
+        } catch (\ReflectionException $e) {
+            // In case we can't reflect the controller, we just
+            // ignore the route
+        }
+    }
+
+    private function getClassAndMethod(string $controller)
+    {
+        if (false === strpos($controller, '::') && 2 === substr_count($controller, ':')) {
+            $controller = $this->controllerNameParser->parse($controller);
+        }
+
+        if (preg_match('#(.+)::([\w]+)#', $controller, $matches)) {
+            $class = $matches[1];
+            $method = $matches[2];
+        } elseif (class_exists($controller)) {
+            $class = $controller;
+            $method = '__invoke';
+        } else {
+            if (preg_match('#(.+):([\w]+)#', $controller, $matches)) {
+                $controller = $matches[1];
+                $method = $matches[2];
+            }
+
+            if ($this->container->has($controller)) {
+                $class = get_class($this->container->get($controller));
+                if (class_exists(ClassUtils::class)) {
+                    $class = ClassUtils::getRealClass($class);
+                }
+
+                if (!isset($method) && method_exists($class, '__invoke')) {
+                    $method = '__invoke';
+                }
+            }
+        }
+
+        if (!isset($class) || !isset($method)) {
+            return;
+        }
+
+        return [$class, $method];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "~7.0|~7.1",
         "symfony/framework-bundle": "^2.8|^3.0",
-        "exsyst/swagger": "~0.2.2"
+        "exsyst/swagger": "~0.2.3"
     },
     "require-dev": {
         "symfony/twig-bundle": "^2.8|^3.0",


### PR DESCRIPTION
As @dbu suggested in [his article](https://blog.liip.ch/archive/2016/05/11/convert-nelmioapidocbundle-to-swagger-php.html), this PR allows to use SwaggerPhp annotations without specifying the path.
An example, before:
```php
/**
 * @Route("/foo", method="GET")
 * @SWG\Get(path="/foo")
 */
public function myAction()
{
}
```

After:
```php
/**
 * @Route("/foo", method="GET")
 * @SWG\Get()
 */
public function myAction()
{
}
```