### PR TITLE
Add boolean enums support to forms

### DIFF
--- a/ModelDescriber/FormModelDescriber.php
+++ b/ModelDescriber/FormModelDescriber.php
@@ -147,7 +147,14 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
                 }
                 if (($choices = $config->getOption('choices')) && is_array($choices) && count($choices)) {
                     $enums = array_values($choices);
-                    $type = $this->isNumbersArray($enums) ? 'number' : 'string';
+                    if ($this->isNumbersArray($enums)) {
+                        $type = 'number';
+                    } elseif ($this->isBooleansArray($enums)) {
+                        $type = 'boolean';
+                    } else {
+                        $type = 'string';
+                    }
+
                     if ($config->getOption('multiple')) {
                         $property->getItems()->setType($type)->setEnum($enums);
                     } else {
@@ -226,6 +233,22 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
     {
         foreach ($array as $item) {
             if (!is_numeric($item)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array $array
+     *
+     * @return bool true if $array contains only booleans, false otherwise
+     */
+    private function isBooleansArray(array $array): bool
+    {
+        foreach ($array as $item) {
+            if (!is_bool($item)) {
                 return false;
             }
         }

--- a/Tests/Functional/Form/DummyType.php
+++ b/Tests/Functional/Form/DummyType.php
@@ -26,6 +26,7 @@ class DummyType extends AbstractType
     {
         $builder->add('bar', TextType::class, ['required' => false]);
         $builder->add('foo', ChoiceType::class, ['choices' => ['male', 'female']]);
+        $builder->add('boo', ChoiceType::class, ['choices' => [true, false], 'required' => false]);
         $builder->add('foz', ChoiceType::class, ['choices' => ['male', 'female'], 'multiple' => true]);
         $builder->add('baz', CheckboxType::class, ['required' => false]);
         $builder->add('bey', IntegerType::class, ['required' => false]);

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -285,6 +285,10 @@ class FunctionalTest extends WebTestCase
                     'type' => 'string',
                     'enum' => ['male', 'female'],
                 ],
+                'boo' => [
+                    'type' => 'boolean',
+                    'enum' => [true, false],
+                ],
                 'foz' => [
                     'type' => 'array',
                     'items' => [


### PR DESCRIPTION
This adds support for boolean enums. 

previous response was:

```php
[
  'type' => 'string',
  'enum' => [true, false],
]
```

The enum is in contradiction with the filed type. Now is:

```php
[
  'type' => 'boolean',
  'enum' => [true, false],
]
```