### PR TITLE
Nullable patterns no longer throw exceptions

### DIFF
--- a/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
+++ b/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
@@ -104,7 +104,7 @@ class SymfonyConstraintAnnotationReader
     /**
      * Append the pattern from the constraint to the existing pattern.
      */
-    private function appendPattern(Schema $property, ?string $newPattern)
+    private function appendPattern(Schema $property, $newPattern)
     {
         if (null === $newPattern) {
             return;

--- a/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
+++ b/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
@@ -104,8 +104,12 @@ class SymfonyConstraintAnnotationReader
     /**
      * Append the pattern from the constraint to the existing pattern.
      */
-    private function appendPattern(Schema $property, string $newPattern)
+    private function appendPattern(Schema $property, ?string $newPattern)
     {
+        if (null === $newPattern) {
+            return;
+        }
+
         if (null !== $property->getPattern()) {
             $property->setPattern(sprintf('%s, %s', $property->getPattern(), $newPattern));
         } else {


### PR DESCRIPTION
I found out that the Regex patterns are nullable which could trigger an exception. This fix will ignore patterns that are null.