### PR TITLE
Require the Symfony/form component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": "^7.0",
         "symfony/framework-bundle": "^3.2.5|^4.0",
+        "symfony/form": "^3.2.5|^4.0",
         "symfony/property-info": "^3.1|^4.0",
         "exsyst/swagger": "~0.3",
         "zircote/swagger-php": "^2.0.9"


### PR DESCRIPTION
The Symfony Form is required for this bundle to work, require it directly.