### PR TITLE
[3.0] Pass real property to swagger annotation reader

### DIFF
--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -72,7 +72,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
             }
 
             $name = $this->namingStrategy->translateName($item);
-            $property = $properties->get($name);
+            $realProp = $property = $properties->get($name);
 
             if ($type = $this->getNestedTypeInArray($item)) {
                 $property->setType('array');
@@ -102,7 +102,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
 
             // read property options from Swagger Property annotation if it exists
             if($item->reflection !== null)
-                $this->swaggerPropertyAnnotationReader->updateWithSwaggerPropertyAnnotation($item->reflection, $property);
+                $this->swaggerPropertyAnnotationReader->updateWithSwaggerPropertyAnnotation($item->reflection, $realProp);
         }
     }
 

--- a/ModelDescriber/ObjectModelDescriber.php
+++ b/ModelDescriber/ObjectModelDescriber.php
@@ -61,7 +61,7 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
             }
 
             $type = $types[0];
-            $property = $properties->get($propertyName);
+            $realProp = $property = $properties->get($propertyName);
 
             if (Type::BUILTIN_TYPE_ARRAY === $type->getBuiltinType()) {
                 $type = $type->getCollectionValueType();
@@ -95,7 +95,7 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
             if (property_exists($class, $propertyName)) {
                 $this->swaggerPropertyAnnotationReader->updateWithSwaggerPropertyAnnotation(
                     new \ReflectionProperty($class, $propertyName),
-                    $property
+                    $realProp
                 );
             }
         }

--- a/ModelDescriber/SwaggerPropertyAnnotationReader.php
+++ b/ModelDescriber/SwaggerPropertyAnnotationReader.php
@@ -36,20 +36,22 @@ class SwaggerPropertyAnnotationReader
     {
         $swgProperty = $this->annotationsReader->getPropertyAnnotation($reflectionProperty, SwgProperty::class);
         if ($swgProperty instanceof SwgProperty) {
-            if ($swgProperty->description !== null) {
-                $property->setDescription($swgProperty->description);
-            }
             if ($swgProperty->type !== null) {
                 $property->setType($swgProperty->type);
             }
             if ($swgProperty->readOnly !== null) {
                 $property->setReadOnly($swgProperty->readOnly);
             }
-            if ($swgProperty->title !== null) {
-                $property->setTitle($swgProperty->title);
-            }
-            if ($swgProperty->example !== null) {
-                $property->setExample((string) $swgProperty->example);
+            if ($property instanceof Schema) {
+                if ($swgProperty->description !== null) {
+                    $property->setDescription($swgProperty->description);
+                }
+                if ($swgProperty->title !== null) {
+                    $property->setTitle($swgProperty->title);
+                }
+                if ($swgProperty->example !== null) {
+                    $property->setExample((string) $swgProperty->example);
+                }
             }
         }
     }

--- a/Tests/Functional/Entity/JMSUser.php
+++ b/Tests/Functional/Entity/JMSUser.php
@@ -41,6 +41,7 @@ class JMSUser
      * @Serializer\Type("array<string>")
      * @Serializer\Accessor(getter="getRoles", setter="setRoles")
      * @Serializer\Expose
+     * @SWG\Property(description = "User roles", required = true, title = "roles", example="[""ADMIN"",""SUPERUSER""]")
      */
     private $roles;
 

--- a/Tests/Functional/Entity/User.php
+++ b/Tests/Functional/Entity/User.php
@@ -33,6 +33,20 @@ class User
     private $email;
 
     /**
+     * @var string[]
+     *
+     * @SWG\Property(
+     *     description = "User roles",
+     *     type = "array",
+     *     items=@SWG\Items(type="string"),
+     *     required = true,
+     *     title = "roles",
+     *     example="[""ADMIN"",""SUPERUSER""]")
+     * )
+     */
+    private $roles;
+
+    /**
      * @var int
      *
      * @SWG\Property(type = "string")
@@ -76,6 +90,14 @@ class User
     public function setEmail(string $email)
     {
         $this->email = $email;
+    }
+
+    /**
+     * @param string[] $roles
+     */
+    public function setRoles(array $roles)
+    {
+        $this->roles = $roles;
     }
 
     /**

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -168,6 +168,13 @@ class FunctionalTest extends WebTestCase
                         'type' => 'string',
                         'readOnly' => false,
                     ],
+                    'roles' => [
+                        'type' => 'array',
+                        'description' => 'User roles',
+                        'title' => 'roles',
+                        'example' => '["ADMIN","SUPERUSER"]',
+                        'items' => ['type' => 'string'],
+                    ],
                     'friendsNumber' => [
                         'type' => 'string',
                     ],

--- a/Tests/Functional/JMSFunctionalTest.php
+++ b/Tests/Functional/JMSFunctionalTest.php
@@ -31,6 +31,9 @@ class JMSFunctionalTest extends WebTestCase
                 ],
                 'roles' => [
                     'type' => 'array',
+                    'description' => 'User roles',
+                    'title' => "roles",
+                    'example' => '["ADMIN","SUPERUSER"]',
                     'items' => ['type' => 'string'],
                 ],
                 'friendsNumber' => [


### PR DESCRIPTION
The type invariation (changing from the real property to the sub items
definition) causes the swagger annotations to end up on the created
`Items` entry.
This changes the behaviour to update the real property entry with the
swagger annotation.

Additionally this ensures that "description", "title" and "example" are
only updated on `Schema` instances.