### PR TITLE
Added support for Doctrine MongoDB ODM 'document' form type

### DIFF
--- a/ModelDescriber/FormModelDescriber.php
+++ b/ModelDescriber/FormModelDescriber.php
@@ -177,25 +177,17 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
                 break;
             }
 
-            if ('entity' === $blockPrefix) {
+            // The DocumentType is bundled with the DoctrineMongoDBBundle
+            if ('entity' === $blockPrefix || 'document' === $blockPrefix) {
                 $entityClass = $config->getOption('class');
 
                 if ($config->getOption('multiple')) {
                     $property->setFormat(sprintf('[%s id]', $entityClass));
                     $property->setType('array');
+                    $property->getItems()->setType('string');
                 } else {
                     $property->setType('string');
                     $property->setFormat(sprintf('%s id', $entityClass));
-                }
-
-                break;
-            }
-
-            if ('document' === $blockPrefix) {
-                if ($config->getOption('multiple')) {
-                    $property->setType('array');
-                } else {
-                    $property->setType('string');
                 }
 
                 break;
@@ -233,11 +225,7 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
                 return null;
             }
 
-            if ('entity' === $type->getBlockPrefix()) {
-                return $type;
-            }
-
-            if ('document' === $type->getBlockPrefix()) {
+            if ('entity' === $type->getBlockPrefix() || 'document' === $type->getBlockPrefix()) {
                 return $type;
             }
 

--- a/ModelDescriber/FormModelDescriber.php
+++ b/ModelDescriber/FormModelDescriber.php
@@ -190,6 +190,16 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
 
                 break;
             }
+
+            if ('document' === $blockPrefix) {
+                if ($config->getOption('multiple')) {
+                    $property->setType('array');
+                } else {
+                    $property->setType('string');
+                }
+
+                break;
+            }
         } while ($builtinFormType = $builtinFormType->getParent());
     }
 
@@ -224,6 +234,10 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
             }
 
             if ('entity' === $type->getBlockPrefix()) {
+                return $type;
+            }
+
+            if ('document' === $type->getBlockPrefix()) {
                 return $type;
             }
 

--- a/Tests/Functional/Form/DocumentType.php
+++ b/Tests/Functional/Form/DocumentType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class DocumentType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setRequired('class');
+    }
+
+    public function getParent(): string
+    {
+        return ChoiceType::class;
+    }
+}

--- a/Tests/Functional/Form/UserType.php
+++ b/Tests/Functional/Form/UserType.php
@@ -37,6 +37,9 @@ class UserType extends AbstractType
             ])
             ->add('quz', DummyType::class, ['documentation' => ['type' => 'string', 'description' => 'User type.'], 'required' => false])
             ->add('entity', EntityType::class, ['class' => 'Entity'])
+            ->add('entities', EntityType::class, ['class' => 'Entity', 'multiple' => true])
+            ->add('document', DocumentType::class, ['class' => 'Document'])
+            ->add('documents', DocumentType::class, ['class' => 'Document', 'multiple' => true])
             ->add('extended_builtin', ExtendedBuiltinType::class, ['required_option' => 'foo']);
     }
 

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -248,12 +248,22 @@ class FunctionalTest extends WebTestCase
                     'type' => 'string',
                     'format' => 'Entity id',
                 ],
+                'entities' => [
+                    'type' => 'array',
+                    'format' => '[Entity id]',
+                ],
+                'document' => [
+                    'type' => 'string',
+                ],
+                'documents' => [
+                    'type' => 'array',
+                ],
                 'extended_builtin' => [
                     'type' => 'string',
                     'enum' => ['foo', 'bar'],
                 ],
             ],
-            'required' => ['dummy', 'dummies', 'entity', 'extended_builtin'],
+            'required' => ['dummy', 'dummies', 'entity', 'entities', 'document', 'documents', 'extended_builtin'],
         ], $this->getModel('UserType')->toArray());
 
         $this->assertEquals([

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -251,12 +251,16 @@ class FunctionalTest extends WebTestCase
                 'entities' => [
                     'type' => 'array',
                     'format' => '[Entity id]',
+                    'items' => ['type' => 'string'],
                 ],
                 'document' => [
                     'type' => 'string',
+                    'format' => 'Document id',
                 ],
                 'documents' => [
                     'type' => 'array',
+                    'format' => '[Document id]',
+                    'items' => ['type' => 'string'],
                 ],
                 'extended_builtin' => [
                     'type' => 'string',


### PR DESCRIPTION
Adds support for the Doctrine MongoDB ODM `document` form type, which like `entity` extends `ChoiceType` and can be a multiple.

Also added test assertions for both `entity` and `document` with multiple enabled.