### PR TITLE
Read more properties from swagger property annotation

### DIFF
--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -80,8 +80,10 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
                 $type = $item->type['name'];
             }
 
-            if (in_array($type, ['boolean', 'integer', 'string', 'array'])) {
+            if (in_array($type, ['boolean', 'string', 'array'])) {
                 $property->setType($type);
+            } elseif (in_array($type, ['int', 'integer'])) {
+                $property->setType('integer');
             } elseif (in_array($type, ['double', 'float'])) {
                 $property->setType('number');
                 $property->setFormat($type);

--- a/ModelDescriber/SwaggerPropertyAnnotationReader.php
+++ b/ModelDescriber/SwaggerPropertyAnnotationReader.php
@@ -37,20 +37,28 @@ class SwaggerPropertyAnnotationReader
     {
         $swgProperty = $this->annotationsReader->getPropertyAnnotation($reflectionProperty, SwgProperty::class);
         if ($swgProperty instanceof SwgProperty) {
-            if (null !== $swgProperty->type) {
+            if ($swgProperty->type !== null) {
                 $property->setType($swgProperty->type);
-            }
-            if (null !== $swgProperty->readOnly) {
-                $property->setReadOnly($swgProperty->readOnly);
-            }
-            if ($swgProperty->title !== null) {
-                $property->setTitle($swgProperty->title);
-            }
-            if ($swgProperty->example !== null) {
-                $property->setExample($swgProperty->example);
             }
             if ($swgProperty->default !== UNDEFINED) {
                 $property->setDefault($swgProperty->default);
+            }
+            if ($swgProperty->enum !== null) {
+                $property->setEnum($swgProperty->enum);
+            }
+            if ($property instanceof Schema) {
+                if ($swgProperty->description !== null) {
+                    $property->setDescription($swgProperty->description);
+                }
+                if ($swgProperty->title !== null) {
+                    $property->setTitle($swgProperty->title);
+                }
+                if ($swgProperty->example !== null) {
+                    $property->setExample($swgProperty->example);
+                }
+                if ($swgProperty->readOnly !== null) {
+                    $property->setReadOnly($swgProperty->readOnly);
+                }
             }
         }
     }

--- a/ModelDescriber/SwaggerPropertyAnnotationReader.php
+++ b/ModelDescriber/SwaggerPropertyAnnotationReader.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Annotations\Reader;
 use EXSyst\Component\Swagger\Items;
 use EXSyst\Component\Swagger\Schema;
 use Swagger\Annotations\Property as SwgProperty;
+use const Swagger\Annotations\UNDEFINED;
 
 /**
  * @internal
@@ -42,16 +43,14 @@ class SwaggerPropertyAnnotationReader
             if (null !== $swgProperty->readOnly) {
                 $property->setReadOnly($swgProperty->readOnly);
             }
-            if ($property instanceof Schema) {
-                if (null !== $swgProperty->description) {
-                    $property->setDescription($swgProperty->description);
-                }
-                if (null !== $swgProperty->title) {
-                    $property->setTitle($swgProperty->title);
-                }
-                if (null !== $swgProperty->example) {
-                    $property->setExample((string) $swgProperty->example);
-                }
+            if ($swgProperty->title !== null) {
+                $property->setTitle($swgProperty->title);
+            }
+            if ($swgProperty->example !== null) {
+                $property->setExample($swgProperty->example);
+            }
+            if ($swgProperty->default !== UNDEFINED) {
+                $property->setDefault($swgProperty->default);
             }
         }
     }

--- a/Tests/Functional/Entity/JMSUser.php
+++ b/Tests/Functional/Entity/JMSUser.php
@@ -51,7 +51,7 @@ class JMSUser
      * @Serializer\Accessor(getter="getRoles", setter="setRoles")
      * @Serializer\Expose
      *
-     * @SWG\Property(default = {"user"}, description = "Roles list", example="[""ADMIN"",""SUPERUSER""]")
+     * @SWG\Property(default = {"user"}, description = "Roles list", example="[""ADMIN"",""SUPERUSER""]", title="roles")
      */
     private $roles;
 

--- a/Tests/Functional/Entity/JMSUser.php
+++ b/Tests/Functional/Entity/JMSUser.php
@@ -25,9 +25,18 @@ class JMSUser
      * @Serializer\Type("integer")
      * @Serializer\Expose
      *
-     * @SWG\Property(description = "User id", required = true, readOnly = true, title = "userid", example=1)
+     * @SWG\Property(description = "User id", required = true, readOnly = true, title = "userid", example=1, default = null)
      */
     private $id;
+
+    /**
+     * @Serializer\Type("int")
+     * @Serializer\Expose
+     * @Serializer\SerializedName("daysOnline")
+     *
+     * @SWG\Property(default = 0)
+     */
+    private $daysOnline;
 
     /**
      * @Serializer\Type("string")
@@ -41,7 +50,8 @@ class JMSUser
      * @Serializer\Type("array<string>")
      * @Serializer\Accessor(getter="getRoles", setter="setRoles")
      * @Serializer\Expose
-     * @SWG\Property(description = "User roles", required = true, title = "roles", example="[""ADMIN"",""SUPERUSER""]")
+     *
+     * @SWG\Property(default = {"user"}, description = "Roles list", example="[""ADMIN"",""SUPERUSER""]")
      */
     private $roles;
 

--- a/Tests/Functional/Entity/JMSUser.php
+++ b/Tests/Functional/Entity/JMSUser.php
@@ -88,6 +88,14 @@ class JMSUser
      */
     private $bestFriend;
 
+    /**
+     * @Serializer\Type("string")
+     * @Serializer\Expose
+     *
+     * @SWG\Property(enum = {"disabled", "enabled"})
+     */
+    private $status;
+
     public function setRoles($roles)
     {
     }

--- a/Tests/Functional/Entity/User.php
+++ b/Tests/Functional/Entity/User.php
@@ -21,7 +21,7 @@ class User
     /**
      * @var int
      *
-     * @SWG\Property(description = "User id", required = true, readOnly = true, title = "userid", example=1)
+     * @SWG\Property(description = "User id", required = true, readOnly = true, title = "userid", example=1, default = null)
      */
     private $id;
 
@@ -37,11 +37,10 @@ class User
      *
      * @SWG\Property(
      *     description = "User roles",
-     *     type = "array",
-     *     items=@SWG\Items(type="string"),
      *     required = true,
      *     title = "roles",
-     *     example="[""ADMIN"",""SUPERUSER""]")
+     *     example="[""ADMIN"",""SUPERUSER""]"),
+     *     default = {"user"},
      * )
      */
     private $roles;
@@ -55,6 +54,7 @@ class User
 
     /**
      * @var float
+	 * @SWG\Property(default = 0.0)
      */
     private $money;
 

--- a/Tests/Functional/Entity/User.php
+++ b/Tests/Functional/Entity/User.php
@@ -39,7 +39,7 @@ class User
      *     description = "User roles",
      *     required = true,
      *     title = "roles",
-     *     example="[""ADMIN"",""SUPERUSER""]"),
+     *     example="[""ADMIN"",""SUPERUSER""]",
      *     default = {"user"},
      * )
      */

