### PR TITLE
Fix #1239: FosRestDescriber properly configures Parameter#pattern property

### DIFF
--- a/RouteDescriber/FosRestDescriber.php
+++ b/RouteDescriber/FosRestDescriber.php
@@ -54,7 +54,18 @@ final class FosRestDescriber implements RouteDescriberInterface
 
                 $normalizedRequirements = $this->normalizeRequirements($annotation->requirements);
                 if (null !== $normalizedRequirements) {
-                    $parameter->setPattern($normalizedRequirements);
+                    if ($normalizedRequirements instanceof Constraint) {
+                        if ($normalizedRequirements instanceof Regex) {
+                            $format = $normalizedRequirements->getHtmlPattern();
+                        } else {
+                            $reflectionClass = new \ReflectionClass($normalizedRequirements);
+                            $format = $reflectionClass->getShortName();
+                        }
+
+                        $parameter->setFormat($format);
+                    } else {
+                        $parameter->setPattern($normalizedRequirements);
+                    }
                 }
             }
         }
@@ -71,13 +82,7 @@ final class FosRestDescriber implements RouteDescriberInterface
         }
         // if custom constraint
         if ($requirements instanceof Constraint) {
-            if ($requirements instanceof Regex) {
-                return $requirements->getHtmlPattern();
-            }
-
-            $reflectionClass = new \ReflectionClass($requirements);
-
-            return $reflectionClass->getShortName();
+            return $requirements;
         }
     }
 }

--- a/RouteDescriber/FosRestDescriber.php
+++ b/RouteDescriber/FosRestDescriber.php
@@ -54,7 +54,7 @@ final class FosRestDescriber implements RouteDescriberInterface
 
                 $normalizedRequirements = $this->normalizeRequirements($annotation->requirements);
                 if (null !== $normalizedRequirements) {
-                    $parameter->setFormat($normalizedRequirements);
+                    $parameter->setPattern($normalizedRequirements);
                 }
             }
         }

--- a/RouteDescriber/FosRestDescriber.php
+++ b/RouteDescriber/FosRestDescriber.php
@@ -52,37 +52,44 @@ final class FosRestDescriber implements RouteDescriberInterface
                     $parameter->setDescription($annotation->description);
                 }
 
-                $normalizedRequirements = $this->normalizeRequirements($annotation->requirements);
-                if (null !== $normalizedRequirements) {
-                    if ($normalizedRequirements instanceof Constraint) {
-                        if ($normalizedRequirements instanceof Regex) {
-                            $format = $normalizedRequirements->getHtmlPattern();
-                        } else {
-                            $reflectionClass = new \ReflectionClass($normalizedRequirements);
-                            $format = $reflectionClass->getShortName();
-                        }
+                $pattern = $this->getPattern($annotation->requirements);
+                if (null !== $pattern) {
+                    $parameter->setPattern($pattern);
+                }
 
-                        $parameter->setFormat($format);
-                    } else {
-                        $parameter->setPattern($normalizedRequirements);
-                    }
+                $format = $this->getFormat($annotation->requirements);
+                if (null !== $format) {
+                    $parameter->setFormat($format);
                 }
             }
         }
     }
 
-    private function normalizeRequirements($requirements)
+    private function getPattern($requirements)
     {
-        // if pattern
         if (is_array($requirements) && isset($requirements['rule'])) {
             return (string) $requirements['rule'];
         }
+
         if (is_string($requirements)) {
             return $requirements;
         }
-        // if custom constraint
-        if ($requirements instanceof Constraint) {
-            return $requirements;
+
+        if ($requirements instanceof Regex) {
+            return $requirements->getHtmlPattern();
         }
+
+        return null;
+    }
+
+    private function getFormat($requirements)
+    {
+        if ($requirements instanceof Constraint && !$requirements instanceof Regex) {
+            $reflectionClass = new \ReflectionClass($requirements);
+
+            return $reflectionClass->getShortName();
+        }
+
+        return null;
     }
 }

--- a/Tests/Functional/Controller/ApiController.php
+++ b/Tests/Functional/Controller/ApiController.php
@@ -23,6 +23,7 @@ use Nelmio\ApiDocBundle\Tests\Functional\Form\DummyType;
 use Nelmio\ApiDocBundle\Tests\Functional\Form\UserType;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Swagger\Annotations as SWG;
