### PR TITLE
Cache authorization in local storage.

### DIFF
--- a/Resources/public/init-swagger-ui.js
+++ b/Resources/public/init-swagger-ui.js
@@ -21,5 +21,30 @@ window.onload = () => {
     layout: 'StandaloneLayout'
   });
 
+  const storageKey = 'nelmio_api_auth';
+
+  // if we have auth in storage use it
+  if (sessionStorage.getItem(storageKey)) {
+    try {
+      ui.authActions.authorize(JSON.parse(sessionStorage.getItem(storageKey)));
+    } catch (ignored) {
+      // catch any errors here so it does not stop script execution
+    }
+  }
+
+  // hook into authorize to store the auth in local storage when user performs authorization
+  const currentAuthorize = ui.authActions.authorize;
+  ui.authActions.authorize = function (payload) {
+    sessionStorage.setItem(storageKey, JSON.stringify(payload));
+    return currentAuthorize(payload);
+  };
+
+  // hook into logout to clear auth from storage if user logs out
+  const currentLogout = ui.authActions.logout;
+  ui.authActions.logout = function (payload) {
+    sessionStorage.removeItem(storageKey);
+    return currentLogout(payload);
+  };
+
   window.ui = ui;
 };


### PR DESCRIPTION
Currently user has to provide authorization every time page is refreshed. During development this becomes extremely annoying as after every change you need to refresh the page and thus re-authorize.

This PR hooks into the swagger authorization mechanism to store the authorization in local storage and restore it on page reload (essentially providing the behavior of API Key storage like it was in V2)