### PR TITLE
Support ``@Model`` in in-object annotations

### DIFF
--- a/ModelDescriber/Annotations/AnnotationsReader.php
+++ b/ModelDescriber/Annotations/AnnotationsReader.php
@@ -13,6 +13,7 @@ namespace Nelmio\ApiDocBundle\ModelDescriber\Annotations;
 
 use Doctrine\Common\Annotations\Reader;
 use EXSyst\Component\Swagger\Schema;
+use Nelmio\ApiDocBundle\Model\ModelRegistry;
 
 /**
  * @internal
@@ -20,17 +21,19 @@ use EXSyst\Component\Swagger\Schema;
 class AnnotationsReader
 {
     private $annotationsReader;
+    private $modelRegistry;
 
     private $phpDocReader;
     private $swgAnnotationsReader;
     private $symfonyConstraintAnnotationReader;
 
-    public function __construct(Reader $annotationsReader)
+    public function __construct(Reader $annotationsReader, ModelRegistry $modelRegistry)
     {
         $this->annotationsReader = $annotationsReader;
+        $this->modelRegistry = $modelRegistry;
 
         $this->phpDocReader = new PropertyPhpDocReader();
-        $this->swgAnnotationsReader = new SwgAnnotationsReader($annotationsReader);
+        $this->swgAnnotationsReader = new SwgAnnotationsReader($annotationsReader, $modelRegistry);
         $this->symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader($annotationsReader);
     }
 
@@ -45,10 +48,10 @@ class AnnotationsReader
         return $this->swgAnnotationsReader->getPropertyName($reflectionProperty, $default);
     }
 
-    public function updateProperty(\ReflectionProperty $reflectionProperty, Schema $property)
+    public function updateProperty(\ReflectionProperty $reflectionProperty, Schema $property, array $serializationGroups = null)
     {
         $this->phpDocReader->updateProperty($reflectionProperty, $property);
-        $this->swgAnnotationsReader->updateProperty($reflectionProperty, $property);
+        $this->swgAnnotationsReader->updateProperty($reflectionProperty, $property, $serializationGroups);
         $this->symfonyConstraintAnnotationReader->updateProperty($reflectionProperty, $property);
     }
 }

--- a/ModelDescriber/Annotations/PropertyPhpDocReader.php
+++ b/ModelDescriber/Annotations/PropertyPhpDocReader.php
@@ -12,6 +12,7 @@
 namespace Nelmio\ApiDocBundle\ModelDescriber\Annotations;
 
 use EXSyst\Component\Swagger\Schema;
+use Nelmio\ApiDocBundle\Model\Model;
 use phpDocumentor\Reflection\DocBlock\Tags\Var_;
 use phpDocumentor\Reflection\DocBlockFactory;
 

--- a/ModelDescriber/Annotations/SwgAnnotationsReader.php
+++ b/ModelDescriber/Annotations/SwgAnnotationsReader.php
@@ -13,8 +13,13 @@ namespace Nelmio\ApiDocBundle\ModelDescriber\Annotations;
 
 use Doctrine\Common\Annotations\Reader;
 use EXSyst\Component\Swagger\Schema;
+use Nelmio\ApiDocBundle\Model\Model;
+use Nelmio\ApiDocBundle\Model\ModelRegistry;
+use Nelmio\ApiDocBundle\SwaggerPhp\ModelRegister;
+use Swagger\Analysis;
 use Swagger\Annotations\Definition as SwgDefinition;
 use Swagger\Annotations\Property as SwgProperty;
+use Swagger\Context;
 
 /**
  * @internal
@@ -22,10 +27,12 @@ use Swagger\Annotations\Property as SwgProperty;
 class SwgAnnotationsReader
 {
     private $annotationsReader;
+    private $modelRegister;
 
-    public function __construct(Reader $annotationsReader)
+    public function __construct(Reader $annotationsReader, ModelRegistry $modelRegistry)
     {
         $this->annotationsReader = $annotationsReader;
+        $this->modelRegister = new ModelRegister($modelRegistry);
     }
 
     public function updateDefinition(\ReflectionClass $reflectionClass, Schema $schema)
@@ -35,9 +42,14 @@ class SwgAnnotationsReader
             return;
         }
 
-        if (null !== $swgDefinition->required) {
-            $schema->setRequired($swgDefinition->required);
+        // Read @Model annotations
+        $this->modelRegister->__invoke(new Analysis([$swgDefinition]));
+
+        if (!$swgDefinition->validate()) {
+            return;
         }
+
+        $schema->merge(json_decode(json_encode($swgDefinition)));
     }
 
     public function getPropertyName(\ReflectionProperty $reflectionProperty, string $default): string
@@ -50,12 +62,23 @@ class SwgAnnotationsReader
         return $swgProperty->property ?? $default;
     }
 
-    public function updateProperty(\ReflectionProperty $reflectionProperty, Schema $property)
+    public function updateProperty(\ReflectionProperty $reflectionProperty, Schema $property, array $serializationGroups = null)
     {
-        /** @var SwgProperty $swgProperty */
         if (!$swgProperty = $this->annotationsReader->getPropertyAnnotation($reflectionProperty, SwgProperty::class)) {
             return;
         }
