### PR TITLE
Add support for bool type in ScalarModelDescriber

### DIFF
--- a/ModelDescriber/ScalarModelDescriber.php
+++ b/ModelDescriber/ScalarModelDescriber.php
@@ -21,6 +21,7 @@ class ScalarModelDescriber implements ModelDescriberInterface
         Type::BUILTIN_TYPE_INT => 'integer',
         Type::BUILTIN_TYPE_FLOAT => 'float',
         Type::BUILTIN_TYPE_STRING => 'string',
+        Type::BUILTIN_TYPE_BOOL => 'boolean'
     ];
 
     public function describe(Model $model, Schema $schema)


### PR DESCRIPTION
No sure if there is a reason why it was not there in the first place. 

It's useful to me =)