### PR TITLE
Add code to handle collectiontype in form describer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,14 @@ matrix:
   include:
     - php: 7.0
       env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.1
+      env: SF_4="true"
 
 before_install:
     - phpenv config-rm xdebug.ini
+    - if [ "$SF_4" == "true" ]; then composer config minimum-stability dev; fi
+    - if [ "$SF_4" == "true" ]; then composer require symfony/symfony:4.0.* --dev --no-update; fi
+    - if [ "$SF_4" == "true" ]; then composer require friendsofsymfony/rest-bundle:dev-master --dev --no-update; fi
 
 install: composer update $COMPOSER_FLAGS --prefer-stable
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,9 @@ matrix:
   include:
     - php: 7.0
       env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: 7.1
-      env: SF_4="true"
 
 before_install:
     - phpenv config-rm xdebug.ini
-    - if [ "$SF_4" == "true" ]; then composer config minimum-stability dev; fi
-    - if [ "$SF_4" == "true" ]; then composer require symfony/symfony:4.0.* --dev --no-update; fi
-    - if [ "$SF_4" == "true" ]; then composer require friendsofsymfony/rest-bundle:dev-master --dev --no-update; fi
 
 install: composer update $COMPOSER_FLAGS --prefer-stable
 

--- a/ModelDescriber/FormModelDescriber.php
+++ b/ModelDescriber/FormModelDescriber.php
@@ -100,7 +100,7 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
                 }
                 if ('collection' === $blockPrefix) {
                     $subType = $config->getOption('entry_type');
-					$property->setType('array');
+                    $property->setType('array');
 
                     $model = new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, $subType), null);
                     $property->getItems()->setRef($this->modelRegistry->register($model));

--- a/ModelDescriber/FormModelDescriber.php
+++ b/ModelDescriber/FormModelDescriber.php
@@ -100,6 +100,10 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
                 }
                 if ('collection' === $blockPrefix) {
                     $subType = $config->getOption('entry_type');
+					$property->setType('array');
+
+                    $model = new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, $subType), null);
+                    $property->getItems()->setRef($this->modelRegistry->register($model));
                 }
 
                 if ('entity' === $blockPrefix) {


### PR DESCRIPTION
Currently, `FormModelDescribe `doesn't handle `CollectionType`.

So I propose a quick fix to enable it.