### PR TITLE
Syntax update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "~7.0|~7.1",
+        "php": "7.0.*|7.1.*",
         "symfony/framework-bundle": "^3.2.5|^4.0",
         "symfony/property-info": "^3.1|^4.0",
         "exsyst/swagger": "~0.3",


### PR DESCRIPTION
`~7.0|~7.1` is the same as `~7.0`. I think you mean to do `7.0.*|7.1.*` since PHP does not do Semver.