### PR TITLE
make upgrade instructions depend on stable version

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -265,7 +265,7 @@ to ``~3.0@beta``:
 ```json
 {
     "require": {
-        "nelmio/api-doc-bundle": "~3.0@beta"
+        "nelmio/api-doc-bundle": "^3.0"
     }
 }
 ```


### PR DESCRIPTION
now that you have a stable release, people do not need to depend on the beta version anymore.

(and afaik composer recommends to use ^ rather than ~ when working with libraries that respect semver)