### PR TITLE
[2.x] Fix compatibility with Symfony 3.4 and 4.0

### DIFF
--- a/Resources/config/formatters.xml
+++ b/Resources/config/formatters.xml
@@ -19,7 +19,7 @@
         <service id="nelmio_api_doc.formatter.simple_formatter" class="%nelmio_api_doc.formatter.simple_formatter.class%"
             parent="nelmio_api_doc.formatter.abstract_formatter" />
         <service id="nelmio_api_doc.formatter.html_formatter" class="%nelmio_api_doc.formatter.html_formatter.class%"
-            parent="nelmio_api_doc.formatter.abstract_formatter">
+            parent="nelmio_api_doc.formatter.abstract_formatter" public="true">
             <call method="setTemplatingEngine">
                 <argument type="service" id="templating" />
             </call>
@@ -61,7 +61,7 @@
             </call>
         </service>
         <service id="nelmio_api_doc.formatter.swagger_formatter" class="%nelmio_api_doc.formatter.swagger_formatter.class%"
-            parent="nelmio_api_doc.formatter.abstract_formatter" />
+            parent="nelmio_api_doc.formatter.abstract_formatter" public="true" />
     </services>
 
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -26,7 +26,7 @@
             <argument type="service" id="kernel" />
         </service>
 
-        <service id="nelmio_api_doc.extractor.api_doc_extractor" class="%nelmio_api_doc.extractor.api_doc_extractor.class%">
+        <service id="nelmio_api_doc.extractor.api_doc_extractor" class="%nelmio_api_doc.extractor.api_doc_extractor.class%" public="true">
             <argument type="service" id="service_container" />
             <argument type="service" id="router" />
             <argument type="service" id="annotation_reader" />

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
     ],
     "require": {
         "php": ">=5.4",
-        "symfony/twig-bundle": "~2.3|~3.0",
-        "symfony/framework-bundle": "~2.3|~3.0",
-        "symfony/console": "~2.3|~3.0",
+        "symfony/twig-bundle": "~2.3|~3.0|~4.0",
+        "symfony/framework-bundle": "~2.3|~3.0|~4.0",
+        "symfony/console": "~2.3|~3.0|~4.0",
         "michelf/php-markdown": "~1.4"
     },
     "conflict": {
@@ -28,20 +28,20 @@
         "symfony/symfony": "~2.7.8"
     },
     "require-dev": {
-        "symfony/css-selector": "~2.3|~3.0",
-        "symfony/browser-kit": "~2.3|~3.0",
-        "symfony/validator": "~2.3|~3.0",
-        "symfony/yaml": "~2.3|~3.0",
-        "symfony/form": "~2.3|~3.0",
-        "symfony/finder": "~2.3|~3.0",
-        "symfony/serializer": "~2.7|~3.0",
+        "symfony/css-selector": "~2.3|~3.0|~4.0",
+        "symfony/browser-kit": "~2.3|~3.0|~4.0",
+        "symfony/validator": "~2.3|~3.0|~4.0",
+        "symfony/yaml": "~2.3|~3.0|~4.0",
+        "symfony/form": "~2.3|~3.0|~4.0",
+        "symfony/finder": "~2.3|~3.0|~4.0",
+        "symfony/serializer": "~2.7|~3.0|~4.0",
         "doctrine/orm": "~2.3",
         "doctrine/doctrine-bundle": "~1.5",
         "friendsofsymfony/rest-bundle": "~1.0|~2.0",
         "jms/serializer-bundle": ">=0.11",
-        "dunglas/api-bundle": "~1.0@dev",
+        "dunglas/api-bundle": "~1.0",
         "sensio/framework-extra-bundle": "~3.0",
-        "symfony/phpunit-bridge": "~2.7|~3.0"
+        "symfony/phpunit-bridge": "~2.7|~3.0|~4.0"
     },
     "suggest": {
         "symfony/form": "For using form definitions as input.",


### PR DESCRIPTION
Tests will be red because they already are, but the API Platform test suite pass with those changes. I suggest to merge this patch as is.