### PR TITLE
fix date type detection with jms model describer

### DIFF
--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -87,7 +87,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
             } elseif (in_array($type, ['double', 'float'])) {
                 $property->setType('number');
                 $property->setFormat($type);
-            } elseif (in_array($type, ['DateTime', 'DateTimeImmutable'])) {
+            } elseif (in_array($type, ['date', 'DateTime', 'DateTimeImmutable'])) {
                 $property->setType('string');
                 $property->setFormat('date-time');
             } else {


### PR DESCRIPTION
when i debugged, jms seems to have transformed an annotation of `\DateTime` into `'date'`.