### PR TITLE
Fixing missing documentation on Markdown output

### DIFF
--- a/Formatter/MarkdownFormatter.php
+++ b/Formatter/MarkdownFormatter.php
@@ -32,7 +32,7 @@ class MarkdownFormatter extends AbstractFormatter
         $markdown .= "\n\n";
 
         if (isset($data['documentation']) && !empty($data['documentation'])) {
-            if (isset($data['description']) && 0 === strcmp($data['description'], $data['documentation'])) {
+            if (isset($data['description']) && 0 !== strcmp($data['description'], $data['documentation'])) {
                 $markdown .= $data['documentation'];
                 $markdown .= "\n\n";
             }


### PR DESCRIPTION
There is a little bug with the markdown generation by missing documentation. 

Adding the documentation section only when it's the same as the description does not make sense. So the documentation is missing when you create the markdown output.

This little tweak fixes it.