### PR TITLE
Support the swagger-php Property annotation for Models

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -56,6 +56,7 @@
 
         <service id="nelmio_api_doc.model_describers.object" class="Nelmio\ApiDocBundle\ModelDescriber\ObjectModelDescriber" public="false">
             <argument type="service" id="property_info" />
+            <argument type="service" id="annotation_reader" />
 
             <tag name="nelmio_api_doc.model_describer" />
         </service>


### PR DESCRIPTION
Hi,

When using the Model annotation in order to reference an Entity class in a doc block, the properties from the object are parsed using the PropertyInfo component to get the variable type an create a $ref for this property.
This behavior prevents to add more information to the property. For instance, it's not possible to set an example value.

This PR adds the ability to annotate object properties with `Swagger\Annotations\Property` and fallback to the current behavior (using $ref) if none is set.

Thanks for your comments and advices.