### PR TITLE
[WIP] Allow to override template for swagger-ui

### DIFF
--- a/Controller/SwaggerUiController.php
+++ b/Controller/SwaggerUiController.php
@@ -20,6 +20,8 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 final class SwaggerUiController
 {
+    private $view;
+
     private $generatorLocator;
 
     private $twig;
@@ -27,7 +29,7 @@ final class SwaggerUiController
     /**
      * @param ContainerInterface $generatorLocator
      */
-    public function __construct($generatorLocator, \Twig_Environment $twig)
+    public function __construct($view, $generatorLocator, \Twig_Environment $twig)
     {
         if (!$generatorLocator instanceof ContainerInterface) {
             if (!$generatorLocator instanceof ApiDocGenerator) {
@@ -56,7 +58,7 @@ final class SwaggerUiController
         }
 
         return new Response(
-            $this->twig->render('@NelmioApiDoc/SwaggerUi/index.html.twig', ['swagger_data' => ['spec' => $spec]]),
+            $this->twig->render($this->view, ['swagger_data' => ['spec' => $spec]]),
             Response::HTTP_OK,
             ['Content-Type' => 'text/html']
         );

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -103,6 +103,12 @@ final class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->arrayNode('ui')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('view')->defaultValue('@NelmioApiDoc/SwaggerUi/index.html.twig')->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -154,6 +154,8 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
 
         // Import the base configuration
         $container->getDefinition('nelmio_api_doc.describers.config')->replaceArgument(0, $config['documentation']);
+
+        $container->setParameter('nelmio_api_doc.ui.view', $config['ui']['view']);
     }
 
     private function findNameAliases(array $names, string $area): array

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -6,6 +6,7 @@
     <services>
         <!-- Controllers -->
         <service id="nelmio_api_doc.controller.swagger_ui" class="Nelmio\ApiDocBundle\Controller\SwaggerUiController" public="true">
+            <argument>%nelmio_api_doc.ui.view%</argument>
             <argument type="service" id="nelmio_api_doc.generator_locator" />
             <argument type="service" id="twig" />
         </service>

--- a/Resources/views/SwaggerUi/index.html.twig
+++ b/Resources/views/SwaggerUi/index.html.twig
@@ -48,7 +48,7 @@ file that was distributed with this source code. #}
         <a id="logo" href="https://github.com/nelmio/NelmioApiDocBundle"><img src="{{ asset('bundles/nelmioapidoc/logo.png') }}" alt="NelmioApiDocBundle"></a>
     </header>
 
-    <div id="swagger-ui" class="api-platform"></div>
+    {% block documentation %}<div id="swagger-ui" class="api-platform"></div>{% endblock %}
 
     <div class="swagger-ui-wrap" style="margin-top: 20px; margin-bottom: 20px;">
         &copy; 2017 <a href="https://api-platform.com">Api-Platform</a>


### PR DESCRIPTION
Following @dbu comment on #1330 

Not sure if it's the right path. Is it ?

To add a block to define parameters, I might be forced to inline `init-swagger-ui.js`. I'm not sure that it make sense to have it in a different file anyway.