### PR TITLE
Add ability to use response objects which defined in configuration

### DIFF
--- a/Describer/SwaggerPhpDescriber.php
+++ b/Describer/SwaggerPhpDescriber.php
@@ -87,6 +87,9 @@ final class SwaggerPhpDescriber implements ModelRegistryAwareInterface
                 if (0 === strpos($ref, '#/parameters/') && isset($this->api->getParameters()[substr($ref, 13)])) {
                     return;
                 }
+                if (0 === strpos($ref, '#/responses/') && $this->api->getResponses()->has(substr($ref, 12))) {
+                    return;
+                }
 
                 parent::ref($ref);
             }

--- a/Tests/Functional/Controller/ApiController.php
+++ b/Tests/Functional/Controller/ApiController.php
@@ -191,6 +191,10 @@ class ApiController
      *     description="Success",
      *     @SWG\Schema(ref="#/definitions/Test")
      * )
+     * @SWG\Response(
+     *     response="201",
+     *     ref="#/responses/201"
+     * )
      * @Route("/configReference", methods={"GET"})
      */
     public function configReferenceAction()

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -387,6 +387,7 @@ class FunctionalTest extends WebTestCase
     {
         $operation = $this->getOperation('/api/configReference', 'get');
         $this->assertEquals('#/definitions/Test', $operation->getResponses()->get('200')->getSchema()->getRef());
+        $this->assertEquals('#/responses/201', $operation->getResponses()->get('201')->getRef());
     }
 
     public function testOperationsWithOtherAnnotationsAction()

--- a/Tests/Functional/TestKernel.php
+++ b/Tests/Functional/TestKernel.php
@@ -133,6 +133,11 @@ class TestKernel extends Kernel
                         'required' => true,
                     ],
                 ],
+                'responses' => [
+                    '201' => [
+                        'description' => 'Awesome description',
+                    ],
+                ],
             ],
            'areas' => [
                'default' => ['path_patterns' => ['^/api(?!/admin)'], 'host_patterns' => ['^api\.']],


### PR DESCRIPTION
We can define responses in configuration, but can't use it in while we describe schema.