### PR TITLE
Fix undefined variable  in ApiPlatformDescriber

### DIFF
--- a/Describer/ApiPlatformDescriber.php
+++ b/Describer/ApiPlatformDescriber.php
@@ -21,6 +21,7 @@ final class ApiPlatformDescriber extends ExternalDocDescriber
     public function __construct(Documentation $documentation, DocumentationNormalizer $normalizer, UrlGeneratorInterface $urlGenerator)
     {
         parent::__construct(function () use ($documentation, $normalizer, $urlGenerator) {
+            $paths = [];
             $baseContext = $urlGenerator->getContext();
             $urlGenerator->setContext(new RequestContext());
 


### PR DESCRIPTION
When I run fresh installation of NelmioApiDocBundle I have such error:

"Notice: Undefined variable: paths" in vendor/nelmio/api-doc-bundle/Describer/ApiPlatformDescriber.php:39

I look at the file and I saw that `$paths` variable is not defined, so I define it as empty array. Bundle with my fix works :)