### PR TITLE
[bugfix] jms serializer group names are on property names

### DIFF
--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -74,14 +74,13 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
                 continue;
             }
 
-            $name = $this->namingStrategy->translateName($item);
             $groups = $model->getGroups();
 
             $previousGroups = null;
-            if (isset($groups[$name]) && is_array($groups[$name])) {
+            if (isset($groups[$item->name]) && is_array($groups[$item->name])) {
                 $previousGroups = $groups;
-                $groups = $model->getGroups()[$name];
-            } elseif (!isset($groups[$name]) && !empty($this->previousGroups[$model->getHash()])) {
+                $groups = $groups[$item->name];
+            } elseif (!isset($groups[$item->name]) && !empty($this->previousGroups[$model->getHash()])) {
                 // $groups = $this->previousGroups[spl_object_hash($model)]; use this for jms/serializer 2.0
                 $groups = false === $this->propertyTypeUsesGroups($item->type) ? null : [GroupsExclusionStrategy::DEFAULT_GROUP];
             } elseif (is_array($groups)) {
@@ -92,6 +91,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
                 $groups = null;
             }
 
+            $name = $this->namingStrategy->translateName($item);
             // read property options from Swagger Property annotation if it exists
             if (null !== $item->reflection) {
                 $property = $properties->get($annotationsReader->getPropertyName($item->reflection, $name));

--- a/Tests/Functional/Controller/JMSController.php
+++ b/Tests/Functional/Controller/JMSController.php
@@ -57,7 +57,7 @@ class JMSController
      * @SWG\Response(
      *     response=200,
      *     description="Success",
-     *     @Model(type=JMSComplex::class, groups={"list", "details", "user" : {"list"}})
+     *     @Model(type=JMSComplex::class, groups={"list", "details", "User" : {"list"}})
      * )
      */
     public function complexAction()
@@ -69,7 +69,7 @@ class JMSController
      * @SWG\Response(
      *     response=200,
      *     description="Success",
-     *     @Model(type=JMSDualComplex::class, groups={"Default", "complex" : {"user" : {"details"}}})
+     *     @Model(type=JMSDualComplex::class, groups={"Default", "complex" : {"User" : {"details"}}})
      * )
      */
     public function complexDualAction()

--- a/Tests/Functional/Entity/JMSComplex.php
+++ b/Tests/Functional/Entity/JMSComplex.php
@@ -35,8 +35,9 @@ class JMSComplex
      * @SWG\Property(ref=@Model(type=JMSUser::class))
      * @Serializer\Expose
      * @Serializer\Groups({"details"})
+     * @Serializer\SerializedName("user")
      */
-    private $user;
+    private $User;
 
     /**
      * @Serializer\Type("string")


### PR DESCRIPTION
jms serializer group names are based on the internal property name, not on the serialized name