### PR TITLE
Add implementation of FormTypeExtensionInterface::getExtendedTypes

### DIFF
--- a/Form/Extension/DocumentationExtension.php
+++ b/Form/Extension/DocumentationExtension.php
@@ -34,6 +34,11 @@ class DocumentationExtension extends AbstractTypeExtension
 
     public function getExtendedType()
     {
-        return FormType::class;
+        return self::getExtendedTypes()[0];
+    }
+
+    public static function getExtendedTypes()
+    {
+        return [FormType::class];
     }
 }


### PR DESCRIPTION
Add method that leads to deprecation message when missed:


> Not implementing the static getExtendedTypes() method in Nelmio\ApiDocBundle\Form\Extension\DocumentationExtension when implementing the Symfony\Component\Form\FormTypeExtensionInterface is deprecated since Symfony 4.2. The method will be added to the interface in 5.0.


Fixes #1448