### PR TITLE
Bugfix/no overrides if already set

### DIFF
--- a/RouteDescriber/RouteMetadataDescriber.php
+++ b/RouteDescriber/RouteMetadataDescriber.php
@@ -33,9 +33,8 @@ final class RouteMetadataDescriber implements RouteDescriberInterface
                 }
 
                 $parameter = $operation->getParameters()->get($pathVariable, 'path');
-                if (null === $parameter->getRequired()) {
-                    $parameter->setRequired(true);
-                }
+                $parameter->setRequired(true);
+
                 if (null === $parameter->getType()) {
                     $parameter->setType('string');
                 }

--- a/RouteDescriber/RouteMetadataDescriber.php
+++ b/RouteDescriber/RouteMetadataDescriber.php
@@ -36,7 +36,7 @@ final class RouteMetadataDescriber implements RouteDescriberInterface
                 if (null === $parameter->getRequired()) {
                     $parameter->setRequired(true);
                 }
-                if(null === $parameter->getType()) {
+                if (null === $parameter->getType()) {
                     $parameter->setType('string');
                 }
 

--- a/RouteDescriber/RouteMetadataDescriber.php
+++ b/RouteDescriber/RouteMetadataDescriber.php
@@ -33,8 +33,12 @@ final class RouteMetadataDescriber implements RouteDescriberInterface
                 }
 
                 $parameter = $operation->getParameters()->get($pathVariable, 'path');
-                $parameter->setRequired(true);
-                $parameter->setType('string');
+                if (null === $parameter->getRequired()) {
+                    $parameter->setRequired(true);
+                }
+                if(null === $parameter->getType()) {
+                    $parameter->setType('string');
+                }
 
                 if (isset($requirements[$pathVariable])) {
                     $parameter->setFormat($requirements[$pathVariable]);


### PR DESCRIPTION
- required for PathVariables is no longer overwritten, if already set
- type is no longer overwritten, if already set

Small Example: 

```
/**
 * @Method("GET")
 * @Route("/api/{optional}", name="optionalRoute", defaults={"optional" = 1})
 * @SWG\Tag(name="Optional")
 * @SWG\Response(
 *     response=200,
 *     description="TBD",
 *     @SWG\Schema(
 *          title="Test",
 *          example="{httpCode: 200, success:true}"
 *
 *     )
 * )
 * @SWG\Parameter(in="path", name="optional", type="integer", description="The Optional Value", required=false, default=1)
 * @return JsonResponse
 */
public function optionalParam(int $optional = 1)
{
	return new JsonResponse([
		'httpCode' => 200,
		'success'  => true,
	]);
}
```
Before:
![grafik](https://user-images.githubusercontent.com/20594134/27808820-cde8750e-604a-11e7-9f26-0e4f485f6963.png)

After:
![grafik](https://user-images.githubusercontent.com/20594134/27808954-f0e6f534-604b-11e7-82c1-3ea5447841ef.png)
