### PR TITLE
Display the FOS query param pattern

### DIFF
--- a/RouteDescriber/FosRestDescriber.php
+++ b/RouteDescriber/FosRestDescriber.php
@@ -12,13 +12,13 @@
 namespace Nelmio\ApiDocBundle\RouteDescriber;
 
 use Doctrine\Common\Annotations\Reader;
+use EXSyst\Component\Swagger\Parameter;
 use EXSyst\Component\Swagger\Swagger;
 use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\RequestParam;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Regex;
-use EXSyst\Component\Swagger\Parameter;
 
 final class FosRestDescriber implements RouteDescriberInterface
 {

--- a/RouteDescriber/FosRestDescriber.php
+++ b/RouteDescriber/FosRestDescriber.php
@@ -18,6 +18,7 @@ use FOS\RestBundle\Controller\Annotations\RequestParam;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Regex;
+use EXSyst\Component\Swagger\Parameter;
 
 final class FosRestDescriber implements RouteDescriberInterface
 {
@@ -45,12 +46,7 @@ final class FosRestDescriber implements RouteDescriberInterface
 
                     $parameter->setRequired(!$annotation->nullable && $annotation->strict);
 
-                    $annotationPattern = $this->getPattern($annotation->requirements);
-                    $oldDescription = $parameter->getDescription() ?: $annotation->description;
-
-                    if (null !== $oldDescription && null !== $annotationPattern) {
-                        $parameter->setDescription(sprintf("%s \r\n Pattern: %s", $oldDescription, $annotationPattern));
-                    }
+                    $this->addPatternToDescription($parameter, $annotation);
                 } else {
                     $body = $operation->getParameters()->get('body', 'body')->getSchema();
                     $body->setType('object');
@@ -82,6 +78,16 @@ final class FosRestDescriber implements RouteDescriberInterface
                     $parameter->setFormat($format);
                 }
             }
+        }
+    }
+
+    private function addPatternToDescription(Parameter $parameter, QueryParam $annotation)
+    {
+        $annotationPattern = $this->getPattern($annotation->requirements);
+        $oldDescription = $parameter->getDescription() ?: $annotation->description;
+
+        if (null !== $oldDescription && null !== $annotationPattern) {
+            $parameter->setDescription(sprintf("%s \r\n Pattern: %s", $oldDescription, $annotationPattern));
         }
     }
 

--- a/RouteDescriber/FosRestDescriber.php
+++ b/RouteDescriber/FosRestDescriber.php
@@ -44,6 +44,13 @@ final class FosRestDescriber implements RouteDescriberInterface
                     $parameter->setAllowEmptyValue($annotation->nullable && $annotation->allowBlank);
 
                     $parameter->setRequired(!$annotation->nullable && $annotation->strict);
+
+                    $annotationPattern = $this->getPattern($annotation->requirements);
+                    $oldDescription = $parameter->getDescription() ?: $annotation->description;
+
+                    if (null !== $oldDescription && null !== $annotationPattern) {
+                        $parameter->setDescription(sprintf("%s \r\n Pattern: %s", $oldDescription, $annotationPattern));
+                    }
                 } else {
                     $body = $operation->getParameters()->get('body', 'body')->getSchema();
                     $body->setType('object');

--- a/Tests/Describer/FosRestDescriberTest.php
+++ b/Tests/Describer/FosRestDescriberTest.php
@@ -58,6 +58,6 @@ class FosRestDescriberTest extends AbstractDescriberTest
 
         $method->invoke($describer, $parameter, $queryParamAnnotation);
 
-        self::assertEquals("Country code filter", $parameter->getDescription());
+        self::assertEquals('Country code filter', $parameter->getDescription());
     }
 }

--- a/Tests/Describer/FosRestDescriberTest.php
+++ b/Tests/Describer/FosRestDescriberTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Describer;
+
+use Doctrine\Common\Annotations\Reader;
+use EXSyst\Component\Swagger\Parameter;
+use FOS\RestBundle\Controller\Annotations\QueryParam;
+use Nelmio\ApiDocBundle\RouteDescriber\FosRestDescriber;
+use ReflectionClass;
+
+class FosRestDescriberTest extends AbstractDescriberTest
+{
+    public function testDisplayPatternInDescription()
+    {
+        $queryParamAnnotation = new QueryParam();
+        $queryParamAnnotation->requirements = '^[a-zA-Z]{1,2}$';
+
+        $parameter = new Parameter(['name' => 'countryCode', 'in' => 'query']);
+        $parameter->setDescription('Country code filter');
+
+        $annotationReaderMock = $this->createMock(Reader::class);
+
+        $describer = new FosRestDescriber($annotationReaderMock);
+        $reflectionClass = new ReflectionClass($describer);
+
+        $method = $reflectionClass->getMethod('addPatternToDescription');
+        $method->setAccessible(true);
+
+        $method->invoke($describer, $parameter, $queryParamAnnotation);
+
+        self::assertEquals("Country code filter \r\n Pattern: ^[a-zA-Z]{1,2}$", $parameter->getDescription());
+    }
+
+    public function testDisplayPatternInDescriptionButIsNull()
+    {
+        $queryParamAnnotation = new QueryParam();
+        $queryParamAnnotation->requirements = null;
+
+        $parameter = new Parameter(['name' => 'countryCode', 'in' => 'query']);
+        $parameter->setDescription('Country code filter');
+
+        $annotationReaderMock = $this->createMock(Reader::class);
+
+        $describer = new FosRestDescriber($annotationReaderMock);
+        $reflectionClass = new ReflectionClass($describer);
+
+        $method = $reflectionClass->getMethod('addPatternToDescription');
+        $method->setAccessible(true);
+
+        $method->invoke($describer, $parameter, $queryParamAnnotation);
+
+        self::assertEquals("Country code filter", $parameter->getDescription());
+    }
+}


### PR DESCRIPTION
The requirements for the FOS query parameters aren't displayed in the UI. This feature adds the regex pattern to the documentation page. See attached screenshot.
![image](https://user-images.githubusercontent.com/10883583/46332817-37a9e600-c61e-11e8-8b10-3ff84c91649a.png)

