### PR TITLE
PHP 7.2 compatibility fix

### DIFF
--- a/Describer/DefaultDescriber.php
+++ b/Describer/DefaultDescriber.php
@@ -38,7 +38,7 @@ final class DefaultDescriber implements DescriberInterface
                 $operation = $path->getOperation($method);
 
                 // Default Response
-                if (0 === count($operation->getResponses())) {
+                if (0 === iterator_count($operation->getResponses())) {
                     $defaultResponse = $operation->getResponses()->get('default');
                     $defaultResponse->setDescription('');
                 }


### PR DESCRIPTION
Starting from PHP 7.2 a warning will be thrown [when calling count() against non-countable objects](https://wiki.php.net/rfc/counting_non_countables).

This pull request attempts to fix a case where count() is called on a non-countable object - 
 `\EXSyst\Component\Swagger\Collections\Responses` is not an array and doesn't implements `Countable`. Given it implements `Traversable`, the counting code is changed from `count()` to `iterator_count()`.

While the title states it as a compatibility fix, I suspect this also fixes a hidden bug.
