### PR TITLE
Respect jms/serializer nested group exclusion

### DIFF
--- a/Tests/Functional/Controller/JMSController.php
+++ b/Tests/Functional/Controller/JMSController.php
@@ -15,6 +15,9 @@ use Nelmio\ApiDocBundle\Annotation\Model;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSComplex;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSDualComplex;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSUser;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup\JMSChat;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup\JMSChatUser;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup\JMSPicture;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\VirtualProperty;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Swagger\Annotations as SWG;
@@ -69,6 +72,42 @@ class JMSController
      * )
      */
     public function complexDualAction()
+    {
+    }
+
+    /**
+     * @Route("/api/jms_chat", methods={"GET"})
+     * @SWG\Response(
+     *     response=200,
+     *     description="Success",
+     *     @Model(type=JMSChat::class, groups={"Default", "members" : {"mini"}})
+     * )
+     */
+    public function chatAction()
+    {
+    }
+
+    /**
+     * @Route("/api/jms_picture", methods={"GET"})
+     * @SWG\Response(
+     *     response=200,
+     *     description="Success",
+     *     @Model(type=JMSPicture::class, groups={"mini"})
+     * )
+     */
+    public function pictureAction()
+    {
+    }
+
+    /**
+     * @Route("/api/jms_mini_user", methods={"GET"})
+     * @SWG\Response(
+     *     response=200,
+     *     description="Success",
+     *     @Model(type=JMSChatUser::class, groups={"mini"})
+     * )
+     */
+    public function minUserAction()
     {
     }
 }

--- a/Tests/Functional/Entity/NestedGroup/JMSChat.php
+++ b/Tests/Functional/Entity/NestedGroup/JMSChat.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * User.
+ *
+ * @Serializer\ExclusionPolicy("all")
+ */
+class JMSChat
+{
+    /**
+     * @Serializer\Type("integer")
+     * @Serializer\Expose
+     */
+    private $id;
+
+    /**
+     * @Serializer\Type("array<Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup\JMSChatUser>")
+     * @Serializer\Expose
+     */
+    private $members;
+}

--- a/Tests/Functional/Entity/NestedGroup/JMSChatUser.php
+++ b/Tests/Functional/Entity/NestedGroup/JMSChatUser.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * User.
+ *
+ * @Serializer\ExclusionPolicy("all")
+ */
+class JMSChatUser
+{
+    /**
+     * @Serializer\Type("integer")
+     * @Serializer\Expose
+     */
+    private $id;
+
+    /**
+     * @Serializer\Type("Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup\JMSPicture")
+     * @Serializer\Groups({"Default", "mini"})
+     * @Serializer\Expose
+     */
+    private $picture;
+
+    /**
+     * @Serializer\Type("array<Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup\JMSPicture>")
+     * @Serializer\Expose
+     */
+    private $allPictures;
+}

--- a/Tests/Functional/Entity/NestedGroup/JMSPicture.php
+++ b/Tests/Functional/Entity/NestedGroup/JMSPicture.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * User.
+ *
+ * @Serializer\ExclusionPolicy("all")
+ */
+class JMSPicture
+{
+    /**
+     * @Serializer\Type("integer")
+     * @Serializer\Expose
+     */
+    private $id;
+
+    /**
+     * @Serializer\Type("integer")
+     * @Serializer\Expose
+     * @Serializer\Groups({"mini"})
+     */
+    private $onlyDirectPictureMini;
+}

--- a/Tests/Functional/JMSFunctionalTest.php
+++ b/Tests/Functional/JMSFunctionalTest.php
@@ -13,6 +13,45 @@ namespace Nelmio\ApiDocBundle\Tests\Functional;
 
 class JMSFunctionalTest extends WebTestCase
 {
+    public function testModelPictureDocumentation()
+    {
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'only_direct_picture_mini' => [
+                    'type' => 'integer',
+                ],
+            ],
+        ], $this->getModel('JMSPicture')->toArray());
+    }
+
+    public function testModeChatDocumentation()
+    {
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'id' => [
+                    'type' => 'integer',
+                ],
+                'members' => [
+                    'items' => [
+                        '$ref' => '#/definitions/JMSChatUser',
+                    ],
+                    'type' => 'array',
+                ],
+            ],
+        ], $this->getModel('JMSChat')->toArray());
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'picture' => [
+                    '$ref' => '#/definitions/JMSPicture',
+                ],
+            ],
+        ], $this->getModel('JMSChatUser')->toArray());
+    }
+
     public function testModelDocumentation()
     {
         $this->assertEquals([


### PR DESCRIPTION
Currently the logic used to infer groups from the JMS serializer is not exactly correct.
When using the [deeper-branches-group override](https://github.com/schmittjoh/serializer/blob/1.x/doc/cookbook/exclusion_strategies.rst#overriding-groups-of-deeper-branches-of-the-graph) feature, when an override is not found, the fallback is to the default group, while the current nelmio implementation is to fallback to the currently used groups.

This is visible on JMS [here](https://github.com/schmittjoh/serializer/blob/5824ce8fa1c2e7db57d47072a6ce9d2feec229da/src/JMS/Serializer/Exclusion/GroupsExclusionStrategy.php#L80) while the curren implementation does not override the group with the default one (see [here](https://github.com/nelmio/NelmioApiDocBundle/blob/2c72aa4efff07862514aaf2cf078fabc58c465d6/ModelDescriber/JMSModelDescriber.php#L74)).

The implementation might be not perfect but it works, feedback is welcome.