### PR TITLE
[3.0] Handle FOSRestBundle QueryParam required

### DIFF
--- a/RouteDescriber/FosRestDescriber.php
+++ b/RouteDescriber/FosRestDescriber.php
@@ -42,6 +42,7 @@ final class FosRestDescriber implements RouteDescriberInterface
                 $in = $annotation instanceof QueryParam ? 'query' : 'formData';
                 $parameter = $operation->getParameters()->get($annotation->getName(), $in);
 
+                $parameter->setRequired(!$annotation->nullable && $annotation->strict);
                 $parameter->setAllowEmptyValue($annotation->nullable && $annotation->allowBlank);
                 $parameter->setType($annotation->map ? 'array' : 'string');
                 $parameter->setDefault($annotation->getDefault());


### PR DESCRIPTION
If the QueryParam is not nullable and strict, a 400 error will be raised if the query param is not raised, so it's required. 