### PR TITLE
fix: map route requirements to parameter pattern instead of format

### DIFF
--- a/RouteDescriber/RouteMetadataDescriber.php
+++ b/RouteDescriber/RouteMetadataDescriber.php
@@ -40,7 +40,7 @@ final class RouteMetadataDescriber implements RouteDescriberInterface
                 }
 
                 if (isset($requirements[$pathVariable])) {
-                    $parameter->setFormat($requirements[$pathVariable]);
+                    $parameter->setPattern($requirements[$pathVariable]);
                 }
             }
         }

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -113,7 +113,8 @@ class FunctionalTest extends WebTestCase
         $parameter = $parameters->get('user', 'path');
         $this->assertTrue($parameter->getRequired());
         $this->assertEquals('string', $parameter->getType());
-        $this->assertEquals('/foo/', $parameter->getFormat());
+        $this->assertEquals('/foo/', $parameter->getPattern());
+        $this->assertEmpty($parameter->getFormat());
     }
 
     public function testFOSRestAction()


### PR DESCRIPTION
Currently symfony route requirements are mapped to swaggers' 'format' field on parameters. As described in the following links, the format is meant to be an extension upon the specified 'type' field. The requirements should be mapped to the 'pattern' field.

see:
[OpenAPI Parameter Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameterObject)
[JSON Validation RFC](https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.3)
[OpenAPI Data Type Format](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#dataTypeFormat)
