### PR TITLE
Fix exception when attempting to read swagger annotation for virtual property

### DIFF
--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -101,7 +101,8 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
             }
 
             // read property options from Swagger Property annotation if it exists
-            $this->swaggerPropertyAnnotationReader->updateWithSwaggerPropertyAnnotation($item->reflection, $property);
+            if($item->reflection !== null)
+                $this->swaggerPropertyAnnotationReader->updateWithSwaggerPropertyAnnotation($item->reflection, $property);
         }
     }
 

--- a/Tests/Functional/Controller/JMSController.php
+++ b/Tests/Functional/Controller/JMSController.php
@@ -13,6 +13,7 @@ namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
 
 use Nelmio\ApiDocBundle\Annotation\Model;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSUser;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\VirtualProperty;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Swagger\Annotations as SWG;
 
@@ -28,5 +29,18 @@ class JMSController
      */
     public function userAction()
     {
+    }
+
+    /**
+     * @Route("/api/yaml", methods={"GET"})
+     * @SWG\Response(
+     *     response=200,
+     *     description="Success",
+     *     @Model(type=VirtualProperty::class)
+     * )
+     */
+    public function yamlAction()
+    {
+
     }
 }

--- a/Tests/Functional/Entity/VirtualProperty.php
+++ b/Tests/Functional/Entity/VirtualProperty.php
@@ -1,0 +1,39 @@
+<?php
+
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * Class VirtualProperty
+ * @package Nelmio\ApiDocBundle\Tests\Functional\Entity
+ *
+ * @Serializer\ExclusionPolicy("all")
+ * @Serializer\VirtualProperty(
+ *     "email",
+ *     exp="object.user.email",
+ *     options={@Serializer\Type("string")}
+ *  )
+ */
+class VirtualProperty
+{
+
+    /**
+     * @var int
+     * @Serializer\Type("integer")
+     * @Serializer\Expose
+     */
+    private $id;
+
+    /**
+     * @var User
+     */
+    private $user;
+
+    public function __construct()
+    {
+        $this->user = new User();
+        $this->user->setEmail("dummy@test.com");
+    }
+}

--- a/Tests/Functional/JMSFunctionalTest.php
+++ b/Tests/Functional/JMSFunctionalTest.php
@@ -49,6 +49,21 @@ class JMSFunctionalTest extends WebTestCase
         ], $this->getModel('JMSUser')->toArray());
     }
 
+    public function testYamlConfig()
+    {
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'id' => [
+                    'type' => 'integer',
+                ],
+                'email' => [
+                    'type' => 'string'
+                ],
+            ],
+        ], $this->getModel('VirtualProperty')->toArray());
+    }
+
     protected static function createKernel(array $options = array())
     {
         return new TestKernel(true);

--- a/composer.json
+++ b/composer.json
@@ -38,12 +38,13 @@
         "symfony/cache": "^3.1|^4.0",
         "symfony/phpunit-bridge": "^3.3",
         "sensio/framework-extra-bundle": "^3.0",
+        "symfony/stopwatch": "^2.8|^3.0|^4.0",
         "doctrine/annotations": "^1.2",
 
         "phpdocumentor/reflection-docblock": "^3.1",
         "api-platform/core": "^2.0.3",
         "friendsofsymfony/rest-bundle": "^2.0",
-        "jms/serializer-bundle": "^1.0|^2.0"
+        "jms/serializer-bundle": "^2.0"
     },
     "suggest": {
         "phpdocumentor/reflection-docblock": "For parsing php docs.",


### PR DESCRIPTION
Latest commit throws exception when attempting to read swagger annotation for virtual property

Nelmio\ApiDocBundle\ModelDescriber\SwaggerPropertyAnnotationReader::updateWithSwaggerPropertyAnnotation() must be an instance of ReflectionProperty, null given, called in D:\Work\php7\vendor\nelmio\api-doc-bundle\ModelDescriber\JMSModelDescriber.php on line 104