### PR TITLE
[JMSModelDescriber] Update `JMSModelDescriber` in order to iterate over nested array definitions

### DIFF
--- a/Tests/Functional/Entity/JMSUser.php
+++ b/Tests/Functional/Entity/JMSUser.php
@@ -126,6 +126,12 @@ class JMSUser
      */
     private $status;
 
+    /**
+     * @Serializer\Type("array<array<float>>")
+     * @Serializer\Expose
+     */
+    private $latLonHistory;
+
     public function setRoles($roles)
     {
     }

--- a/Tests/Functional/JMSFunctionalTest.php
+++ b/Tests/Functional/JMSFunctionalTest.php
@@ -83,6 +83,16 @@ class JMSFunctionalTest extends WebTestCase
                 'last_update' => [
                     'type' => 'date',
                 ],
+                'lat_lon_history' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'array',
+                        'items' => [
+                            'type' => 'number',
+                            'format' => 'float',
+                        ],
+                    ],
+                ],
             ],
         ], $this->getModel('JMSUser')->toArray());
     }


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |yes   |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|#1364 |
|License      |MIT   |
|Doc PR       |n/a   |

Solution based on @GuilhemN's suggestion (see https://github.com/nelmio/NelmioApiDocBundle/issues/1364#issuecomment-406713022).

**TODO:**
- [x] Check if is possible to use `PropertyMetadata` for nested items at `describeItem()` and `getNestedTypeInArray()`.

Closes #1364.