--- a/Tests/Functional/Entity/User.php
+++ b/Tests/Functional/Entity/User.php
@@ -69,6 +69,13 @@ class User
     private $users;
 
     /**
+     * @var string
+     *
+     * @SWG\Property(enum = {"disabled", "enabled"})
+     */
+    private $status;
+
+    /**
      * @param float $money
      */
     public function setMoney(float $money)
@@ -117,6 +124,10 @@ class User
     }
 
     public function setDummy(Dummy $dummy)
+    {
+    }
+
+    public function setStatus(string $status)
     {
     }
 }

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -198,6 +198,10 @@ class FunctionalTest extends WebTestCase
                         'default' => ['user'],
                         'description' => 'Roles list',
                     ],
+                    'status' => [
+                        'type' => 'string',
+                        'enum' => ["disabled", "enabled"],
+                    ],
                 ],
             ],
             $this->getModel('User')->toArray()

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -170,11 +170,12 @@ class FunctionalTest extends WebTestCase
                         'readOnly' => false,
                     ],
                     'roles' => [
+                        'title' => 'roles',
                         'type' => 'array',
                         'description' => 'User roles',
-                        'title' => 'roles',
                         'example' => '["ADMIN","SUPERUSER"]',
                         'items' => ['type' => 'string'],
+                        'default' => ['user'],
                     ],
                     'friendsNumber' => [
                         'type' => 'string',
@@ -191,12 +192,6 @@ class FunctionalTest extends WebTestCase
                     ],
                     'dummy' => [
                         '$ref' => '#/definitions/Dummy2',
-                    ],
-                    'roles' => [
-                        'type' => 'array',
-                        'items' => ['type' => 'string'],
-                        'default' => ['user'],
-                        'description' => 'Roles list',
                     ],
                     'status' => [
                         'type' => 'string',

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -156,6 +156,7 @@ class FunctionalTest extends WebTestCase
                     'money' => [
                         'type' => 'number',
                         'format' => 'float',
+                        'default' => 0.0
                     ],
                     'id' => [
                         'type' => 'integer',
@@ -190,6 +191,12 @@ class FunctionalTest extends WebTestCase
                     ],
                     'dummy' => [
                         '$ref' => '#/definitions/Dummy2',
+                    ],
+                    'roles' => [
+                        'type' => 'array',
+                        'items' => ['type' => 'string'],
+                        'default' => ['user'],
+                        'description' => 'Roles list',
                     ],
                 ],
             ],

