### PR TITLE
Add the swagger spec info name in <title>

### DIFF
--- a/Resources/views/SwaggerUi/index.html.twig
+++ b/Resources/views/SwaggerUi/index.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code. #}
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>NelmioApiDocBundle</title>
+    <title>{{ swagger_data.spec.info.title }} - NelmioApiDocBundle</title>
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700">
     <link rel="stylesheet" href="{{ asset('bundles/nelmioapidoc/swagger-ui/swagger-ui.css') }}">


### PR DESCRIPTION
It can be confusing to have only "NelmioApiDocBundle" in the title bar when browing the doc.

I've added the title of the documentation so it's clearer.