### PR TITLE
Respect invalid argument syntax used by PHP at `ApiPlatformDescriber::__construct()`

### DIFF
--- a/Describer/ApiPlatformDescriber.php
+++ b/Describer/ApiPlatformDescriber.php
@@ -21,7 +21,7 @@ final class ApiPlatformDescriber extends ExternalDocDescriber
     public function __construct(Documentation $documentation, $normalizer, UrlGeneratorInterface $urlGenerator)
     {
         if (!$normalizer instanceof ApiGatewayNormalizer && !$normalizer instanceof DocumentationNormalizer) {
-            throw new \LogicException(sprintf('Argument $normalizer of %s must be an instance of %s or %s. %s provided.', __METHOD__, ApiGatewayNormalizer::class, DocumentationNormalizer::class, get_class($normalizer)));
+            throw new \InvalidArgumentException(sprintf('Argument 2 passed to %s() must be an instance of %s or %s, %s given.', __METHOD__, ApiGatewayNormalizer::class, DocumentationNormalizer::class, get_class($normalizer)));
         }
 
         parent::__construct(function () use ($documentation, $normalizer, $urlGenerator) {


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |no    |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|#1260 |
|License      |MIT   |
|Doc PR       |n/a   |
                      

See https://github.com/nelmio/NelmioApiDocBundle/pull/1260/files#r175258427.