### PR TITLE
Allow jms/serializer v2.0 and willdurand/Hateoas v3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
   include:
     - php: 7.0
       env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.2
+      env: COMPOSER_FLAGS="--prefer-lowest"
 
 before_install:
     - phpenv config-rm xdebug.ini

--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -23,7 +23,6 @@ use Nelmio\ApiDocBundle\Routing\FilteredRouteCollectionBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;

--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -12,6 +12,7 @@
 namespace Nelmio\ApiDocBundle\DependencyInjection;
 
 use FOS\RestBundle\Controller\Annotations\ParamInterface;
+use JMS\Serializer\Visitor\SerializationVisitorInterface;
 use Nelmio\ApiDocBundle\ApiDocGenerator;
 use Nelmio\ApiDocBundle\Describer\ExternalDocDescriber;
 use Nelmio\ApiDocBundle\Describer\RouteDescriber;
@@ -22,6 +23,7 @@ use Nelmio\ApiDocBundle\Routing\FilteredRouteCollectionBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -141,11 +143,13 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
 
         // JMS metadata support
         if ($config['models']['use_jms']) {
+            $jmsNamingStrategy = interface_exists(SerializationVisitorInterface::class) ? null : new Reference('jms_serializer.naming_strategy');
+
             $container->register('nelmio_api_doc.model_describers.jms', JMSModelDescriber::class)
                 ->setPublic(false)
                 ->setArguments([
                     new Reference('jms_serializer.metadata_factory'),
-                    new Reference('jms_serializer.naming_strategy'),
+                    $jmsNamingStrategy,
                     new Reference('annotation_reader'),
                 ])
                 ->addTag('nelmio_api_doc.model_describer', ['priority' => 50]);

--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -42,7 +42,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
 
     public function __construct(
         MetadataFactoryInterface $factory,
-        PropertyNamingStrategyInterface $namingStrategy,
+        PropertyNamingStrategyInterface $namingStrategy = null,
         Reader $reader
     ) {
         $this->factory = $factory;
@@ -81,8 +81,9 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
                 $previousGroups = $groups;
                 $groups = $groups[$item->name];
             } elseif (!isset($groups[$item->name]) && !empty($this->previousGroups[$model->getHash()])) {
-                // $groups = $this->previousGroups[spl_object_hash($model)]; use this for jms/serializer 2.0
-                $groups = false === $this->propertyTypeUsesGroups($item->type) ? null : [GroupsExclusionStrategy::DEFAULT_GROUP];
+                $groups = false === $this->propertyTypeUsesGroups($item->type)
+                    ? null
+                    : ($this->namingStrategy ? [GroupsExclusionStrategy::DEFAULT_GROUP] : $this->previousGroups[$model->getHash()]);
             } elseif (is_array($groups)) {
                 $groups = array_filter($groups, 'is_scalar');
             }
@@ -91,7 +92,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
                 $groups = null;
             }
 
-            $name = $this->namingStrategy->translateName($item);
+            $name = $this->namingStrategy ? $this->namingStrategy->translateName($item) : $item->serializedName;
             // read property options from Swagger Property annotation if it exists
             if (null !== $item->reflection) {
                 $property = $properties->get($annotationsReader->getPropertyName($item->reflection, $name));

--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -165,7 +165,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
             }
 
             $property->setType('array');
-            $this->describeItem($nestedType, $property->getItems(), $groups);
+            $this->describeItem($nestedType, $property->getItems(), $groups, $previousGroups);
         } elseif ('array' === $type['name']) {
             $property->setType('object');
             $property->merge(['additionalProperties' => []]);

--- a/Tests/Functional/Controller/JMSController.php
+++ b/Tests/Functional/Controller/JMSController.php
@@ -17,6 +17,7 @@ use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSDualComplex;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSNamingStrategyConstraints;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSUser;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup\JMSChat;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup\JMSChatRoomUser;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup\JMSChatUser;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup\JMSPicture;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\VirtualProperty;
@@ -121,6 +122,18 @@ class JMSController
      * )
      */
     public function minUserAction()
+    {
+    }
+
+    /**
+     * @Route("/api/jms_mini_user_nested", methods={"GET"})
+     * @SWG\Response(
+     *     response=200,
+     *     description="Success",
+     *     @Model(type=JMSChatRoomUser::class, groups={"mini", "friend": {"living":{"Default"}}})
+     * )
+     */
+    public function minUserNestedAction()
     {
     }
 }

--- a/Tests/Functional/Entity/BazingaUser.php
+++ b/Tests/Functional/Entity/BazingaUser.php
@@ -18,7 +18,7 @@ use Hateoas\Configuration\Annotation as Hateoas;
  *
  * @Hateoas\Relation(name="example", attributes={"str_att":"bar", "float_att":5.6, "bool_att": false}, href="http://www.example.com")
  * @Hateoas\Relation(name="route", href=@Hateoas\Route("foo"))
