### PR TITLE
Fixed deprecated use of TreeBuilder.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,10 +23,11 @@ final class Configuration implements ConfigurationInterface
         // For compatibility with older versions
         if(!method_exists($treeBuilder, 'getRootNode')) {
             $rootNode = $treeBuilder->root('nelmio_api_doc');
+        } else {
+            $rootNode = $treeBuilder->getRootNode();
         }
 
         $rootNode
-            ->getRootNode()
             ->beforeNormalization()
                 ->ifTrue(function ($v) {
                     return !isset($v['areas']) && isset($v['routes']);

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -21,10 +21,10 @@ final class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('nelmio_api_doc');
 
         // For compatibility with older versions
-        if(!method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->root('nelmio_api_doc');
-        } else {
+        if (method_exists($treeBuilder, 'getRootNode')) {
             $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('fos_rest');
         }
 
         $rootNode

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,9 +18,9 @@ final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder('nelmio_api_doc');
         $treeBuilder
-            ->root('nelmio_api_doc')
+            ->getRootNode()
             ->beforeNormalization()
                 ->ifTrue(function ($v) {
                     return !isset($v['areas']) && isset($v['routes']);

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,7 +27,7 @@ final class Configuration implements ConfigurationInterface
             $rootNode = $treeBuilder->root('nelmio_api_doc');
         }
 
-        $rootNode
+        $rootNode->children()
             ->beforeNormalization()
                 ->ifTrue(function ($v) {
                     return !isset($v['areas']) && isset($v['routes']);

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,7 +19,13 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('nelmio_api_doc');
-        $treeBuilder
+
+        // For compatibility with older versions
+        if(!method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->root('nelmio_api_doc');
+        }
+
+        $rootNode
             ->getRootNode()
             ->beforeNormalization()
                 ->ifTrue(function ($v) {
@@ -115,6 +121,6 @@ final class Configuration implements ConfigurationInterface
                 ->end()
             ->end();
 
-        return $treeBuilder;
+        return $rootNode;
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -24,7 +24,7 @@ final class Configuration implements ConfigurationInterface
         if (method_exists($treeBuilder, 'getRootNode')) {
             $rootNode = $treeBuilder->getRootNode();
         } else {
-            $rootNode = $treeBuilder->root('fos_rest');
+            $rootNode = $treeBuilder->root('nelmio_api_doc');
         }
 
         $rootNode


### PR DESCRIPTION
(A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.)