### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+.*                  export-ignore
+phpunit*            export-ignore
+Tests               export-ignore


### PR DESCRIPTION
This file reduces the stuff that gets exported when packaging this lib in the vendor folder through Composer, i.e. the test lib does not belong there.