### PR TITLE
Made nelmio_api_doc.generator a public service

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -15,7 +15,7 @@
         </service>
 
         <!-- Swagger Spec Generator -->
-        <service id="nelmio_api_doc.generator" alias="nelmio_api_doc.generator.default" />
+        <service id="nelmio_api_doc.generator" alias="nelmio_api_doc.generator.default" public="true" />
 
         <service id="nelmio_api_doc.controller_reflector" class="Nelmio\ApiDocBundle\Util\ControllerReflector" public="false">
             <argument type="service" id="service_container" />


### PR DESCRIPTION
The service was not defined public or private, which threw deprecation notices in the tests where we use it from the container. It is now declared public explicitly to not have deprecations.