### PR TITLE
Supporting different sets of documentations for different domains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.phpunit
 /Tests/Functional/cache
 /Tests/Functional/logs
+/.idea/

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -29,12 +29,50 @@ final class Configuration implements ConfigurationInterface
                     ->prototype('variable')->end()
                 ->end()
                 ->arrayNode('routes')
+                    ->beforeNormalization()
+                        ->ifTrue(function ($v) {
+                            return is_array($v) && array_key_exists('path_patterns', $v) && is_array($v['path_patterns']) && !array_key_exists('path_patterns', $v['path_patterns']);
+                        })
+                        ->then(function ($v) {
+                            $v['host'] = null;
+                            return [$v];
+                        })
+                    ->end()
+                    ->beforeNormalization()
+                        ->ifTrue(function ($v) { // make sure that each host was mentioned once
+                            $hosts = [];
+                            foreach ($v as $arr) {
+                                if (in_array($arr['host'], $hosts)) {
+                                    return true;
+                                }
+                                $hosts[] = $arr['host'];
+                            }
+                            return false;
+                        })
+                        ->then(function ($v) {
+                            $result = [];
+                            foreach ($v as $arr){
+                                foreach ($result as &$item) {
+                                    if ($arr['host'] === $item['host']) {
+                                        $item['path_patterns'] = array_unique(array_merge($item['path_patterns'], $arr['path_patterns']));
+                                        continue 2;
+                                    }
+                                }
+                                $result[] = $arr;
+                            }
+                            return $result;
+                        })
+                    ->end()
                     ->info('Filter the routes that are documented')
-                    ->addDefaultsIfNotSet()
-                    ->children()
-                        ->arrayNode('path_patterns')
-                            ->example(['^/api', '^/api(?!/admin)'])
-                            ->prototype('scalar')->end()
+                    ->prototype('array')
+                        ->children()
+                            ->scalarNode('host')
+                                ->defaultValue(null)
+                            ->end()
+                            ->arrayNode('path_patterns')
+                                ->example(['^/api', '^/api(?!/admin)'])
+                                ->prototype('scalar')->end()
+                            ->end()
                         ->end()
                     ->end()
                 ->end()

--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -63,7 +63,7 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
         $routesDefinition = (new Definition(RouteCollection::class))
             ->setFactory([new Reference('router'), 'getRouteCollection']);
 
