### PR TITLE
Allow configuration to be split on root key level.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,6 +23,7 @@ final class Configuration implements ConfigurationInterface
             ->root('nelmio_api_doc')
             ->children()
                 ->arrayNode('documentation')
+                    ->useAttributeAsKey('key')
                     ->info('The documentation used as base')
                     ->example(['info' => ['title' => 'My App']])
                     ->prototype('variable')->end()

--- a/Tests/DependencyInjection/NelmioApiDocExtensionTest.php
+++ b/Tests/DependencyInjection/NelmioApiDocExtensionTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Describer;
+
+use Nelmio\ApiDocBundle\DependencyInjection\NelmioApiDocExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class NelmioApiDocExtensionTest extends TestCase
+{
+    public function testMergesRootKeysFromMultipleConfigurations()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.bundles', []);
+        $extension = new NelmioApiDocExtension();
+        $extension->load([
+            [
+                'documentation' => [
+                    'info' => [
+                        'title' => 'API documentation',
+                        'description' => 'This is the api documentation, use it wisely',
+                    ],
+                ],
+            ],
+            [
+                'documentation' => [
+                    'tags' => [
+                        [
+                            'name' => 'secured',
+                            'description' => 'Requires authentication',
+                        ],
+                        [
+                            'name' => 'another',
+                            'description' => 'Another tag serving another purpose',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'documentation' => [
+                    'paths' => [
+                        '/api/v1/model' => [
+                            'get' => [
+                                'tags' => ['secured'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $container);
+
+        $this->assertSame([
+            'info' => [
+                'title' => 'API documentation',
+                'description' => 'This is the api documentation, use it wisely',
+            ],
+            'tags' => [
+                [
+                    'name' => 'secured',
+                    'description' => 'Requires authentication',
+                ],
+                [
+                    'name' => 'another',
+                    'description' => 'Another tag serving another purpose',
+                ],
+            ],
+            'paths' => [
+                '/api/v1/model' => [
+                    'get' => [
+                        'tags' => ['secured'],
+                    ],
+                ],
+            ],
+        ], $container->getDefinition('nelmio_api_doc.describers.config')->getArgument(0));
+    }
+}


### PR DESCRIPTION
We now allow to split the configuration on multiple files, each
containing one of the various root keys of the "documentation" entry.

This means, you may now split "documentation/*" out to own yml files and
import them.

NOTE: this only allows splitting of entries being a direct child of the
documentation entry, so splitting i.e. the info key over multiple files
will not work.

This is the implementation of #1051.