### PR TITLE
Prevent Swagger UI from using resources via CDNs

### DIFF
--- a/Resources/public/style.css
+++ b/Resources/public/style.css
@@ -171,7 +171,7 @@ header #logo img {
 
 #formats {
   text-align:right;
-  font-family: Open Sans,sans-serif;
+  font-family: sans-serif;
   width: 100%;
   max-width: 1460px;
   padding: 0px 60px;
@@ -287,5 +287,5 @@ text-align:center;
 .swagger-ui .info .title small pre,
 .swagger-ui .scopes h2,
 .swagger-ui .errors-wrapper hgroup h4 {
-  font-family: Open Sans,sans-serif!important;
+  font-family: sans-serif!important;
 }

--- a/Resources/views/SwaggerUi/index.html.twig
+++ b/Resources/views/SwaggerUi/index.html.twig
@@ -11,7 +11,6 @@ file that was distributed with this source code. #}
     <meta charset="UTF-8">
     <title>{{ swagger_data.spec.info.title }} - NelmioApiDocBundle</title>
 
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700">
     <link rel="stylesheet" href="{{ asset('bundles/nelmioapidoc/swagger-ui/swagger-ui.css') }}">
     <link rel="stylesheet" href="{{ asset('bundles/nelmioapidoc/style.css') }}">
 


### PR DESCRIPTION
The API documentation of a service should not "leak" information to a third party. Using Google Fonts is not nessecary in this particular situation.

Also there is a new data protection law in European Union (GDRP). To avoid data protection issues the usage of google fonts was removed. The system fonts provided by the operating systems are used instead.