+
+        $declaringClass = $reflectionProperty->getDeclaringClass();
+        $context = new Context([
+            'namespace' => $declaringClass->getNamespaceName(),
+            'class' => $declaringClass->getShortName(),
+            'property' => $reflectionProperty->name,
+            'filename' => $declaringClass->getFileName(),
+        ]);
+        $swgProperty->_context = $context;
+
+        // Read @Model annotations
+        $this->modelRegister->__invoke(new Analysis([$swgProperty]), $serializationGroups);
 
         if (!$swgProperty->validate()) {
             return;

--- a/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
+++ b/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
@@ -13,7 +13,6 @@ namespace Nelmio\ApiDocBundle\ModelDescriber\Annotations;
 
 use Doctrine\Common\Annotations\Reader;
 use EXSyst\Component\Swagger\Schema;
-use ReflectionProperty;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -39,7 +38,7 @@ class SymfonyConstraintAnnotationReader
     /**
      * Update the given property and schema with defined Symfony constraints.
      */
-    public function updateProperty(ReflectionProperty $reflectionProperty, Schema $property)
+    public function updateProperty(\ReflectionProperty $reflectionProperty, Schema $property)
     {
         $annotations = $this->annotationsReader->getPropertyAnnotations($reflectionProperty);
 
@@ -88,7 +87,7 @@ class SymfonyConstraintAnnotationReader
     /**
      * Set the required properties on the scheme.
      */
-    private function updateSchemaDefinitionWithRequiredProperty(ReflectionProperty $reflectionProperty)
+    private function updateSchemaDefinitionWithRequiredProperty(\ReflectionProperty $reflectionProperty)
     {
         if (null === $this->schema) {
             return;

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -262,6 +262,7 @@ General PHP objects
 
 If you want to customize the documentation of a property of an object, you can use ``@SWG\Property``::
 
+    use NelmioApiDocBundle\Annotation\Model;
     use Swagger\Annotations as SWG;
 
     class User
@@ -276,6 +277,11 @@ If you want to customize the documentation of a property of an object, you can u
          * @SWG\Property(type="string", maxLength=255)
          */
         public $username;
+
+        /**
+         * @SWG\Property(ref=@Model(type=User::class))
+         */
+        public $friend;
     }
 
 See the `OpenAPI 2.0 specification`__ to see all the available fields of ``@SWG\Property``.

--- a/Tests/Functional/Entity/JMSComplex.php
+++ b/Tests/Functional/Entity/JMSComplex.php
@@ -12,11 +12,15 @@
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
 
 use JMS\Serializer\Annotation as Serializer;
+use Nelmio\ApiDocBundle\Annotation\Model;
 use Swagger\Annotations as SWG;
 
 /**
  * @Serializer\ExclusionPolicy("all")
- * @SWG\Definition(required={"id", "user"})
+ * @SWG\Definition(
+ *     required={"id", "user"},
+ *     @SWG\Property(property="virtual", ref=@Model(type=JMSUser::class))
+ * )
  */
 class JMSComplex
 {
@@ -28,7 +32,7 @@ class JMSComplex
     private $id;
 
     /**
-     * @Serializer\Type("Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSUser")
+     * @SWG\Property(ref=@Model(type=JMSUser::class))
      * @Serializer\Expose
      * @Serializer\Groups({"details"})
      */

--- a/Tests/Functional/JMSFunctionalTest.php
+++ b/Tests/Functional/JMSFunctionalTest.php
@@ -78,6 +78,7 @@ class JMSFunctionalTest extends WebTestCase
                 'id' => ['type' => 'integer'],
                 'user' => ['$ref' => '#/definitions/JMSUser2'],
                 'name' => ['type' => 'string'],
+                'virtual' => ['$ref' => '#/definitions/JMSUser'],
             ],
             'required' => [
                 'id',


### PR DESCRIPTION
That's quite weird to not be able to use ``@Model`` in objects, this PR fixes this limitation.