### PR TITLE
Handle form collection types

### DIFF
--- a/Tests/Functional/Form/DummyEmptyType.php
+++ b/Tests/Functional/Form/DummyEmptyType.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class DummyEmptyType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+    }
+}

--- a/Tests/Functional/Form/UserType.php
+++ b/Tests/Functional/Form/UserType.php
@@ -14,6 +14,7 @@ namespace Nelmio\ApiDocBundle\Tests\Functional\Form;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\User;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -22,9 +23,17 @@ class UserType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
+            ->add('strings', CollectionType::class, [
+                'entry_type' => TextType::class,
+                'required' => false,
+            ])
             ->add('dummy', DummyType::class)
             ->add('dummies', CollectionType::class, [
                 'entry_type' => DummyType::class,
+            ])
+            ->add('empty_dummies', CollectionType::class, [
+                'entry_type' => DummyEmptyType::class,
+                'required' => false,
             ])
             ->add('quz', DummyType::class, ['documentation' => ['type' => 'string', 'description' => 'User type.'], 'required' => false]);
     }

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -12,6 +12,7 @@
 namespace Nelmio\ApiDocBundle\Tests\Functional;
 
 use EXSyst\Component\Swagger\Tag;
+use Nelmio\ApiDocBundle\Tests\Functional\Form\DummyEmptyType;
 use Nelmio\ApiDocBundle\Tests\Functional\Form\DummyType;
 
 class FunctionalTest extends WebTestCase
@@ -223,11 +224,20 @@ class FunctionalTest extends WebTestCase
         $this->assertEquals([
             'type' => 'object',
             'properties' => [
+                'strings' => [
+                    'items' => ['type' => 'string'],
+                    'type' => 'array',
+                ],
                 'dummy' => ['$ref' => '#/definitions/DummyType'],
                 'dummies' => [
                     'items' => ['$ref' => '#/definitions/DummyType'],
                     'type' => 'array',
                     'example' => sprintf('[{%s}]', DummyType::class),
+                ],
+                'empty_dummies' => [
+                    'items' => ['$ref' => '#/definitions/DummyEmptyType'],
+                    'type' => 'array',
+                    'example' => sprintf('[{%s}]', DummyEmptyType::class),
                 ],
                 'quz' => [
                     'type' => 'string',


### PR DESCRIPTION
Fixes https://github.com/nelmio/NelmioApiDocBundle/issues/1184
Closes https://github.com/nelmio/NelmioApiDocBundle/pull/1224 (alternative implementation to it)

IMO this solution is better than #1224 because it does less "hacks" to infer the type, it just calls recursively itself solving the inner collection type. 

Since this PR just moves the code in a private method, suggest to have a look at a [split mode with no white spaces diff mode](https://github.com/nelmio/NelmioApiDocBundle/pull/1309/files?w=1) that should be much easier to review.