### PR TITLE
fix(SymfonyConstraintAnnotationReader): fixed enum guessing in Assert…

### DIFF
--- a/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
+++ b/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
@@ -70,7 +70,7 @@ class SymfonyConstraintAnnotationReader
             }
 
             if ($annotation instanceof Assert\Choice) {
-                $property->setEnum($annotation->choices);
+                $property->setEnum($annotation->callback ? call_user_func($annotation->callback) : $annotation->choices);
             }
 
             if ($annotation instanceof Assert\Expression) {

--- a/Tests/Functional/Entity/SymfonyConstraints.php
+++ b/Tests/Functional/Entity/SymfonyConstraints.php
@@ -67,6 +67,13 @@ class SymfonyConstraints
     /**
      * @var int
      *
+     * @Assert\Choice(callback={SymfonyConstraints::class,"fetchAllowedChoices"})
+     */
+    private $propertyChoiceWithCallback;
+
+    /**
+     * @var int
+     *
      * @Assert\Expression(
      *     "this.getCategory() in ['php', 'symfony'] or !this.isTechnicalPost()",
      *     message="If this is a tech post, the category should be either php or symfony!"
@@ -131,10 +138,26 @@ class SymfonyConstraints
     }
 
     /**
+     * @param int $propertyChoiceWithCallback
+     */
+    public function setPropertyChoiceWithCallback(int $propertyChoiceWithCallback): void
+    {
+        $this->propertyChoiceWithCallback = $propertyChoiceWithCallback;
+    }
+
+    /**
      * @param int $propertyExpression
      */
     public function setPropertyExpression(int $propertyExpression): void
     {
         $this->propertyExpression = $propertyExpression;
+    }
+
+    /**
+     * @return array
+     */
+    public static function fetchAllowedChoices()
+    {
+        return ["choice1", "choice2"];
     }
 }

--- a/Tests/Functional/Entity/SymfonyConstraints.php
+++ b/Tests/Functional/Entity/SymfonyConstraints.php
@@ -158,6 +158,6 @@ class SymfonyConstraints
      */
     public static function fetchAllowedChoices()
     {
-        return ["choice1", "choice2"];
+        return ['choice1', 'choice2'];
     }
 }

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -341,6 +341,10 @@ class FunctionalTest extends WebTestCase
                     'type' => 'integer',
                     'enum' => ['choice1', 'choice2'],
                 ],
+                'propertyChoiceWithCallback' => [
+                    'type' => 'integer',
+                    'enum' => ['choice1', 'choice2'],
+                ],
                 'propertyExpression' => [
                     'type' => 'integer',
                     'pattern' => 'If this is a tech post, the category should be either php or symfony!',


### PR DESCRIPTION
Hello, 

In Symfony, when using ``` Assert\Choice``` with ```callback```parameter, choices are not rendered in swagger documentation.
This PR proposes a small fix ;-)