### PR TITLE
FormModelDescriber: set type to array with correct example for multiple choices form.

### DIFF
--- a/ModelDescriber/FormModelDescriber.php
+++ b/ModelDescriber/FormModelDescriber.php
@@ -103,7 +103,6 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
                 if ('choice' === $blockPrefix) {
                     if ($config->getOption('multiple')) {
                         $property->setType('array');
-                        $property->setExample('[1, 2, 3]');
                     } else {
                         $property->setType('string');
                     }
@@ -135,7 +134,6 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
                     if ($config->getOption('multiple')) {
                         $property->setFormat(sprintf('[%s id]', $entityClass));
                         $property->setType('array');
-                        $property->setExample('[1, 2, 3]');
                     } else {
                         $property->setType('string');
                         $property->setFormat(sprintf('%s id', $entityClass));

--- a/ModelDescriber/FormModelDescriber.php
+++ b/ModelDescriber/FormModelDescriber.php
@@ -101,7 +101,12 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
                 }
 
                 if ('choice' === $blockPrefix) {
-                    $property->setType('string');
+                    if ($config->getOption('multiple')) {
+                        $property->setType('array');
+                        $property->setExample('[1, 2, 3]');
+                    } else {
+                        $property->setType('string');
+                    }
                     if (($choices = $config->getOption('choices')) && is_array($choices) && count($choices)) {
                         $property->setEnum(array_values($choices));
                     }

--- a/ModelDescriber/FormModelDescriber.php
+++ b/ModelDescriber/FormModelDescriber.php
@@ -45,7 +45,6 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
         }
 
         $schema->setType('object');
-        $properties = $schema->getProperties();
 
         $class = $model->getType()->getClassName();
 
@@ -107,7 +106,13 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
                         $property->setType('string');
                     }
                     if (($choices = $config->getOption('choices')) && is_array($choices) && count($choices)) {
-                        $property->setEnum(array_values($choices));
+                        $enums = array_values($choices);
+                        $type = $this->isNumbersArray($enums) ? 'number' : 'string';
+                        if ($config->getOption('multiple')) {
+                            $property->getItems()->setType($type)->setEnum($enums);
+                        } else {
+                            $property->setType($type)->setEnum($enums);
+                        }
                     }
 
                     break;
@@ -158,6 +163,22 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
                 $schema->setRequired($required);
             }
         }
+    }
+
+    /**
+     * @param array $array
+     *
+     * @return bool true if $array contains only numbers, false otherwise
+     */
+    private function isNumbersArray(array $array): bool
+    {
+        foreach ($array as $item) {
+            if (!is_numeric($item)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private function isBuiltinType(string $type): bool

--- a/Tests/Functional/Form/DummyType.php
+++ b/Tests/Functional/Form/DummyType.php
@@ -24,6 +24,7 @@ class DummyType extends AbstractType
     {
         $builder->add('bar', TextType::class, ['required' => false]);
         $builder->add('foo', ChoiceType::class, ['choices' => ['male', 'female']]);
+        $builder->add('foz', ChoiceType::class, ['choices' => ['male', 'female'], 'multiple' => true]);
         $builder->add('baz', CheckboxType::class, ['required' => false]);
         $builder->add('bey', IntegerType::class, ['required' => false]);
     }

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -230,7 +230,10 @@ class FunctionalTest extends WebTestCase
                 ],
                 'foz' => [
                     'type' => 'array',
-                    'enum' => ['male', 'female'],
+                    'items' => [
+                        'type' => 'string',
+                        'enum' => ['male', 'female'],
+                    ],
                 ],
                 'baz' => [
                     'type' => 'boolean',

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -228,6 +228,10 @@ class FunctionalTest extends WebTestCase
                     'type' => 'string',
                     'enum' => ['male', 'female'],
                 ],
+                'foz' => [
+                    'type' => 'array',
+                    'enum' => ['male', 'female'],
+                ],
                 'baz' => [
                     'type' => 'boolean',
                 ],
@@ -235,7 +239,7 @@ class FunctionalTest extends WebTestCase
                     'type' => 'integer',
                 ],
             ],
-            'required' => ['foo'],
+            'required' => ['foo', 'foz'],
         ], $this->getModel('DummyType')->toArray());
     }
 


### PR DESCRIPTION
When a form containing a ChoiceType field with option multiple set to true is used with the `Nelmio\ApiDocBundle\Annotation\Model` annotation, the field type is set to `string` instead of `array` in the api documentation.

This PR set the type to `array` ~~and add an example value of `[1, 2, 3]`~~.