### PR TITLE
Support @SWG\Tag

### DIFF
--- a/Describer/SwaggerPhpDescriber.php
+++ b/Describer/SwaggerPhpDescriber.php
@@ -87,6 +87,7 @@ final class SwaggerPhpDescriber extends ExternalDocDescriber implements ModelReg
                 'filename' => $method->getFileName(),
             ]);
             $implicitAnnotations = [];
+            $tags = [];
             foreach ($annotations as $annotation) {
                 $annotation->_context = $context;
 
@@ -114,6 +115,13 @@ final class SwaggerPhpDescriber extends ExternalDocDescriber implements ModelReg
                     continue;
                 }
 
+                if ($annotation instanceof SWG\Tag) {
+                    $annotation->validate();
+                    $tags[] = $annotation->name;
+
+                    continue;
+                }
+
                 if (!$annotation instanceof SWG\Response && !$annotation instanceof SWG\Parameter && !$annotation instanceof SWG\ExternalDocumentation) {
                     throw new \LogicException(sprintf('Using the annotation "%s" as a root annotation in "%s::%s()" is not allowed.', get_class($annotation), $method->getDeclaringClass()->name, $method->name));
                 }
@@ -121,13 +129,13 @@ final class SwaggerPhpDescriber extends ExternalDocDescriber implements ModelReg
                 $implicitAnnotations[] = $annotation;
             }
 
-            if (0 === count($implicitAnnotations)) {
+            if (0 === count($implicitAnnotations) && 0 === count($tags)) {
                 continue;
             }
 
             foreach ($httpMethods as $httpMethod) {
                 $annotationClass = $operationAnnotations[$httpMethod];
-                $operation = new $annotationClass(['_context' => $context, 'path' => $path, 'value' => $implicitAnnotations]);
+                $operation = new $annotationClass(['_context' => $context, 'path' => $path, 'value' => $implicitAnnotations, 'tags' => $tags]);
                 $analysis->addAnnotation($operation, null);
             }
         }

--- a/Tests/Functional/Controller/ApiController.php
+++ b/Tests/Functional/Controller/ApiController.php
@@ -51,6 +51,7 @@ class ApiController
      *         @Model(type=User::class)
      *     )
      * )
+     * @SWG\Tag(name="implicit")
      */
     public function implicitSwaggerAction()
     {

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -12,6 +12,7 @@
 namespace Nelmio\ApiDocBundle\Tests\Functional;
 
 use EXSyst\Component\Swagger\Operation;
+use EXSyst\Component\Swagger\Tag;
 use EXSyst\Component\Swagger\Schema;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
@@ -61,6 +62,8 @@ class FunctionalTest extends WebTestCase
     public function testImplicitSwaggerAction($method)
     {
         $operation = $this->getOperation('/api/swagger/implicit', $method);
+
+        $this->assertEquals(array(new Tag('implicit')), $operation->getTags());
 
         $responses = $operation->getResponses();
         $this->assertTrue($responses->has('201'));


### PR DESCRIPTION
Fix https://github.com/nelmio/NelmioApiDocBundle/issues/965

Theorically this works fine but I wonder whether `exsyst/swagger` prints a valid file for operation tags as they must not be arrays.