--- a/Tests/Functional/JMSFunctionalTest.php
+++ b/Tests/Functional/JMSFunctionalTest.php
@@ -35,7 +35,6 @@ class JMSFunctionalTest extends WebTestCase
                 ],
                 'roles' => [
                     'type' => 'array',
-                    'description' => 'User roles',
                     'title' => 'roles',
                     'example' => '["ADMIN","SUPERUSER"]',
                     'items' => ['type' => 'string'],

--- a/Tests/Functional/JMSFunctionalTest.php
+++ b/Tests/Functional/JMSFunctionalTest.php
@@ -25,6 +25,10 @@ class JMSFunctionalTest extends WebTestCase
                     'title' => 'userid',
                     'example' => 1,
                 ],
+                'daysOnline' => [
+                    'type' => 'integer',
+                    'default' => 0,
+                ],
                 'email' => [
                     'type' => 'string',
                     'readOnly' => false,
@@ -35,6 +39,8 @@ class JMSFunctionalTest extends WebTestCase
                     'title' => 'roles',
                     'example' => '["ADMIN","SUPERUSER"]',
                     'items' => ['type' => 'string'],
+                    'default' => ['user'],
+                    'description' => 'Roles list',
                 ],
                 'friendsNumber' => [
                     'type' => 'string',

--- a/Tests/Functional/JMSFunctionalTest.php
+++ b/Tests/Functional/JMSFunctionalTest.php
@@ -54,6 +54,10 @@ class JMSFunctionalTest extends WebTestCase
                 'best_friend' => [
                     '$ref' => '#/definitions/User',
                 ],
+                'status' => [
+                    'type' => 'string',
+                    'enum' => ["disabled", "enabled"],
+                ],
             ],
         ], $this->getModel('JMSUser')->toArray());
     }


### PR DESCRIPTION
I have done a few improvements
1. For jms model descriper added support type "int" alias of "intreger"
2. Reading "enum" and "default" from swagger property annotation
3. Fixed bug when data related to whole array was appended to its items. Just has found that this bug is already fixed in #1145 so i have stolen also improvements for SwaggerPropertyAnnotationReader from there.