### PR TITLE
Fix an error when installing NelmioApiDocBundle

### DIFF
--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -17,10 +17,19 @@ use Swagger\Annotations\Swagger;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
-final class NelmioApiDocExtension extends Extension
+final class NelmioApiDocExtension extends Extension implements PrependExtensionInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function prepend(ContainerBuilder $container)
+    {
+        $container->prependExtensionConfig('framework', ['property_info' => ['enabled' => true]]);
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
I just issued an error while installing NelmioApiDocBundle:
```
[Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]   
  The service "nelmio_api_doc.generator" has a dependency on a non-existent service "property_info". 
```

This is caused by the fact that symfony does not enable the `property_info` component integration by default.