### PR TITLE
Restore jms nested groups feature

### DIFF
--- a/Model/ModelRegistry.php
+++ b/Model/ModelRegistry.php
@@ -40,32 +40,30 @@ final class ModelRegistry
     {
         $this->modelDescribers = $modelDescribers;
         $this->api = $api;
-        $this->alternativeNames = array_reverse($alternativeNames); // last rule wins
+        $this->alternativeNames = []; // last rule wins
+
+        foreach (array_reverse($alternativeNames) as $alternativeName => $criteria) {
+            $this->alternativeNames[] = $model = new Model(new Type('object', false, $criteria['type']), $criteria['groups']);
+            $this->names[$model->getHash()] = $alternativeName;
+            $this->api->getDefinitions()->get($alternativeName);
+        }
     }
 
     public function register(Model $model): string
     {
-        return $this->doRegister($model);
-    }
-
-    /**
-     * Private method allowing to enforce the model name for alternative names.
-     */
-    private function doRegister(Model $model, string $name = null)
-    {
         $hash = $model->getHash();
-        if (isset($this->names[$hash])) {
-            return '#/definitions/'.$this->names[$hash];
+        if (!isset($this->models[$hash])) {
+            $this->models[$hash] = $model;
+            $this->unregistered[] = $hash;
+        }
+        if (!isset($this->names[$hash])) {
+            $this->names[$hash] = $this->generateModelName($model);
         }
 
-        $this->names[$hash] = $name = ($name ?? $this->generateModelName($model));
-        $this->models[$hash] = $model;
-        $this->unregistered[] = $hash;
-
         // Reserve the name
-        $this->api->getDefinitions()->get($name);
+        $this->api->getDefinitions()->get($this->names[$hash]);
 
-        return '#/definitions/'.$name;
+        return '#/definitions/'.$this->names[$hash];
     }
 
     /**
@@ -100,58 +98,29 @@ final class ModelRegistry
 
                 $this->api->getDefinitions()->set($name, $schema);
             }
-        }
-    }
 
-    private function isReservedForAnotherModel(string $name, Model $model): bool
-    {
-        foreach ($this->alternativeNames as $alternativeName => $criteria) {
-            if ($name !== $alternativeName) {
-                continue;
-            }
-            $candidate = new Model(new Type('object', false, $criteria['type']), $criteria['groups']);
-            if ($candidate->getHash() !== $model->getHash()) {
-                return true;
+            if (0 === count($this->unregistered)) {
+                foreach ($this->alternativeNames as $model) {
+                    $this->register($model);
+                }
+                $this->alternativeNames = [];
             }
         }
-
-        return false;
     }
 
     private function generateModelName(Model $model): string
     {
         $definitions = $this->api->getDefinitions();
 
-        $name = $base = $this->getAlternativeName($model) ?? $this->getTypeShortName($model->getType());
+        $name = $base = $this->getTypeShortName($model->getType());
 
         $i = 1;
-        while ($definitions->has($name) || $this->isReservedForAnotherModel($name, $model)) {
+        while ($definitions->has($name)) {
             ++$i;
             $name = $base.$i;
         }
 
         return $name;
-    }
-
-    /**
-     * @param Model $model
-     *
-     * @return string|null
-     */
-    private function getAlternativeName(Model $model)
-    {
-        $type = $model->getType();
-        foreach ($this->alternativeNames as $alternativeName => $criteria) {
-            if (
-                Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType() &&
-                $type->getClassName() === $criteria['type'] &&
-                $criteria['groups'] === $model->getGroups()
-            ) {
-                return $alternativeName;
-            }
-        }
-
-        return null;
     }
 
     private function getTypeShortName(Type $type): string

--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -204,7 +204,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
      */
     private function propertyTypeUsesGroups(array $type)
     {
-        if (!array_key_exists($type['name'], $this->propertyTypeUseGroupsCache)) {
+        if (array_key_exists($type['name'], $this->propertyTypeUseGroupsCache)) {
             return $this->propertyTypeUseGroupsCache[$type['name']];
         }
 

--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -171,9 +171,8 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
                 return null;
             }
 
-            $property->setRef($this->modelRegistry->register(
-                new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, $type['name']), $groups)
-            ));
+            $model = new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, $type['name']), $groups);
+            $property->setRef($this->modelRegistry->register($model));
 
             if ($previousGroups) {
                 $this->previousGroups[spl_object_hash($model)] = $previousGroups;

--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -81,7 +81,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
             if (isset($groups[$name]) && is_array($groups[$name])) {
                 $previousGroups = $groups;
                 $groups = $model->getGroups()[$name];
-            } elseif (!isset($groups[$name]) && !empty($this->previousGroups[spl_object_hash($model)])) {
+            } elseif (!isset($groups[$name]) && !empty($this->previousGroups[$model->getHash()])) {
                 // $groups = $this->previousGroups[spl_object_hash($model)]; use this for jms/serializer 2.0
                 $groups = false === $this->propertyTypeUsesGroups($item->type) ? null : [GroupsExclusionStrategy::DEFAULT_GROUP];
             } elseif (is_array($groups)) {
@@ -175,7 +175,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
             $property->setRef($this->modelRegistry->register($model));
 
             if ($previousGroups) {
-                $this->previousGroups[spl_object_hash($model)] = $previousGroups;
+                $this->previousGroups[$model->getHash()] = $previousGroups;
             }
         }
     }


### PR DESCRIPTION
As said in https://github.com/nelmio/NelmioApiDocBundle/pull/1311#issuecomment-423981494 ,  #1384 broke the jms nested group feature implemented with https://github.com/nelmio/NelmioApiDocBundle/pull/1311.

This PR re integrates it. To do so was necessary to allow to not auto-register aliases. This is mainly because of how the nested groups work, is fundamental to know which was the previous group.

This PR fixes also few issues in the merge commit https://github.com/nelmio/NelmioApiDocBundle/commit/63cee64e6b02ef6f3685ee4a568a81444936d2fe


I'm open to hear better proposal since `reserve_name` to me sounds as a workaround for disabling  https://github.com/nelmio/NelmioApiDocBundle/pull/1384, otherwise will be impossible to achieve this feature.