### PR TITLE
Jms serializer default groups should not generate new definitions when possible

### DIFF
--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -76,7 +76,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
                 $groups = array_filter($groups, 'is_scalar');
             }
 
-            if ([GroupsExclusionStrategy::DEFAULT_GROUP] == $groups) {
+            if ([GroupsExclusionStrategy::DEFAULT_GROUP] === $groups) {
                 $groups = null;
             }
 

--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -76,6 +76,10 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
                 $groups = array_filter($groups, 'is_scalar');
             }
 
+            if ([GroupsExclusionStrategy::DEFAULT_GROUP] == $groups) {
+                $groups = null;
+            }
+
             // read property options from Swagger Property annotation if it exists
             if (null !== $item->reflection) {
                 $property = $properties->get($annotationsReader->getPropertyName($item->reflection, $name));

--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -72,6 +72,8 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
             $groups = $model->getGroups();
             if (isset($groups[$name]) && is_array($groups[$name])) {
                 $groups = $model->getGroups()[$name];
+            } elseif (is_array($groups)) {
+                $groups = array_filter($groups, 'is_scalar');
             }
 
             // read property options from Swagger Property annotation if it exists

--- a/Tests/Functional/Controller/JMSController.php
+++ b/Tests/Functional/Controller/JMSController.php
@@ -13,6 +13,7 @@ namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
 
 use Nelmio\ApiDocBundle\Annotation\Model;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSComplex;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSDualComplex;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSUser;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\VirtualProperty;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -56,6 +57,18 @@ class JMSController
      * )
      */
     public function complexAction()
+    {
+    }
+
+    /**
+     * @Route("/api/jms_complex_dual", methods={"GET"})
+     * @SWG\Response(
+     *     response=200,
+     *     description="Success",
+     *     @Model(type=JMSDualComplex::class, groups={"Default", "complex" : {"user" : {"details"}}})
+     * )
+     */
+    public function complexDualAction()
     {
     }
 }

--- a/Tests/Functional/Entity/JMSDualComplex.php
+++ b/Tests/Functional/Entity/JMSDualComplex.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
+
+use JMS\Serializer\Annotation as Serializer;
+use Nelmio\ApiDocBundle\Annotation\Model;
+use Swagger\Annotations as SWG;
+
+class JMSDualComplex
+{
+    /**
+     * @Serializer\Type("integer")
+     */
+    private $id;
+
+    /**
+     * @SWG\Property(ref=@Model(type=JMSComplex::class))
+     */
+    private $complex;
+
+    /**
+     * @SWG\Property(ref=@Model(type=JMSUser::class))
+     */
+    private $user;
+}

--- a/Tests/Functional/JMSFunctionalTest.php
+++ b/Tests/Functional/JMSFunctionalTest.php
@@ -97,6 +97,24 @@ class JMSFunctionalTest extends WebTestCase
         ], $this->getModel('JMSUser')->toArray());
     }
 
+    public function testModelComplexDualDocumentation()
+    {
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'id' => [
+                    'type' => 'integer',
+                ],
+                'complex' => [
+                    '$ref' => '#/definitions/JMSComplex2',
+                ],
+                'user' => [
+                    '$ref' => '#/definitions/JMSUser',
+                ],
+            ],
+        ], $this->getModel('JMSDualComplex')->toArray());
+    }
+
     public function testModelComplexDocumentation()
     {
         $this->assertEquals([


### PR DESCRIPTION
jms/serializer default groups should not generate new definitions when possible.

This PR handles two cases
- When the default group is used
- When nested groups are used but on other properties that should not influence the current object