### PR TITLE
Fix #1283: Invalid swagger.json generation - definition for entities …

### DIFF
--- a/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
+++ b/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
@@ -97,7 +97,7 @@ class SymfonyConstraintAnnotationReader
 
         $existingRequiredFields[] = $reflectionProperty->getName();
 
-        $this->schema->setRequired(array_unique($existingRequiredFields));
+        $this->schema->setRequired(array_values(array_unique($existingRequiredFields)));
     }
 
     /**

--- a/Tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
+++ b/Tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\ModelDescriber\Annotations;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use EXSyst\Component\Swagger\Schema;
+use Nelmio\ApiDocBundle\ModelDescriber\Annotations\SymfonyConstraintAnnotationReader;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class SymfonyConstraintAnnotationReaderTest extends TestCase
+{
+    public function testUpdatePropertyFix1283()
+    {
+        $entity = new class() {
+            /**
+             * @Assert\NotBlank()
+             * @Assert\Length(min = 1)
+             */
+            private $property1;
+            /**
+             * @Assert\NotBlank()
+             */
+            private $property2;
+        };
+        $reflectionProperties = (new \ReflectionClass($entity))->getProperties();
+        $property = new Schema();
+        $schema = new Schema();
+
+        $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader(new AnnotationReader());
+        $symfonyConstraintAnnotationReader->setSchema($schema);
+        foreach ($reflectionProperties as $reflectionProperty) {
+            $symfonyConstraintAnnotationReader->updateProperty($reflectionProperty, $property);
+        }
+
+        // expect required to be numeric array with sequential keys (not [0 => ..., 2 => ...])
+        $this->assertEquals($schema->getRequired(), ['property1', 'property2']);
+    }
+}


### PR DESCRIPTION
…with Assert\NotBlank and Assert\Length

Having an entity with both `@Assert\NotBlank` and `@Assert\Length` may result in generating `swagger.json` from array like `[0 => "name", 2 => "accountId"]`, so we get:
```json
"definitions":{"User":{"required":{"0":"name","2":"accountId"}
```
This is due to the way `array_unique()` function works - it preserves keys (also the numeric ones). 

Example:
```php
<?php

$array = array_unique([1,1]);
$array[] = 2;
var_dump($array);
/*
array(2) {
  [0]=>
  int(1)
  [2]=>
  int(2)
}
*/
```
