### PR TITLE
Remove SwaggerUI controller when TwigBundle is not registered

### DIFF
--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -88,6 +88,9 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
 
         // ApiPlatform support
         $bundles = $container->getParameter('kernel.bundles');
+        if (!isset($bundles['TwigBundle'])) {
+            $container->removeDefinition('nelmio_api_doc.controller.swagger_ui');
+        }
         if (isset($bundles['ApiPlatformBundle']) && class_exists('ApiPlatform\Core\Documentation\Documentation')) {
             $loader->load('api_platform.xml');
         }


### PR DESCRIPTION
Fixes https://github.com/nelmio/NelmioApiDocBundle/issues/1072