### PR TITLE
[3.0] Add integer support to FormModelDescriber

### DIFF
--- a/ModelDescriber/FormModelDescriber.php
+++ b/ModelDescriber/FormModelDescriber.php
@@ -78,6 +78,11 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
                     break;
                 }
 
+                if ('integer' === $blockPrefix) {
+                    $property->setType('integer');
+                    break;
+                }
+
                 if ('date' === $blockPrefix) {
                     $property->setType('string');
                     $property->setFormat('date');

--- a/Tests/Functional/Form/DummyType.php
+++ b/Tests/Functional/Form/DummyType.php
@@ -14,6 +14,7 @@ namespace Nelmio\ApiDocBundle\Tests\Functional\Form;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -24,5 +25,6 @@ class DummyType extends AbstractType
         $builder->add('bar', TextType::class, ['required' => false]);
         $builder->add('foo', ChoiceType::class, ['choices' => ['male', 'female']]);
         $builder->add('baz', CheckboxType::class, ['required' => false]);
+        $builder->add('bey', IntegerType::class, ['required' => false]);
     }
 }

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -231,6 +231,9 @@ class FunctionalTest extends WebTestCase
                 'baz' => [
                     'type' => 'boolean',
                 ],
+                'bey' => [
+                    'type' => 'integer',
+                ],
             ],
             'required' => ['foo'],
         ], $this->getModel('DummyType')->toArray());


### PR DESCRIPTION
Integer support was missing so far.