- * @Hateoas\Relation(name="route", attributes={"foo":"bar"}, embedded=@Hateoas\Embedded("expr(foo)"))
+ * @Hateoas\Relation(name="route", attributes={"foo":"bar"}, embedded=@Hateoas\Embedded("expr(service('xx'))"))
  */
 class BazingaUser
 {

--- a/Tests/Functional/Entity/NestedGroup/JMSChatFriend.php
+++ b/Tests/Functional/Entity/NestedGroup/JMSChatFriend.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * User.
+ *
+ * @Serializer\ExclusionPolicy("all")
+ */
+class JMSChatFriend
+{
+    /**
+     * @Serializer\Type("Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup\JMSChatRoom")
+     * @Serializer\Expose
+     * @Serializer\Groups({"mini"})
+     */
+    private $room;
+
+    /**
+     * @Serializer\Type("Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup\JMSChatLivingRoom")
+     * @Serializer\Expose
+     * @Serializer\Groups({"Default"})
+     */
+    private $living;
+
+    /**
+     * @Serializer\Type("Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup\JMSChatRoom")
+     * @Serializer\Expose
+     */
+    private $dining;
+}

--- a/Tests/Functional/Entity/NestedGroup/JMSChatLivingRoom.php
+++ b/Tests/Functional/Entity/NestedGroup/JMSChatLivingRoom.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * User.
+ *
+ * @Serializer\ExclusionPolicy("all")
+ */
+class JMSChatLivingRoom
+{
+    /**
+     * @Serializer\Type("integer")
+     * @Serializer\Expose
+     */
+    private $id;
+}

--- a/Tests/Functional/Entity/NestedGroup/JMSChatRoom.php
+++ b/Tests/Functional/Entity/NestedGroup/JMSChatRoom.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * User.
+ *
+ * @Serializer\ExclusionPolicy("all")
+ */
+class JMSChatRoom
+{
+    /**
+     * @Serializer\Type("integer")
+     * @Serializer\Expose
+     * @Serializer\Groups({"Default"})
+     */
+    private $id1;
+
+    /**
+     * @Serializer\Type("integer")
+     * @Serializer\Expose
+     * @Serializer\Groups({"mini"})
+     */
+    private $id2;
+
+    /**
+     * @Serializer\Type("integer")
+     * @Serializer\Expose
+     */
+    private $id3;
+}

--- a/Tests/Functional/Entity/NestedGroup/JMSChatRoomUser.php
+++ b/Tests/Functional/Entity/NestedGroup/JMSChatRoomUser.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * User.
+ *
+ * @Serializer\ExclusionPolicy("all")
+ */
+class JMSChatRoomUser
+{
+    /**
+     * @Serializer\Type("integer")
+     * @Serializer\Expose
+     */
+    private $id;
+
+    /**
+     * @Serializer\Type("Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup\JMSChatFriend")
+     * @Serializer\Expose
+     * @Serializer\Groups({"mini"})
+     */
+    private $friend;
+}

--- a/Tests/Functional/JMSFunctionalTest.php
+++ b/Tests/Functional/JMSFunctionalTest.php
@@ -11,6 +11,8 @@
 
 namespace Nelmio\ApiDocBundle\Tests\Functional;
 
+use JMS\Serializer\Visitor\SerializationVisitorInterface;
+
 class JMSFunctionalTest extends WebTestCase
 {
     public function testModelPictureDocumentation()
@@ -190,6 +192,59 @@ class JMSFunctionalTest extends WebTestCase
                 ],
             ],
         ], $this->getModel('JMSDualComplex')->toArray());
+    }
+
+    public function testNestedGroupsV1()
+    {
+        if (interface_exists(SerializationVisitorInterface::class)){
+            $this->markTestSkipped('This applies only for jms/serializer v1.x');
+        }
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'living' => ['$ref' => '#/definitions/JMSChatLivingRoom'],
+                'dining' => ['$ref' => '#/definitions/JMSChatRoom'],
+            ],
+        ], $this->getModel('JMSChatFriend')->toArray());
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'id1' => ['type' => 'integer'],
+                'id2' => ['type' => 'integer'],
+                'id3' => ['type' => 'integer'],
+            ],
+        ], $this->getModel('JMSChatRoom')->toArray());
+    }
+
+    public function testNestedGroupsV2()
+    {
+        if (!interface_exists(SerializationVisitorInterface::class)){
+           $this->markTestSkipped('This applies only for jms/serializer v2.x');
+        }
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'living' => ['$ref' => '#/definitions/JMSChatLivingRoom'],
+                'dining' => ['$ref' => '#/definitions/JMSChatRoom'],
+            ],
+        ], $this->getModel('JMSChatFriend')->toArray());
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'id2' => ['type' => 'integer'],
+            ],
+        ], $this->getModel('JMSChatRoom')->toArray());
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'id' => ['type' => 'integer'],
+            ],
+        ], $this->getModel('JMSChatLivingRoom')->toArray());
     }
 
     public function testModelComplexDocumentation()

--- a/Tests/Functional/JMSFunctionalTest.php
+++ b/Tests/Functional/JMSFunctionalTest.php
@@ -48,7 +48,7 @@ class JMSFunctionalTest extends WebTestCase
             'type' => 'object',
             'properties' => [
                 'picture' => [
-                    '$ref' => '#/definitions/JMSPicture',
+                    '$ref' => '#/definitions/JMSPicture2',
                 ],
             ],
         ], $this->getModel('JMSChatUser')->toArray());

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "api-platform/core": "^2.1.0",
         "friendsofsymfony/rest-bundle": "^2.0",
         "willdurand/hateoas-bundle": "^1.0",
-        "jms/serializer-bundle": "^2.0"
+        "jms/serializer-bundle": "^2.0|^3.0"
     },
     "suggest": {
         "api-platform/core": "For using an API oriented framework.",

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
 
         "api-platform/core": "^2.1.0",
         "friendsofsymfony/rest-bundle": "^2.0",
-        "willdurand/hateoas-bundle": "^1.0",
+        "willdurand/hateoas-bundle": "^1.0|^2.0",
         "jms/serializer-bundle": "^2.0|^3.0"
     },
     "suggest": {


### PR DESCRIPTION
This introduces support for  jms/serializer v2.0

It looks that because of dependencies, this will work only when both FOSRestBundle and BazingaHateoasBundle will support jms/serializer v2.0

Closes https://github.com/nelmio/NelmioApiDocBundle/issues/1464
Closes https://github.com/nelmio/NelmioApiDocBundle/issues/1437