### PR TITLE
Add `options` parameter to `@Model` (#1286)

### DIFF
--- a/Annotation/Model.php
+++ b/Annotation/Model.php
@@ -22,6 +22,7 @@ final class Model extends AbstractAnnotation
     public static $_types = [
         'type' => 'string',
         'groups' => '[string]',
+        'options' => '[mixed]',
     ];
 
     public static $_required = ['type'];
@@ -40,4 +41,9 @@ final class Model extends AbstractAnnotation
      * @var string[]
      */
     public $groups;
+
+    /**
+     * @var mixed[]
+     */
+    public $options;
 }

--- a/Model/Model.php
+++ b/Model/Model.php
@@ -19,13 +19,17 @@ final class Model
 
     private $groups;
 
+    private $options;
+
     /**
      * @param string[]|null $groups
+     * @param mixed[]|null $options
      */
-    public function __construct(Type $type, array $groups = null)
+    public function __construct(Type $type, array $groups = null, array $options = null)
     {
         $this->type = $type;
         $this->groups = $groups;
+        $this->options = $options;
     }
 
     /**
@@ -42,6 +46,14 @@ final class Model
     public function getGroups()
     {
         return $this->groups;
+    }
+
+    /**
+     * @return mixed[]|null
+     */
+    public function getOptions()
+    {
+        return $this->options;
     }
 
     public function getHash(): string

--- a/ModelDescriber/FormModelDescriber.php
+++ b/ModelDescriber/FormModelDescriber.php
@@ -53,7 +53,7 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
 
         $class = $model->getType()->getClassName();
 
-        $form = $this->formFactory->create($class, null, []);
+        $form = $this->formFactory->create($class, null, $model->getOptions() ?? []);
         $this->parseForm($definition, $form);
     }
 
@@ -98,7 +98,11 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
 
         if (!$builtinFormType = $this->getBuiltinFormType($type)) {
             // if form type is not builtin in Form component.
-            $model = new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, get_class($type->getInnerType())));
+            $model = new Model(
+                new Type(Type::BUILTIN_TYPE_OBJECT, false, get_class($type->getInnerType())),
+                null,
+                $config->getOptions()
+            );
             $property->ref = $this->modelRegistry->register($model);
 
             return;

--- a/SwaggerPhp/ModelRegister.php
+++ b/SwaggerPhp/ModelRegister.php
@@ -45,7 +45,7 @@ final class ModelRegister
                 $model = $annotation->ref;
 
                 $annotation->ref = $this->modelRegistry->register(
-                    new Model($this->createType($model->type), $this->getGroups($model, $parentGroups))
+                    new Model($this->createType($model->type), $this->getGroups($model, $parentGroups), $model->options)
                 );
 
                 // It is no longer an unmerged annotation
@@ -93,7 +93,7 @@ final class ModelRegister
 
             Util::getChild($annotation, $annotationClass, [
                 'ref' => $this->modelRegistry->register(
-                    new Model($this->createType($model->type), $this->getGroups($model, $parentGroups))
+                    new Model($this->createType($model->type), $this->getGroups($model, $parentGroups), $model->options)
                 ),
             ]);
 

--- a/Tests/Functional/Controller/ApiController.php
+++ b/Tests/Functional/Controller/ApiController.php
@@ -20,6 +20,7 @@ use Nelmio\ApiDocBundle\Tests\Functional\Entity\Article;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\SymfonyConstraints;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\User;
 use Nelmio\ApiDocBundle\Tests\Functional\Form\DummyType;
+use Nelmio\ApiDocBundle\Tests\Functional\Form\OptionType;
 use Nelmio\ApiDocBundle\Tests\Functional\Form\UserType;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Swagger\Annotations as SWG;
@@ -90,7 +91,7 @@ class ApiController
      *     name="foo",
      *     in="body",
      *     description="This is a parameter",
-     *     @SWG\Schema(ref=@Model(type=UserType::class))
+     *     @SWG\Schema(ref=@Model(type=UserType::class, options={"bar": "baz"}))
      * )
      */
     public function submitUserTypeAction()

--- a/Tests/Functional/Form/UserType.php
+++ b/Tests/Functional/Form/UserType.php
@@ -48,5 +48,7 @@ class UserType extends AbstractType
         $resolver->setDefaults([
             'data_class' => User::class,
         ]);
+
+        $resolver->setRequired('bar');
     }
 }


### PR DESCRIPTION
Add `options` parameter to `@Model`, so that specific option could be passed to the form which have a required one.

`@Model(type=SomeType::class, options={"bar": "baz"})`