### PR TITLE
Change the behavior of path_patterns filter to use OR instead of AND

### DIFF
--- a/Routing/FilteredRouteCollectionBuilder.php
+++ b/Routing/FilteredRouteCollectionBuilder.php
@@ -38,11 +38,11 @@ final class FilteredRouteCollectionBuilder
     private function match(Route $route): bool
     {
         foreach ($this->pathPatterns as $pathPattern) {
-            if (!preg_match('{'.$pathPattern.'}', $route->getPath())) {
-                return false;
+            if (preg_match('{'.$pathPattern.'}', $route->getPath())) {
+                return true;
             }
         }
 
-        return true;
+        return false;
     }
 }

--- a/Tests/Routing/FilteredRouteCollectionBuilderTest.php
+++ b/Tests/Routing/FilteredRouteCollectionBuilderTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Routing;
+
+use Nelmio\ApiDocBundle\Routing\FilteredRouteCollectionBuilder;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for FilteredRouteCollectionBuilder class
+ */
+class FilteredRouteCollectionBuilderTest extends TestCase
+{
+    public function testFilter()
+    {
+        $pathPattern = [
+            '^/api/foo',
+            '^/api/bar',
+        ];
+
+        $routes = new RouteCollection();
+        $routes->add('r1', new Route('/api/bar/action1'));
+        $routes->add('r2', new Route('/api/foo/action1'));
+        $routes->add('r3', new Route('/api/foo/action2'));
+        $routes->add('r4', new Route('/api/demo'));
+        $routes->add('r5', new Route('/_profiler/test/test'));
+
+        $routeBuilder = new FilteredRouteCollectionBuilder($pathPattern);
+        $filteredRoutes = $routeBuilder->filter($routes);
+
+        $this->assertCount(3, $filteredRoutes);
+    }
+}


### PR DESCRIPTION
The rule of path_patterns config parameter is not obvious. This pull request changes the filter behavior of the route path_patterns. It makes a OR between pattern elements instead of a AND.