### PR TITLE
Change validation to allow fields described as DateTimeInterface.

### DIFF
--- a/ModelDescriber/ObjectModelDescriber.php
+++ b/ModelDescriber/ObjectModelDescriber.php
@@ -106,7 +106,7 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
                 $property->setType('number');
                 $property->setFormat('float');
             } elseif (Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType()) {
-                if (is_subclass_of($type->getClassName(), \DateTimeInterface::class)) {
+                if (is_a($type->getClassName(), \DateTimeInterface::class, true)) {
                     $property->setType('string');
                     $property->setFormat('date-time');
                 } else {

--- a/Tests/Functional/Entity/User.php
+++ b/Tests/Functional/Entity/User.php
@@ -79,6 +79,11 @@ class User
     private $status;
 
     /**
+     * @var \DateTimeInterface
+     */
+    private $dateAsInterface;
+
+    /**
      * @param float $money
      */
     public function setMoney(float $money)
@@ -133,5 +138,21 @@ class User
 
     public function setStatus(string $status)
     {
+    }
+
+    /**
+     * @return \DateTimeInterface
+     */
+    public function getDateAsInterface(): \DateTimeInterface
+    {
+        return $this->dateAsInterface;
+    }
+
+    /**
+     * @param \DateTimeInterface $dateAsInterface
+     */
+    public function setDateAsInterface(\DateTimeInterface $dateAsInterface)
+    {
+        $this->dateAsInterface = $dateAsInterface;
     }
 }

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -220,6 +220,10 @@ class FunctionalTest extends WebTestCase
                         'type' => 'string',
                         'enum' => ['disabled', 'enabled'],
                     ],
+                    'dateAsInterface' => [
+                        'type' => 'string',
+                        'format' => 'date-time',
+                    ]
                 ],
             ],
             $this->getModel('User')->toArray()

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -223,7 +223,7 @@ class FunctionalTest extends WebTestCase
                     'dateAsInterface' => [
                         'type' => 'string',
                         'format' => 'date-time',
-                    ]
+                    ],
                 ],
             ],
             $this->getModel('User')->toArray()


### PR DESCRIPTION
My models are described using interfaces, but when I tried to use "DateTimeInterface" wasn't working, only after change do DateTime or other custom DateTime format the documentation works.

The error:
```
The PropertyInfo component was not able to guess the type of DateTimeInterface::$timezone
```