### PR TITLE
Fix deprecation for symfony/config 4.2+

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,9 +18,15 @@ final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $treeBuilder
-            ->root('nelmio_api_doc')
+        $treeBuilder = new TreeBuilder('nelmio_api_doc');
+        if (method_exists($treeBuilder, 'getRootNode')) {                                                                                                                                
+            $rootNode = $treeBuilder->getRootNode();                                                                                                                                     
+        } else {                                                                                                                                                                         
+            // BC layer for symfony/config 4.1 and older                                                                                                                                 
+            $rootNode = $treeBuilder->root('nelmio_api_doc');                                                                                                                            
+        }                                                                                                                                                                                
+
+        $rootNode 
             ->beforeNormalization()
                 ->ifTrue(function ($v) {
                     return !isset($v['areas']) && isset($v['routes']);


### PR DESCRIPTION
Fix the "A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0" deprecation; same as https://github.com/doctrine/DoctrineBundle/pull/853