### PR TITLE
Reading form recursively down(nested form)

### DIFF
--- a/Describer/ModelRegistryAwareTrait.php
+++ b/Describer/ModelRegistryAwareTrait.php
@@ -20,9 +20,6 @@ trait ModelRegistryAwareTrait
      */
     private $modelRegistry;
 
-    /**
-     * @param ModelRegistry $modelRegistry
-     */
     public function setModelRegistry(ModelRegistry $modelRegistry)
     {
         $this->modelRegistry = $modelRegistry;

--- a/Describer/ModelRegistryAwareTrait.php
+++ b/Describer/ModelRegistryAwareTrait.php
@@ -15,8 +15,14 @@ use Nelmio\ApiDocBundle\Model\ModelRegistry;
 
 trait ModelRegistryAwareTrait
 {
+    /**
+     * @var ModelRegistry
+     */
     private $modelRegistry;
 
+    /**
+     * @param ModelRegistry $modelRegistry
+     */
     public function setModelRegistry(ModelRegistry $modelRegistry)
     {
         $this->modelRegistry = $modelRegistry;

--- a/ModelDescriber/FormModelDescriber.php
+++ b/ModelDescriber/FormModelDescriber.php
@@ -116,11 +116,8 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
                     break;
                 }
 
-                if (
-                    ($formType = $type->getInnerType()) &&
-                    ($formClass = get_class($formType)) &&
-                    !$this->isBuiltinType($formClass)   //don't check builtin types in Form component.
-                ) {
+                if ($type->getInnerType() && ($formClass = get_class($type->getInnerType())) && !$this->isBuiltinType($formClass)) {
+                    //if form type is not builtin in Form component.
                     $model = new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, $formClass));
                     $property->setRef($this->modelRegistry->register($model));
                     break;
@@ -136,13 +133,8 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
         }
     }
 
-    /**
-     * @param string $type
-     *
-     * @return bool
-     */
-    private function isBuiltinType(string $type) : bool
+    private function isBuiltinType(string $type): bool
     {
-        return strpos($type, 'Symfony\Component\Form\Extension\Core\Type') !== false;
+        return 0 === strpos($type, 'Symfony\Component\Form\Extension\Core\Type');
     }
 }

--- a/ModelDescriber/FormModelDescriber.php
+++ b/ModelDescriber/FormModelDescriber.php
@@ -12,15 +12,22 @@
 namespace Nelmio\ApiDocBundle\ModelDescriber;
 
 use EXSyst\Component\Swagger\Schema;
+use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
+use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareTrait;
 use Nelmio\ApiDocBundle\Model\Model;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormTypeInterface;
+use Symfony\Component\PropertyInfo\Type;
 
 /**
  * @internal
  */
-final class FormModelDescriber implements ModelDescriberInterface
+final class FormModelDescriber implements ModelDescriberInterface, ModelRegistryAwareInterface
 {
+    use ModelRegistryAwareTrait;
+
     private $formFactory;
 
     public function __construct(FormFactoryInterface $formFactory = null)
@@ -30,7 +37,7 @@ final class FormModelDescriber implements ModelDescriberInterface
 
     public function describe(Model $model, Schema $schema)
     {
-        if (method_exists('Symfony\Component\Form\AbstractType', 'setDefaultOptions')) {
+        if (method_exists(AbstractType::class, 'setDefaultOptions')) {
             throw new \LogicException('symfony/form < 3.0 is not supported, please upgrade to an higher version to use a form as a model.');
         }
         if (null === $this->formFactory) {
@@ -51,9 +58,10 @@ final class FormModelDescriber implements ModelDescriberInterface
         return is_a($model->getType()->getClassName(), FormTypeInterface::class, true);
     }
 
-    private function parseForm(Schema $schema, $form)
+    private function parseForm(Schema $schema, FormInterface $form)
     {
         $properties = $schema->getProperties();
+
         foreach ($form as $name => $child) {
             $config = $child->getConfig();
             $property = $properties->get($name);
@@ -64,16 +72,24 @@ final class FormModelDescriber implements ModelDescriberInterface
                     $property->setType('string');
                     break;
                 }
+
+                if ('number' === $blockPrefix) {
+                    $property->setType('number');
+                    break;
+                }
+
                 if ('date' === $blockPrefix) {
                     $property->setType('string');
                     $property->setFormat('date');
                     break;
                 }
+
                 if ('datetime' === $blockPrefix) {
                     $property->setType('string');
                     $property->setFormat('date-time');
                     break;
                 }
+
                 if ('choice' === $blockPrefix) {
                     $property->setType('string');
                     if (($choices = $config->getOption('choices')) && is_array($choices) && count($choices)) {
@@ -85,6 +101,30 @@ final class FormModelDescriber implements ModelDescriberInterface
                 if ('collection' === $blockPrefix) {
                     $subType = $config->getOption('entry_type');
                 }
+
+                if ('entity' === $blockPrefix) {
+                    $entityClass = $config->getOption('class');
+
+                    if ($config->getOption('multiple')) {
+                        $property->setFormat(sprintf('[%s id]', $entityClass));
+                        $property->setType('array');
+                        $property->setExample('[1, 2, 3]');
+                    } else {
+                        $property->setType('string');
+                        $property->setFormat(sprintf('%s id', $entityClass));
+                    }
+                    break;
+                }
+
+                if (
+                    ($formType = $type->getInnerType()) &&
+                    ($formClass = get_class($formType)) &&
+                    !$this->isBuiltinType($formClass)   //don't check builtin types in Form component.
+                ) {
+                    $model = new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, $formClass));
+                    $property->setRef($this->modelRegistry->register($model));
+                    break;
+                }
             }
 
             if ($config->getRequired()) {
@@ -94,5 +134,15 @@ final class FormModelDescriber implements ModelDescriberInterface
                 $schema->setRequired($required);
             }
         }
+    }
+
+    /**
+     * @param string $type
+     *
+     * @return bool
+     */
+    private function isBuiltinType(string $type) : bool
+    {
+        return strpos($type, 'Symfony\Component\Form\Extension\Core\Type') !== false;
     }
 }

