### PR TITLE
fix route parameter not required

### DIFF
--- a/RouteDescriber/RouteMetadataDescriber.php
+++ b/RouteDescriber/RouteMetadataDescriber.php
@@ -33,7 +33,7 @@ final class RouteMetadataDescriber implements RouteDescriberInterface
                 }
 
                 $parameter = $operation->getParameters()->get($pathVariable, 'path');
-                $parameter->setRequired(true);
+                $parameter->setRequired(!$route->hasDefault($pathVariable) || null!==$route->getDefault($pathVariable));
 
                 if (null === $parameter->getType()) {
                     $parameter->setType('string');


### PR DESCRIPTION
Route  parameters are set to always required, but there are use cases and in symfony is it possible to declare them not required. This should fix it.