-        if (0 === count($config['routes']['path_patterns'])) {
+        if (0 === count($config['routes'])) {
             $container->setDefinition('nelmio_api_doc.routes', $routesDefinition)
                 ->setPublic(false);
         } else {
@@ -71,7 +71,8 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
                 ->setPublic(false)
                 ->setFactory([
                     (new Definition(FilteredRouteCollectionBuilder::class))
-                        ->addArgument($config['routes']['path_patterns']),
+                        ->addArgument(new Reference('request_stack'))
+                        ->addArgument($config['routes']),
                     'filter',
                 ])
                 ->addArgument($routesDefinition);

--- a/README.md
+++ b/README.md
@@ -82,6 +82,23 @@ nelmio_api_doc:
             - ^/api
 ```
 
+Alternative configuration for different hosts.
+
+```yml
+# app/config/config.yml
+nelmio_api_doc:
+    routes:
+        api:
+            host: api.example.com
+            path_patterns: # an array of regexps
+                - ^/api
+        rest:
+            host: rest.example.com
+            path_patterns:
+                - ^/rest
+            
+```
+
 ## Use the bundle
 
 You can configure globally your documentation in the config (take a look at

--- a/Routing/FilteredRouteCollectionBuilder.php
+++ b/Routing/FilteredRouteCollectionBuilder.php
@@ -42,7 +42,8 @@ final class FilteredRouteCollectionBuilder
 
     private function match(Route $route): bool
     {
-        $actualHost = $this->requestStack->getCurrentRequest()->getHost();
+        $masterRequest = $this->requestStack->getMasterRequest();
+        $actualHost = $masterRequest ? $masterRequest->getHost() : null;
         foreach ($this->routesConfig as $oneRouteConfig) {
             if (array_key_exists('host', $oneRouteConfig) && $oneRouteConfig['host'] !== null && $oneRouteConfig['host'] !== $actualHost) {
                 continue;

--- a/Routing/FilteredRouteCollectionBuilder.php
+++ b/Routing/FilteredRouteCollectionBuilder.php
@@ -11,16 +11,21 @@
 
 namespace Nelmio\ApiDocBundle\Routing;
 
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
 final class FilteredRouteCollectionBuilder
 {
-    private $pathPatterns;
+    /** @var RequestStack */
+    private $requestStack;
+    /** @var array */
+    private $routesConfig;
 
-    public function __construct(array $pathPatterns = [])
+    public function __construct(RequestStack $requestStack, array $routesConfig = [])
     {
-        $this->pathPatterns = $pathPatterns;
+        $this->requestStack = $requestStack;
+        $this->routesConfig = $routesConfig;
     }
 
     public function filter(RouteCollection $routes): RouteCollection
@@ -37,9 +42,15 @@ final class FilteredRouteCollectionBuilder
 
     private function match(Route $route): bool
     {
-        foreach ($this->pathPatterns as $pathPattern) {
-            if (preg_match('{'.$pathPattern.'}', $route->getPath())) {
-                return true;
+        $actualHost = $this->requestStack->getCurrentRequest()->getHost();
+        foreach ($this->routesConfig as $oneRouteConfig) {
+            if (array_key_exists('host', $oneRouteConfig) && $oneRouteConfig['host'] !== null && $oneRouteConfig['host'] !== $actualHost) {
+                continue;
+            }
+            foreach ($oneRouteConfig['path_patterns'] as $pathPattern) {
+                if (preg_match('{' . $pathPattern . '}', $route->getPath())) {
+                    return true;
+                }
             }
         }
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,61 @@
+<?php
+namespace DependencyInjection;
+
+use Nelmio\ApiDocBundle\DependencyInjection\Configuration;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Processor;
+
+class ConfigurationTest extends TestCase
+{
+    public function testOnlyPathPatternsConfigurations()
+    {
+        $config = [
+            'routes' => [
+                'path_patterns' => ['/api/doc', '/api/info']
+            ]
+        ];
+
+        $processor = new Processor();
+        $configuration = new Configuration();
+        $processedConfiguration = $processor->processConfiguration(
+            $configuration,
+            [$config]
+        );
+
+        $this->assertSame([
+            'routes'        => [
+                ['path_patterns' => ['/api/doc', '/api/info'], 'host' => null]
+            ],
+            'documentation' => [],
+            'models'        => ['use_jms' => false]
+        ], $processedConfiguration);
+    }
+
+    public function testMultipleRoutesConfigurations()
+    {
+        $config = [
+            'routes' => [
+                ['host' => null, 'path_patterns' => ['/api/doc', '/api/info']],
+                ['host' => 'app.foobar.com', 'path_patterns' => ['/api/foo', '/api/bar']],
+                ['host' => 'app.foobar.com', 'path_patterns' => ['/api/foo1', '/api/bar1']],
+                ['host' => 'app.foobar.com', 'path_patterns' => ['/api/foo', '/api/bar1']],
+            ],
+        ];
+
+        $processor = new Processor();
+        $configuration = new Configuration();
+        $processedConfiguration = $processor->processConfiguration(
+            $configuration,
+            [$config]
+        );
+
+        $this->assertSame([
+            'routes'        => [
+                ['host' => null, 'path_patterns' => ['/api/doc', '/api/info']],
+                ['host' => 'app.foobar.com', 'path_patterns' => ['/api/foo', '/api/bar', '/api/foo1', '/api/bar1']],
+            ],
+            'documentation' => [],
+            'models'        => ['use_jms' => false]
+        ], $processedConfiguration);
+    }
+}

--- a/Tests/Routing/FilteredRouteCollectionBuilderTest.php
+++ b/Tests/Routing/FilteredRouteCollectionBuilderTest.php
@@ -13,6 +13,8 @@ namespace Nelmio\ApiDocBundle\Tests\Routing;
 
 use Nelmio\ApiDocBundle\Routing\FilteredRouteCollectionBuilder;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -21,13 +23,33 @@ use Symfony\Component\Routing\RouteCollection;
  */
 class FilteredRouteCollectionBuilderTest extends TestCase
 {
-    public function testFilter()
+    /**
+     * @dataProvider routesProvider
+     * @param RequestStack $requestStack
+     * @param RouteCollection $routes
+     * @param $expectedCount
+     */
+    public function testFilter($requestStack, $routes, $expectedCount)
     {
-        $pathPattern = [
-            '^/api/foo',
-            '^/api/bar',
+        $routesConfig = [
+            ['host' => null, 'path_patterns' => ['^/api/foo', '^/api/bar']],
+            ['host' => 'fakehost2.com', 'path_patterns' => ['^/api/demo']]
         ];
 
+        $routeBuilder = new FilteredRouteCollectionBuilder($requestStack, $routesConfig);
+        $filteredRoutes = $routeBuilder->filter($routes);
+
+        $this->assertCount($expectedCount, $filteredRoutes);
+    }
+
+    public function routesProvider()
+    {
+        $result = [];
+
+        $requestStack = new RequestStack();
+        $fakeRequest = Request::create('/', 'GET');
+        $fakeRequest->headers->add(['HOST' => 'fakehost.com']);
+        $requestStack->push($fakeRequest);
         $routes = new RouteCollection();
         $routes->add('r1', new Route('/api/bar/action1'));
         $routes->add('r2', new Route('/api/foo/action1'));
@@ -35,9 +57,34 @@ class FilteredRouteCollectionBuilderTest extends TestCase
         $routes->add('r4', new Route('/api/demo'));
         $routes->add('r5', new Route('/_profiler/test/test'));
 
-        $routeBuilder = new FilteredRouteCollectionBuilder($pathPattern);
-        $filteredRoutes = $routeBuilder->filter($routes);
+        $result[] = [$requestStack, $routes, 3];
 
-        $this->assertCount(3, $filteredRoutes);
+        $requestStack = new RequestStack();
+        $fakeRequest = Request::create('/', 'GET');
+        $fakeRequest->headers->add(['HOST' => 'fakehost2.com']);
+        $requestStack->push($fakeRequest);
+        $routes = new RouteCollection();
+        $routes->add('r1', new Route('/api/bar/action1'));
+        $routes->add('r2', new Route('/api/foo/action1'));
+        $routes->add('r3', new Route('/api/foo/action2', [], [], [], 'fakehost2.com'));
+        $routes->add('r4', new Route('/api/demo', [], [], [], 'fakehost2.com'));
+        $routes->add('r5', new Route('/_profiler/test/test'));
+
+        $result[] = [$requestStack, $routes, 4];
+
+
+        $requestStack = new RequestStack();
+        $fakeRequest = Request::create('/', 'GET');
+        $fakeRequest->headers->add(['HOST' => 'fakehost2.com']);
+        $requestStack->push($fakeRequest);
+        $routes = new RouteCollection();
+        $routes->add('r1', new Route('/api/baz/action1'));
+        $routes->add('r2', new Route('/api/you/shall/not/pass'));
+        $routes->add('r4', new Route('/api/demo', [], [], [], 'fakehost2.com'));
+        $routes->add('r5', new Route('/_profiler/test/test'));
+
+        $result[] = [$requestStack, $routes, 1];
+
+        return $result;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,11 +36,11 @@
         "symfony/phpunit-bridge": "^3.3",
         "sensio/framework-extra-bundle": "^3.0",
         "doctrine/annotations": "^1.2",
-
         "phpdocumentor/reflection-docblock": "^3.1",
         "api-platform/core": "^2.0.3",
         "friendsofsymfony/rest-bundle": "^2.0",
-        "jms/serializer-bundle": "^1.0|^2.0"
+        "jms/serializer-bundle": "^1.0|^2.0",
+        "phpunit/phpunit": "^6.3"
     },
     "suggest": {
         "phpdocumentor/reflection-docblock": "For parsing php docs.",


### PR DESCRIPTION
The feature allows to configure displayed API function for different domains.
Backward compatibility was saved.
Tests work ok.

```
nelmio_api_doc:
    routes:
        api:
            host: api.example.com
            path_patterns: # an array of regexps
                - ^/api
        rest:
            host: rest.example.com
            path_patterns:
                - ^/rest
```