+use Symfony\Component\Validator\Constraints\Regex;
 
 /**
  * @Route("/api")
@@ -107,7 +108,7 @@ class ApiController
 
     /**
      * @Route("/fosrest.{_format}", methods={"POST"})
-     * @QueryParam(name="foo")
+     * @QueryParam(name="foo", requirements=@Regex("/^\d+$/"))
      * @RequestParam(name="bar", requirements="\d+")
      */
     public function fosrestAction()

--- a/Tests/Functional/Controller/ApiController.php
+++ b/Tests/Functional/Controller/ApiController.php
@@ -108,7 +108,7 @@ class ApiController
     /**
      * @Route("/fosrest.{_format}", methods={"POST"})
      * @QueryParam(name="foo")
-     * @RequestParam(name="bar")
+     * @RequestParam(name="bar", requirements="\d+")
      */
     public function fosrestAction()
     {

--- a/Tests/Functional/Controller/ApiController.php
+++ b/Tests/Functional/Controller/ApiController.php
@@ -23,6 +23,7 @@ use Nelmio\ApiDocBundle\Tests\Functional\Form\DummyType;
 use Nelmio\ApiDocBundle\Tests\Functional\Form\UserType;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Swagger\Annotations as SWG;
+use Symfony\Component\Validator\Constraints\IsTrue;
 use Symfony\Component\Validator\Constraints\Regex;
 
 /**
@@ -110,6 +111,7 @@ class ApiController
      * @Route("/fosrest.{_format}", methods={"POST"})
      * @QueryParam(name="foo", requirements=@Regex("/^\d+$/"))
      * @RequestParam(name="bar", requirements="\d+")
+     * @RequestParam(name="baz", requirements=@IsTrue)
      */
     public function fosrestAction()
     {

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -125,9 +125,15 @@ class FunctionalTest extends WebTestCase
         $this->assertTrue($parameters->has('foo', 'query'));
         $this->assertTrue($parameters->has('bar', 'formData'));
 
+        $fooParameter = $parameters->get('foo', 'query');
+        $this->assertNotNull($fooParameter->getFormat());
+        $this->assertEquals('\d+', $fooParameter->getFormat());
+        $this->assertNull($fooParameter->getPattern());
+
         $barParameter = $parameters->get('bar', 'formData');
         $this->assertNotNull($barParameter->getPattern());
         $this->assertEquals('\d+', $barParameter->getPattern());
+        $this->assertNull($barParameter->getFormat());
 
         // The _format path attribute should be removed
         $this->assertFalse($parameters->has('_format', 'path'));

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -124,16 +124,22 @@ class FunctionalTest extends WebTestCase
         $parameters = $operation->getParameters();
         $this->assertTrue($parameters->has('foo', 'query'));
         $this->assertTrue($parameters->has('bar', 'formData'));
+        $this->assertTrue($parameters->has('baz', 'formData'));
 
         $fooParameter = $parameters->get('foo', 'query');
-        $this->assertNotNull($fooParameter->getFormat());
-        $this->assertEquals('\d+', $fooParameter->getFormat());
-        $this->assertNull($fooParameter->getPattern());
+        $this->assertNotNull($fooParameter->getPattern());
+        $this->assertEquals('\d+', $fooParameter->getPattern());
+        $this->assertNull($fooParameter->getFormat());
 
         $barParameter = $parameters->get('bar', 'formData');
         $this->assertNotNull($barParameter->getPattern());
         $this->assertEquals('\d+', $barParameter->getPattern());
         $this->assertNull($barParameter->getFormat());
+
+        $bazParameter = $parameters->get('baz', 'formData');
+        $this->assertNotNull($bazParameter->getFormat());
+        $this->assertEquals('IsTrue', $bazParameter->getFormat());
+        $this->assertNull($bazParameter->getPattern());
 
         // The _format path attribute should be removed
         $this->assertFalse($parameters->has('_format', 'path'));

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -125,6 +125,10 @@ class FunctionalTest extends WebTestCase
         $this->assertTrue($parameters->has('foo', 'query'));
         $this->assertTrue($parameters->has('bar', 'formData'));
 
+        $barParameter = $parameters->get('bar', 'formData');
+        $this->assertNotNull($barParameter->getPattern());
+        $this->assertEquals('\d+', $barParameter->getPattern());
+
         // The _format path attribute should be removed
         $this->assertFalse($parameters->has('_format', 'path'));
     }


### PR DESCRIPTION
Minor bugfix that configures `Parameter#pattern` property instead of `Parameter#format`.
Tests provided that prove this implementation works as expected.