### PR TITLE
faq.rst: enhance readability in symfony.com docs

### DIFF
--- a/Resources/doc/faq.rst
+++ b/Resources/doc/faq.rst
@@ -45,7 +45,7 @@ Optional Path Parameters
 ------------------------
 
 Q: I have a controller with an optional path parameter. In swagger-ui, the parameter is required - can I make it
-   optional? The controller might look like this::
+optional? The controller might look like this::
 
     /**
      * Get all user meta or metadata for a specific field.
@@ -66,7 +66,7 @@ Q: I have a controller with an optional path parameter. In swagger-ui, the param
     }
 
 A: Optional path parameters are not supported by the OpenAPI specification. The solution to this is to define two
-   separate actions in your controller. For example::
+separate actions in your controller. For example::
 
     /**
      * Get all user meta data.
@@ -120,8 +120,8 @@ Asset files not loaded
 Q: How do I fix 404 or 406 HTTP status on NelmioApiDocBundle assets files (css, js, images)?
 
 A: The assets normally are installed by composer if any command event (usually ``post-install-cmd`` or
-   ``post-update-cmd``) triggers the ``ScriptHandler::installAssets`` script.
-   If you have not set up this script, you can manually execute this command:
+``post-update-cmd``) triggers the ``ScriptHandler::installAssets`` script.
+If you have not set up this script, you can manually execute this command:
 
 .. code-block:: bash
 


### PR DESCRIPTION
## Issue
Here's how it's displayed [on symfony.com](https://symfony.com/doc/current/bundles/NelmioApiDocBundle/faq.html#asset-files-not-loaded): the last word of the first line gets printed on the next row, while the two next lines have a nice indentation
:
![frequently asked questions -faq- - nelmio apidoc bundle docs- 10-17-2018 9-42-47 am](https://user-images.githubusercontent.com/1551971/47070312-31f0fa80-d1f1-11e8-846c-b7412231207c.png)

## Solution
After the fix, it will look like this:
![frequently asked questions -faq- - nelmio apidoc bundle docs- 10-17-2018 9-47-08 am](https://user-images.githubusercontent.com/1551971/47070500-a3c94400-d1f1-11e8-86a1-7a2e93e0ea03.png)
No nice indentation under to emphasis the "A: " thing, but it looks a bit more readable

An alternative for that would be to ensure that the "or" doesn't get wrapped by fine-tuning on which word we wrap the line in the RST file, but it does not feel like the right thing to do