### PR TITLE
parse phpdoc annotations in jms models

### DIFF
--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -103,6 +103,7 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
                     new Reference('jms_serializer.metadata_factory'),
                     new Reference('jms_serializer.naming_strategy'),
                     new Reference('nelmio_api_doc.model_describers.swagger_property_annotation_reader'),
+                    new Reference('nelmio_api_doc.model_describers.phpdoc_property_annotation_reader'),
                 ])
                 ->addTag('nelmio_api_doc.model_describer', ['priority' => 50]);
         }

--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -103,6 +103,8 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
 
             // read property options from Swagger Property annotation if it exists
             if (null !== $item->reflection) {
+                $phpdocReader = new PhpdocAnnotationReader();
+                $phpdocReader->updateWithPhpdoc($item->reflection, $realProp);
                 $this->swaggerPropertyAnnotationReader->updateWithSwaggerPropertyAnnotation($item->reflection, $realProp);
             }
         }

--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -35,14 +35,18 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
 
     private $swaggerPropertyAnnotationReader;
 
+    private $phpdocPropertyAnnotationsReader;
+
     public function __construct(
         MetadataFactoryInterface $factory,
         PropertyNamingStrategyInterface $namingStrategy,
-        SwaggerPropertyAnnotationReader $swaggerPropertyAnnotationReader
+        SwaggerPropertyAnnotationReader $swaggerPropertyAnnotationReader,
+        PhpdocPropertyAnnotationReader $phpdocPropertyAnnotationReader
     ) {
         $this->factory = $factory;
         $this->namingStrategy = $namingStrategy;
         $this->swaggerPropertyAnnotationReader = $swaggerPropertyAnnotationReader;
+        $this->phpdocPropertyAnnotationsReader = $phpdocPropertyAnnotationReader;
     }
 
     /**
@@ -103,8 +107,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
 
             // read property options from Swagger Property annotation if it exists
             if (null !== $item->reflection) {
-                $phpdocReader = new PhpdocAnnotationReader();
-                $phpdocReader->updateWithPhpdoc($item->reflection, $realProp);
+                $this->phpdocPropertyAnnotationsReader->updateWithPhpdoc($item->reflection, $realProp);
                 $this->swaggerPropertyAnnotationReader->updateWithSwaggerPropertyAnnotation($item->reflection, $realProp);
             }
         }

--- a/ModelDescriber/PhpdocAnnotationReader.php
+++ b/ModelDescriber/PhpdocAnnotationReader.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\ModelDescriber;
+
+use EXSyst\Component\Swagger\Schema;
+use EXSyst\Component\Swagger\Items;
+use phpDocumentor\Reflection\DocBlock\Tags\Var_;
+use phpDocumentor\Reflection\DocBlockFactory;
+use phpDocumentor\Reflection\DocBlockFactoryInterface;
+
+/**
+ * @internal
+ */
+class PhpdocAnnotationReader
+{
+    private $docBlockFactory;
+
+    public function __construct(DocBlockFactoryInterface $docBlockFactory = null)
+    {
+        if (null === $docBlockFactory) {
+            $docBlockFactory = DocBlockFactory::createInstance();
+        }
+        $this->docBlockFactory = $docBlockFactory;
+    }
+
+    /**
+     * @param \ReflectionProperty $reflectionProperty
+     * @param Items|Schema        $property
+     */
+    public function updateWithPhpdoc(\ReflectionProperty $reflectionProperty, $property)
+    {
+        try {
+            $docBlock = $this->docBlockFactory->create($reflectionProperty);
+            if (!$title = $docBlock->getSummary()) {
+                /** @var Var_ $var */
+                foreach ($docBlock->getTagsByName('var') as $var) {
+                    if (null === $description = $var->getDescription()) continue;
+                    $title = $description->render();
+                    if ($title) break;
+                }
+            }
+            if ($property->getTitle() === null && $title) {
+                $property->setTitle($title);
+            }
+            if ($property->getDescription() === null && $docBlock->getDescription()) {
+                $property->setDescription($docBlock->getDescription()->render());
+            }
+        } catch (\Exception $e) {
+            // ignore
+        }
+    }
+}

