### PR TITLE
Fix migration command

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -81,7 +81,7 @@ class SwaggerDocblockConvertCommand extends ContainerAwareCommand
      *     summary="'.$this->escapeQuotes($apiDoc->getDescription()).'"';
 
         foreach ($apiDoc->getFilters() as $name => $parameter) {
-            $description = array_key_exists('description', $parameter)
+            $description = array_key_exists('description', $parameter) && null !== $parameter['description']
                 ? $this->escapeQuotes($parameter['description'])
                 : 'todo';
 


### PR DESCRIPTION
Fix null argument
```php
 [Symfony\Component\Debug\Exception\FatalThrowableError]                                                                                                                                                         
  Type error: Argument 1 passed to SwaggerDocblockConvertCommand::escapeQuotes() must be of the type string, null given, called in SwaggerDocblockConvertCommand.php on line 92                   
```