### PR TITLE
Ignore unsupported HTTP methods

### DIFF
--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -95,6 +95,7 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
                     new Reference(sprintf('nelmio_api_doc.routes.%s', $area)),
                     new Reference('nelmio_api_doc.controller_reflector'),
                     new Reference('annotation_reader'),
+                    new Reference('logger'),
                 ])
                 ->addTag(sprintf('nelmio_api_doc.describer.%s', $area), ['priority' => -200]);
         }

--- a/Describer/SwaggerPhpDescriber.php
+++ b/Describer/SwaggerPhpDescriber.php
@@ -206,6 +206,7 @@ final class SwaggerPhpDescriber implements ModelRegistryAwareInterface
                 $path = $this->normalizePath($route->getPath());
                 $httpMethods = $route->getMethods() ?: Swagger::$METHODS;
                 $httpMethods = array_map('strtolower', $httpMethods);
+                $httpMethods = array_intersect($httpMethods, Swagger::$METHODS);
 
                 yield $method => [$path, $httpMethods];
             }

--- a/Describer/SwaggerPhpDescriber.php
+++ b/Describer/SwaggerPhpDescriber.php
@@ -209,10 +209,10 @@ final class SwaggerPhpDescriber implements ModelRegistryAwareInterface
                 $path = $this->normalizePath($route->getPath());
                 $httpMethods = $route->getMethods() ?: Swagger::$METHODS;
                 $httpMethods = array_map('strtolower', $httpMethods);
-                $validHttpMethods = array_intersect($httpMethods, Swagger::$METHODS);
+                $supportedHttpMethods = array_intersect($httpMethods, Swagger::$METHODS);
 
-                if (empty($validHttpMethods)) {
-                    $this->logger->warning('No valid HTTP method for path', [
+                if (empty($supportedHttpMethods)) {
+                    $this->logger->warning('None of the HTTP methods specified for path {path} are supported by swagger-ui, skipping this path', [
                         'path' => $path,
                         'methods' => $httpMethods,
                     ]);
@@ -220,7 +220,7 @@ final class SwaggerPhpDescriber implements ModelRegistryAwareInterface
                     continue;
                 }
 
-                yield $method => [$path, $validHttpMethods];
+                yield $method => [$path, $supportedHttpMethods];
             }
         }
     }

--- a/Describer/SwaggerPhpDescriber.php
+++ b/Describer/SwaggerPhpDescriber.php
@@ -18,6 +18,7 @@ use Nelmio\ApiDocBundle\Annotation\Security;
 use Nelmio\ApiDocBundle\SwaggerPhp\AddDefaults;
 use Nelmio\ApiDocBundle\SwaggerPhp\ModelRegister;
 use Nelmio\ApiDocBundle\Util\ControllerReflector;
+use Psr\Log\LoggerInterface;
 use Swagger\Analysis;
 use Swagger\Annotations\AbstractAnnotation;
 use Swagger\Annotations as SWG;
@@ -31,13 +32,15 @@ final class SwaggerPhpDescriber implements ModelRegistryAwareInterface
     private $routeCollection;
     private $controllerReflector;
     private $annotationReader;
+    private $logger;
     private $overwrite;
 
-    public function __construct(RouteCollection $routeCollection, ControllerReflector $controllerReflector, Reader $annotationReader, bool $overwrite = false)
+    public function __construct(RouteCollection $routeCollection, ControllerReflector $controllerReflector, Reader $annotationReader, LoggerInterface $logger, bool $overwrite = false)
     {
         $this->routeCollection = $routeCollection;
         $this->controllerReflector = $controllerReflector;
         $this->annotationReader = $annotationReader;
+        $this->logger = $logger;
         $this->overwrite = $overwrite;
     }
 
@@ -206,13 +209,18 @@ final class SwaggerPhpDescriber implements ModelRegistryAwareInterface
                 $path = $this->normalizePath($route->getPath());
                 $httpMethods = $route->getMethods() ?: Swagger::$METHODS;
                 $httpMethods = array_map('strtolower', $httpMethods);
-                $httpMethods = array_intersect($httpMethods, Swagger::$METHODS);
+                $validHttpMethods = array_intersect($httpMethods, Swagger::$METHODS);
 
-                if (empty($httpMethods)) {
+                if (empty($validHttpMethods)) {
+                    $this->logger->warning('No valid HTTP method for path', [
+                        'path' => $path,
+                        'methods' => $httpMethods,
+                    ]);
+
                     continue;
                 }
 
-                yield $method => [$path, $httpMethods];
+                yield $method => [$path, $validHttpMethods];
             }
         }
     }

--- a/Describer/SwaggerPhpDescriber.php
+++ b/Describer/SwaggerPhpDescriber.php
@@ -208,6 +208,10 @@ final class SwaggerPhpDescriber implements ModelRegistryAwareInterface
                 $httpMethods = array_map('strtolower', $httpMethods);
                 $httpMethods = array_intersect($httpMethods, Swagger::$METHODS);
 
+                if (empty($httpMethods)) {
+                    continue;
+                }
+
                 yield $method => [$path, $httpMethods];
             }
         }

--- a/Tests/Functional/Controller/ApiController.php
+++ b/Tests/Functional/Controller/ApiController.php
@@ -44,7 +44,9 @@ class ApiController
     }
 
     /**
-     * @Route("/swagger", methods={"GET"})
+     * The method LINK is not supported by OpenAPI so the method will be ignored.
+     *
+     * @Route("/swagger", methods={"GET", "LINK"})
      * @Route("/swagger2", methods={"GET"})
      * @Operation(
      *     @SWG\Response(response="201", description="An example resource")


### PR DESCRIPTION
If an action use a LINK, UNLINK or COPY methods the bundle fails with: `Notice: Undefined index: link
 in vendor/nelmio/api-doc-bundle/Describer/SwaggerPhpDescriber.php (line 174)`

OpenAPI doesn't supports the LINK and UNLINK methods so the bundle must ignore this methods.

Fix #1290