--- a/ModelDescriber/PhpdocPropertyAnnotationReader.php
+++ b/ModelDescriber/PhpdocPropertyAnnotationReader.php
@@ -52,7 +52,9 @@ class PhpdocPropertyAnnotationReader
         if (!$title = $docBlock->getSummary()) {
             /** @var Var_ $var */
             foreach ($docBlock->getTagsByName('var') as $var) {
-                if (!$description = $var->getDescription()) continue;
+                if (!$description = $var->getDescription()) {
+                    continue;
+                }
                 $title = $description->render();
                 if ($title) break;
             }
@@ -62,15 +64,6 @@ class PhpdocPropertyAnnotationReader
         }
         if ($property->getDescription() === null && $docBlock->getDescription() && $docBlock->getDescription()->render()) {
             $property->setDescription($docBlock->getDescription()->render());
-        }
-        if ($property->getType() === null) {
-            /** @var Var_ $var */
-            foreach ($docBlock->getTagsByName('var') as $var) {
-                if ($var->getType()) {
-                    $property->setType($var->getType());
-                    break;
-                }
-            }
         }
     }
 }

--- a/ModelDescriber/PhpdocPropertyAnnotationReader.php
+++ b/ModelDescriber/PhpdocPropertyAnnotationReader.php
@@ -52,7 +52,7 @@ class PhpdocPropertyAnnotationReader
         if (!$title = $docBlock->getSummary()) {
             /** @var Var_ $var */
             foreach ($docBlock->getTagsByName('var') as $var) {
-                if (null === $description = $var->getDescription()) continue;
+                if (!$description = $var->getDescription()) continue;
                 $title = $description->render();
                 if ($title) break;
             }
@@ -60,7 +60,7 @@ class PhpdocPropertyAnnotationReader
         if ($property->getTitle() === null && $title) {
             $property->setTitle($title);
         }
-        if ($property->getDescription() === null && $docBlock->getDescription()) {
+        if ($property->getDescription() === null && $docBlock->getDescription() && $docBlock->getDescription()->render()) {
             $property->setDescription($docBlock->getDescription()->render());
         }
         if ($property->getType() === null) {

--- a/ModelDescriber/PhpdocPropertyAnnotationReader.php
+++ b/ModelDescriber/PhpdocPropertyAnnotationReader.php
@@ -18,9 +18,11 @@ use phpDocumentor\Reflection\DocBlockFactory;
 use phpDocumentor\Reflection\DocBlockFactoryInterface;
 
 /**
+ * Extract information about properties of a model from the DocBlock comment.
+ *
  * @internal
  */
-class PhpdocAnnotationReader
+class PhpdocPropertyAnnotationReader
 {
     private $docBlockFactory;
 
@@ -33,6 +35,8 @@ class PhpdocAnnotationReader
     }
 
     /**
+     * Update the Swagger information with information from the DocBlock comment.
+     *
      * @param \ReflectionProperty $reflectionProperty
      * @param Items|Schema        $property
      */
@@ -40,22 +44,33 @@ class PhpdocAnnotationReader
     {
         try {
             $docBlock = $this->docBlockFactory->create($reflectionProperty);
-            if (!$title = $docBlock->getSummary()) {
-                /** @var Var_ $var */
-                foreach ($docBlock->getTagsByName('var') as $var) {
-                    if (null === $description = $var->getDescription()) continue;
-                    $title = $description->render();
-                    if ($title) break;
-                }
-            }
-            if ($property->getTitle() === null && $title) {
-                $property->setTitle($title);
-            }
-            if ($property->getDescription() === null && $docBlock->getDescription()) {
-                $property->setDescription($docBlock->getDescription()->render());
-            }
         } catch (\Exception $e) {
             // ignore
+            return;
+        }
+
+        if (!$title = $docBlock->getSummary()) {
+            /** @var Var_ $var */
+            foreach ($docBlock->getTagsByName('var') as $var) {
+                if (null === $description = $var->getDescription()) continue;
+                $title = $description->render();
+                if ($title) break;
+            }
+        }
+        if ($property->getTitle() === null && $title) {
+            $property->setTitle($title);
+        }
+        if ($property->getDescription() === null && $docBlock->getDescription()) {
+            $property->setDescription($docBlock->getDescription()->render());
+        }
+        if ($property->getType() === null) {
+            /** @var Var_ $var */
+            foreach ($docBlock->getTagsByName('var') as $var) {
+                if ($var->getType()) {
+                    $property->setType($var->getType());
+                    break;
+                }
+            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ serialization groups when using the Symfony serializer.
 ### If you're using the JMS Serializer
 
 The metadata of the JMS serializer are used by default to describe your
-models.
+models. Additional information is extracted from the PHP doc block comment.
 
 In case you prefer using the [Symfony PropertyInfo component](https://symfony.com/doc/current/components/property_info.html) (you
 won't be able to use JMS serialization groups), you can disable JMS serializer

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ serialization groups when using the Symfony serializer.
 ### If you're using the JMS Serializer
 
 The metadata of the JMS serializer are used by default to describe your
-models. Note that PHP doc blocks aren't supported in this case.
+models.
 
 In case you prefer using the [Symfony PropertyInfo component](https://symfony.com/doc/current/components/property_info.html) (you
 won't be able to use JMS serialization groups), you can disable JMS serializer

--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ serialization groups when using the Symfony serializer.
 ### If you're using the JMS Serializer
 
 The metadata of the JMS serializer are used by default to describe your
-models. Additional information is extracted from the PHP doc block comment.
+models. Additional information is extracted from the PHP doc block comment,
+but the property types must be specified in the JMS annotations.
 
 In case you prefer using the [Symfony PropertyInfo component](https://symfony.com/doc/current/components/property_info.html) (you
 won't be able to use JMS serialization groups), you can disable JMS serializer

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -54,6 +54,12 @@
             <argument type="service" id="annotation_reader" />
         </service>
 
+        <service
+                id="nelmio_api_doc.model_describers.phpdoc_property_annotation_reader"
+                class="Nelmio\ApiDocBundle\ModelDescriber\PhpdocPropertyAnnotationReader"
+                public="false"
+        />
+
         <service id="nelmio_api_doc.model_describers.object" class="Nelmio\ApiDocBundle\ModelDescriber\ObjectModelDescriber" public="false">
             <argument type="service" id="property_info" />
             <argument type="service" id="nelmio_api_doc.model_describers.swagger_property_annotation_reader" />

--- a/Tests/Functional/Entity/JMSUser.php
+++ b/Tests/Functional/Entity/JMSUser.php
@@ -89,6 +89,11 @@ class JMSUser
     private $bestFriend;
 
     /**
+     * Whether this user is enabled or disabled.
+     *
+     * Only enabled users may be used in actions.
+     *
+     * @var string
      * @Serializer\Type("string")
      * @Serializer\Expose
      *

--- a/Tests/Functional/JMSFunctionalTest.php
+++ b/Tests/Functional/JMSFunctionalTest.php
@@ -55,6 +55,8 @@ class JMSFunctionalTest extends WebTestCase
                 ],
                 'status' => [
                     'type' => 'string',
+                    'title' => 'Whether this user is enabled or disabled.',
+                    'description' => 'Only enabled users may be used in actions.',
                     'enum' => ['disabled', 'enabled'],
                 ],
             ],


### PR DESCRIPTION
The jms metadata model seems to not pick up descriptions. Imho we should pick them up, i played around with this code and hope for feedback. If the maintainers agree, i am happy to wrap up the pull request. Potentially it could also make sense to use the PhpdocAnnotationReader together with the form model generator, in case it does not pick all of the phpdoc.