### PR TITLE
[Bug] Respect property name for constraints

### DIFF
--- a/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
+++ b/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
@@ -49,8 +49,13 @@ class SymfonyConstraintAnnotationReader
                     continue;
                 }
 
+                $propertyName = $this->getSchemaPropertyName($property);
+                if (null === $propertyName) {
+                    continue;
+                }
+
                 $existingRequiredFields = $this->schema->getRequired() ?? [];
-                $existingRequiredFields[] = $reflectionProperty->getName();
+                $existingRequiredFields[] = $propertyName;
 
                 $this->schema->setRequired(array_values(array_unique($existingRequiredFields)));
             } elseif ($annotation instanceof Assert\Length) {
@@ -74,6 +79,24 @@ class SymfonyConstraintAnnotationReader
     public function setSchema($schema)
     {
         $this->schema = $schema;
+    }
+
+    /**
+     * Get assigned property name for property schema.
+     */
+    private function getSchemaPropertyName(Schema $property)
+    {
+        if (null === $this->schema) {
+            return null;
+        }
+
+        foreach ($this->schema->getProperties() as $name => $schemaProperty) {
+            if ($schemaProperty === $property) {
+                return $name;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/Tests/Functional/Controller/JMSController.php
+++ b/Tests/Functional/Controller/JMSController.php
@@ -14,6 +14,7 @@ namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSComplex;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSDualComplex;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSNamingStrategyConstraints;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSUser;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup\JMSChat;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup\JMSChatUser;
@@ -72,6 +73,18 @@ class JMSController
      * )
      */
     public function complexDualAction()
+    {
+    }
+
+    /**
+     * @Route("/api/jms_naming_strategy", methods={"GET"})
+     * @SWG\Response(
+     *     response=200,
+     *     description="Success",
+     *     @Model(type=JMSNamingStrategyConstraints::class, groups={"Default"})
+     * )
+     */
+    public function namingStrategyConstraintsAction()
     {
     }
 

--- a/Tests/Functional/Entity/JMSNamingStrategyConstraints.php
+++ b/Tests/Functional/Entity/JMSNamingStrategyConstraints.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
+
+use JMS\Serializer\Annotation as Serializer;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class JMSNamingStrategyConstraints
+{
+    /**
+     * @var string
+     *
+     * @Serializer\Type("string")
+     * @Serializer\SerializedName("beautifulName")
+     *
+     * @Assert\NotBlank()
+     * @Assert\Regex(pattern="\w+")
+     * @Assert\Length(min="3", max="10")
+     */
+    private $some_weird_named_property = 'default';
+
+    public function getSomeWeirdNamedProperty(): string
+    {
+        return $this->some_weird_named_property;
+    }
+
+    public function setSomeWeirdNamedProperty(string $some_weird_named_property)
+    {
+        $this->some_weird_named_property = $some_weird_named_property;
+    }
+}

--- a/Tests/Functional/JMSFunctionalTest.php
+++ b/Tests/Functional/JMSFunctionalTest.php
@@ -237,6 +237,21 @@ class JMSFunctionalTest extends WebTestCase
         ], $this->getModel('VirtualProperty')->toArray());
     }
 
+    public function testNamingStrategyWithConstraints()
+    {
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'beautifulName' => [
+                    'type' => 'string',
+                    'maxLength' => '10',
+                    'minLength' => '3',
+                ],
+            ],
+            'required' => ['beautifulName'],
+        ], $this->getModel('JMSNamingStrategyConstraints')->toArray());
+    }
+
     protected static function createKernel(array $options = [])
     {
         return new TestKernel(true);

--- a/Tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
+++ b/Tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
@@ -32,15 +32,16 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
              */
             private $property2;
         };
-        $reflectionProperties = (new \ReflectionClass($entity))->getProperties();
-        $property = new Schema();
+
         $schema = new Schema();
+        $schema->getProperties()->set('property1', new Schema());
+        $schema->getProperties()->set('property2', new Schema());
 
         $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader(new AnnotationReader());
         $symfonyConstraintAnnotationReader->setSchema($schema);
-        foreach ($reflectionProperties as $reflectionProperty) {
-            $symfonyConstraintAnnotationReader->updateProperty($reflectionProperty, $property);
-        }
+
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->getProperties()->get('property1'));
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property2'), $schema->getProperties()->get('property2'));
 
         // expect required to be numeric array with sequential keys (not [0 => ..., 2 => ...])
         $this->assertEquals($schema->getRequired(), ['property1', 'property2']);


### PR DESCRIPTION
Currenly `@NotNull` or `@NotBlank` constraints utilize reflection property name, which is incorrect for cases where naming strategy is involved.

- [x] Created test (+model and controller) to reflect the bug present
- [x] Fixed the test