### PR TITLE
Added possibility to use another ValidationParser through the config

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -162,6 +162,12 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('file')->defaultValue('%kernel.cache_dir%/api-doc.cache')->end()
                     ->end()
                 ->end()
+                ->arrayNode('parser')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('validation')->defaultValue('Nelmio\ApiDocBundle\Parser\ValidationParser')->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -56,10 +56,7 @@ class NelmioApiDocExtension extends Extension
             $container->setParameter('nelmio_api_doc.sandbox.authentication', $config['sandbox']['authentication']);
         }
 
-        // backwards compatibility for Symfony2.1 https://github.com/nelmio/NelmioApiDocBundle/issues/231
-        if (!interface_exists('\Symfony\Component\Validator\MetadataFactoryInterface')) {
-            $container->setParameter('nelmio_api_doc.parser.validation_parser.class', 'Nelmio\ApiDocBundle\Parser\ValidationParserLegacy');
-        }
+        $container->setParameter('nelmio_api_doc.parser.validation_parser.class', $config['parser']['validation']);
 
         $container->setParameter('nelmio_api_doc.swagger.base_path', $config['swagger']['api_base_path']);
         $container->setParameter('nelmio_api_doc.swagger.swagger_version', $config['swagger']['swagger_version']);

--- a/Resources/config/services.validation.xml
+++ b/Resources/config/services.validation.xml
@@ -3,10 +3,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="nelmio_api_doc.parser.validation_parser.class">Nelmio\ApiDocBundle\Parser\ValidationParser</parameter>
-    </parameters>
-
     <services>
         <service id="nelmio_api_doc.parser.validation_parser" class="%nelmio_api_doc.parser.validation_parser.class%">
             <argument type="service" id="validator.mapping.class_metadata_factory" />

--- a/Resources/doc/configuration-in-depth.rst
+++ b/Resources/doc/configuration-in-depth.rst
@@ -102,7 +102,7 @@ If you want to user another Validation Parser, or want backwards Compatibility f
     # app/config/config.yml
     nelmio_api_doc:
         parser:
-            validation: MyBundl\Parser\MyValidationParser
+            validation: Nelmio\ApiDocBundle\Parser\ValidationParserLegacy
 
 MOTD
 ----

--- a/Resources/doc/configuration-in-depth.rst
+++ b/Resources/doc/configuration-in-depth.rst
@@ -94,6 +94,16 @@ registration:
             tags:
                 - { name: nelmio_api_doc.extractor.parser, priority: 2 }
 
+
+If you want to user another Validation Parser, or want backwards Compatibility for Symfony 2.1, change the validation parser config
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+    nelmio_api_doc:
+        parser:
+            validation: MyBundl\Parser\MyValidationParser
+
 MOTD
 ----
 
@@ -130,3 +140,4 @@ cached:
         cache:
             enabled: true
             file: "/tmp/symfony-app/%kernel.environment%/api-doc.cache"
+

--- a/Resources/doc/configuration-reference.rst
+++ b/Resources/doc/configuration-reference.rst
@@ -53,3 +53,5 @@ Configuration Reference
         cache:
             enabled:              false
             file:                 '%kernel.cache_dir%/api-doc.cache'
+        parser:
+            validation:           Nelmio\ApiDocBundle\Parser\ValidationParser


### PR DESCRIPTION
I wanted to use another ValidationParser instead of the default provided. 

So i added the possibility to configure it. 