--- a/Tests/Functional/Controller/ApiController.php
+++ b/Tests/Functional/Controller/ApiController.php
@@ -20,6 +20,7 @@ use Nelmio\ApiDocBundle\Tests\Functional\Entity\User;
 use Nelmio\ApiDocBundle\Tests\Functional\Form\DummyType;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Swagger\Annotations as SWG;
+use Nelmio\ApiDocBundle\Tests\Functional\Form\UserType;
 
 /**
  * @Route("/api")
@@ -68,6 +69,27 @@ class ApiController
      * @SWG\Tag(name="implicit")
      */
     public function implicitSwaggerAction()
+    {
+    }
+
+    /**
+     * @Route("/test/users/{user}", methods={"POST"}, schemes={"https"}, requirements={"user"="/foo/"})
+     * @SWG\Response(
+     *     response="201",
+     *     description="Operation automatically detected",
+     *     @Model(type=User::class)
+     * )
+     * @SWG\Parameter(
+     *     name="foo",
+     *     in="body",
+     *     description="This is a parameter",
+     *     @SWG\Schema(
+     *         type="array",
+     *         @Model(type=UserType::class)
+     *     )
+     * )
+     */
+    public function submitUserTypeAction()
     {
     }
 

--- a/Tests/Functional/Controller/ApiController.php
+++ b/Tests/Functional/Controller/ApiController.php
@@ -18,9 +18,9 @@ use Nelmio\ApiDocBundle\Annotation\Operation;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\Article;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\User;
 use Nelmio\ApiDocBundle\Tests\Functional\Form\DummyType;
+use Nelmio\ApiDocBundle\Tests\Functional\Form\UserType;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Swagger\Annotations as SWG;
-use Nelmio\ApiDocBundle\Tests\Functional\Form\UserType;
 
 /**
  * @Route("/api")

--- a/Tests/Functional/Form/UserType.php
+++ b/Tests/Functional/Form/UserType.php
@@ -1,11 +1,20 @@
 <?php
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional\Form;
 
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\User;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Nelmio\ApiDocBundle\Tests\Functional\Entity\User;
 
 class UserType extends AbstractType
 {
@@ -17,7 +26,7 @@ class UserType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'data_class' => User::class
+            'data_class' => User::class,
         ]);
     }
 }

--- a/Tests/Functional/Form/UserType.php
+++ b/Tests/Functional/Form/UserType.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\User;
+
+class UserType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('dummy', DummyType::class);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'data_class' => User::class
+        ]);
+    }
+}

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -179,7 +179,7 @@ class FunctionalTest extends WebTestCase
         $this->assertEquals([
             'type' => 'object',
             'properties' => [
-                'dummy' => ['$ref' => '#/definitions/DummyType']
+                'dummy' => ['$ref' => '#/definitions/DummyType'],
             ],
             'required' => ['dummy'],
         ], $this->getModel('UserType')->toArray());

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -179,6 +179,14 @@ class FunctionalTest extends WebTestCase
         $this->assertEquals([
             'type' => 'object',
             'properties' => [
+                'dummy' => ['$ref' => '#/definitions/DummyType']
+            ],
+            'required' => ['dummy'],
+        ], $this->getModel('UserType')->toArray());
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
                 'bar' => [
                     'type' => 'string',
                 ],


### PR DESCRIPTION
1. Read form recursively (nested forms).
2.Added support for `EntityType` in `FormModelDescriber`. (if `multiple -> true` - array, not - string. Added examples).
2.Added support for `NumberType`.
3.Modified `formSupport` test.
fix https://github.com/nelmio/NelmioApiDocBundle/issues/1079