### PR TITLE
Support model field required information from swagger-php class annotation

### DIFF
--- a/ModelDescriber/SwaggerPropertyAnnotationReader.php
+++ b/ModelDescriber/SwaggerPropertyAnnotationReader.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Annotations\Reader;
 use EXSyst\Component\Swagger\Items;
 use EXSyst\Component\Swagger\Schema;
 use Swagger\Annotations\Property as SwgProperty;
+use Swagger\Annotations\Definition as SwgDefinition;
 use const Swagger\Annotations\UNDEFINED;
 
 /**
@@ -59,6 +60,13 @@ class SwaggerPropertyAnnotationReader
                 if ($swgProperty->readOnly !== null) {
                     $property->setReadOnly($swgProperty->readOnly);
                 }
+            }
+        }
+
+        $swgDefinition = $this->annotationsReader->getClassAnnotation($reflectionProperty->getDeclaringClass(), SwgDefinition::class);
+        if ($swgDefinition instanceof SwgDefinition) {
+            if (in_array($reflectionProperty->getName(), $swgDefinition->required)) {
+                $property->setRequired(true);
             }
         }
     }


### PR DESCRIPTION
the swg definition annotation on the class level can specify whether a property of a model is required or not. e.g.

```
/**
 * @SWG\Definition(required={"id", "displayName", "name"})
 */
```