### PR TITLE
Enclose form type fields in an object

### DIFF
--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -177,26 +177,37 @@ class FunctionalTest extends WebTestCase
 
     public function testFormSupport()
     {
+        // User Object
         $this->assertEquals([
             'type' => 'object',
             'properties' => [
-                'dummy' => ['$ref' => '#/definitions/DummyType'],
+                'user' => ['$ref' => '#/definitions/UserTypeProperties'],
             ],
-            'required' => ['dummy'],
+            'required' => ['user'],
         ], $this->getModel('UserType')->toArray());
 
+        $this->assertTrue($this->getSwaggerDefinition()->getDefinitions()->has('UserTypeProperties'));
+
+        $userTypeProperties = $this->getSwaggerDefinition()->getDefinitions()->get('UserTypeProperties');
+        $properties = $userTypeProperties->getProperties();
+
+        $this->assertTrue($properties->has('dummy'));
+
+        // Dummy object
         $this->assertEquals([
             'type' => 'object',
             'properties' => [
-                'bar' => [
-                    'type' => 'string',
-                ],
-                'foo' => [
-                    'type' => 'string',
-                    'enum' => ['male', 'female'],
-                ],
+                'dummy' => ['$ref' => '#/definitions/DummyTypeProperties'],
             ],
-            'required' => ['foo'],
+            'required' => ['dummy'],
         ], $this->getModel('DummyType')->toArray());
+
+        $this->assertTrue($this->getSwaggerDefinition()->getDefinitions()->has('DummyTypeProperties'));
+
+        $userTypeProperties = $this->getSwaggerDefinition()->getDefinitions()->get('DummyTypeProperties');
+        $properties = $userTypeProperties->getProperties();
+
+        $this->assertTrue($properties->has('foo'));
+        $this->assertTrue($properties->has('bar'));
     }
 }

--- a/Tests/Functional/WebTestCase.php
+++ b/Tests/Functional/WebTestCase.php
@@ -13,6 +13,7 @@ namespace Nelmio\ApiDocBundle\Tests\Functional;
 
 use EXSyst\Component\Swagger\Operation;
 use EXSyst\Component\Swagger\Schema;
+use EXSyst\Component\Swagger\Swagger;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 
 class WebTestCase extends BaseWebTestCase
@@ -22,7 +23,7 @@ class WebTestCase extends BaseWebTestCase
         return new TestKernel();
     }
 
-    protected function getSwaggerDefinition()
+    protected function getSwaggerDefinition(): Swagger
     {
         static::createClient();
 


### PR DESCRIPTION
When serializing a form type, its fields are actually enclosed in an object which name is the one of the entity the form takes account for.

To achieve this, we register one more form wich is actually an extension of the original formType in the model registery to have a second pass on the describer.
On the first pass, we had a ref to the fields definition on the original form type, and on the second one we actually register the fields.

Something like
```
@SWG\Parameter(
     *     name="body",
     *     in="body",
     *     description="Artist to add",
     *     required=true,
     *     @Model(type=ArtistType::class),
     * )
```

With a form like this one

```
        $builder
            ->add('name', TextType::class, ['required' => true])
            ->add('slug', TextType::class, ['required' => true])
```

Should generate those definitions

```
        "ArtistType": {
            "required": [
                "artist"
            ],
            "properties": {
                "artist": {
                    "$ref": "#/definitions/ArtistTypeProperties"
                }
            },
            "type": "object"
        },
        "ArtistTypeProperties": {
            "required": [
                "name",
                "slug"
            ],
            "properties": {
                "name": {
                    "type": "string"
                },
                "slug": {
                    "type": "string"
                }
            },
            "type": "object"
        }
```