### PR TITLE
Fix choice annotation with callback method name without class

### DIFF
--- a/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
+++ b/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
@@ -69,7 +69,7 @@ class SymfonyConstraintAnnotationReader
                 $property->setMinItems($annotation->min);
                 $property->setMaxItems($annotation->max);
             } elseif ($annotation instanceof Assert\Choice) {
-                $property->setEnum($annotation->callback ? call_user_func($annotation->callback) : $annotation->choices);
+                $property->setEnum($annotation->callback ? call_user_func(is_array($annotation->callback) ? $annotation->callback : [$reflectionProperty->class, $annotation->callback]) : $annotation->choices);
             } elseif ($annotation instanceof Assert\Expression) {
                 $this->appendPattern($property, $annotation->message);
             }

--- a/Tests/Functional/Entity/SymfonyConstraints.php
+++ b/Tests/Functional/Entity/SymfonyConstraints.php
@@ -67,6 +67,13 @@ class SymfonyConstraints
     /**
      * @var int
      *
+     * @Assert\Choice(callback="fetchAllowedChoices")
+     */
+    private $propertyChoiceWithCallbackWithoutClass;
+
+    /**
+     * @var int
+     *
      * @Assert\Expression(
      *     "this.getCategory() in ['php', 'symfony'] or !this.isTechnicalPost()",
      *     message="If this is a tech post, the category should be either php or symfony!"
@@ -128,6 +135,14 @@ class SymfonyConstraints
     public function setPropertyChoiceWithCallback(int $propertyChoiceWithCallback): void
     {
         $this->propertyChoiceWithCallback = $propertyChoiceWithCallback;
+    }
+
+    /**
+     * @param int $propertyChoiceWithCallbackWithoutClass
+     */
+    public function setPropertyChoiceWithCallbackWithoutClass(int $propertyChoiceWithCallbackWithoutClass): void
+    {
+        $this->propertyChoiceWithCallbackWithoutClass = $propertyChoiceWithCallbackWithoutClass;
     }
 
     /**

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -374,6 +374,10 @@ class FunctionalTest extends WebTestCase
                     'type' => 'integer',
                     'enum' => ['choice1', 'choice2'],
                 ],
+                'propertyChoiceWithCallbackWithoutClass' => [
+                    'type' => 'integer',
+                    'enum' => ['choice1', 'choice2'],
+                ],
                 'propertyExpression' => [
                     'type' => 'integer',
                     'pattern' => 'If this is a tech post, the category should be either php or symfony!',


### PR DESCRIPTION
Fix https://github.com/nelmio/NelmioApiDocBundle/issues/1397 added in https://github.com/nelmio/NelmioApiDocBundle/pull/1325