### PR TITLE
Fix NelmioApiDocBundle view customization instructions

### DIFF
--- a/Resources/doc/customization.rst
+++ b/Resources/doc/customization.rst
@@ -13,11 +13,11 @@ This allows to change the title, the header, add additional or replace existing 
 Take a look at the Twig documentation `how to extend templates <https://twig.symfony.com/doc/2.x/tags/extends.html>`_.
 
 The following example will add additional scripts and a custom style to the template.
-Just create a file ``templates/bundles/NelmioApiDocBundle/views/SwaggerUi/index.html.twig``.
+Just create a file ``templates/bundles/NelmioApiDocBundle/SwaggerUi/index.html.twig``.
 
 .. code-block:: twig
 
-    {# templates/bundles/NelmioApiDocBundle/views/SwaggerUi/index.html.twig #}
+    {# templates/bundles/NelmioApiDocBundle/SwaggerUi/index.html.twig #}
 
     {#
         To avoid a "reached nested level" error an exclamation mark `!` has to be added

--- a/Resources/doc/customization.rst
+++ b/Resources/doc/customization.rst
@@ -13,7 +13,7 @@ This allows to change the title, the header, add additional or replace existing 
 Take a look at the Twig documentation `how to extend templates <https://twig.symfony.com/doc/2.x/tags/extends.html>`_.
 
 The following example will add additional scripts and a custom style to the template.
-Just create a file ``templates/bundles/NelmioApiDocBundle/SwaggerUI/index.html.twig``.
+Just create a file ``templates/bundles/NelmioApiDocBundle/views/SwaggerUi/index.html.twig``.
 
 .. code-block:: twig
 


### PR DESCRIPTION
"Just create a file..." was not OK (missing views/ subdirectory, wrong SwaggerUi case)
The path showcased as code-block's first row was OK