### PR TITLE
add a way to filter areas on route by annotation

### DIFF
--- a/Annotation/Areas.php
+++ b/Annotation/Areas.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Annotation;
+
+/**
+ * @Annotation
+ */
+final class Areas
+{
+    /** @var string[] */
+    private $areas;
+
+    public function __construct(array $properties)
+    {
+        if (!array_key_exists('value', $properties) || !is_array($properties['value'])) {
+            throw new \InvalidArgumentException('An array of areas was expected');
+        }
+
+        $areas = [];
+        foreach ($properties['value'] as $area) {
+            if (!is_string($area)) {
+                throw new \InvalidArgumentException('An area must be given as a string');
+            }
+
+            if (!in_array($area, $areas)) {
+                $areas[] = $area;
+            }
+        }
+
+        if (0 === count($areas)) {
+            throw new \LogicException('At least one area is expected');
+        }
+
+        $this->areas = $areas;
+    }
+
+    public function has(string $area): bool
+    {
+        return in_array($area, $this->areas, true);
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -48,7 +48,16 @@ final class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('areas')
                     ->info('Filter the routes that are documented')
-                    ->defaultValue(['default' => ['path_patterns' => [], 'host_patterns' => [], 'documentation' => []]])
+                    ->defaultValue(
+                        [
+                            'default' => [
+                                'path_patterns' => [],
+                                'host_patterns' => [],
+                                'with_annotation' => false,
+                                'documentation' => [],
+                            ],
+                        ]
+                    )
                     ->beforeNormalization()
                         ->ifTrue(function ($v) {
                             return 0 === count($v) || isset($v['path_patterns']) || isset($v['host_patterns']) || isset($v['documentation']);
@@ -76,6 +85,10 @@ final class Configuration implements ConfigurationInterface
                                 ->defaultValue([])
                                 ->example(['^api\.'])
                                 ->prototype('scalar')->end()
+                            ->end()
+                            ->booleanNode('with_annotation')
+                                ->defaultFalse()
+                                ->info('whether to filter by annotation')
                             ->end()
                             ->arrayNode('documentation')
                                 ->useAttributeAsKey('key')

--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -100,7 +100,10 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
                 ->addTag(sprintf('nelmio_api_doc.describer.%s', $area), ['priority' => 990]);
 
             unset($areaConfig['documentation']);
-            if (0 === count($areaConfig['path_patterns']) && 0 === count($areaConfig['host_patterns'])) {
+            if (0 === count($areaConfig['path_patterns'])
+                && 0 === count($areaConfig['host_patterns'])
+                && false === $areaConfig['with_annotation']
+            ) {
                 $container->setDefinition(sprintf('nelmio_api_doc.routes.%s', $area), $routesDefinition)
                     ->setPublic(false);
             } else {
@@ -108,7 +111,14 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
                     ->setPublic(false)
                     ->setFactory([
                         (new Definition(FilteredRouteCollectionBuilder::class))
-                            ->addArgument($areaConfig),
+                            ->setArguments(
+                                [
+                                    new Reference('annotation_reader'),
+                                    new Reference('nelmio_api_doc.controller_reflector'),
+                                    $area,
+                                    $areaConfig,
+                                ]
+                            ),
                         'filter',
                     ])
                     ->addArgument($routesDefinition);

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -22,16 +22,41 @@ class ConfigurationTest extends TestCase
         $processor = new Processor();
         $config = $processor->processConfiguration(new Configuration(), [['areas' => ['path_patterns' => ['/foo']]]]);
 
-        $this->assertSame(['default' => ['path_patterns' => ['/foo'], 'host_patterns' => [], 'documentation' => []]], $config['areas']);
+        $this->assertSame(
+            [
+                'default' => [
+                    'path_patterns' => ['/foo'],
+                    'host_patterns' => [],
+                    'with_annotation' => false,
+                    'documentation' => [],
+                ],
+            ],
+            $config['areas']
+        );
     }
 
     public function testAreas()
     {
         $processor = new Processor();
         $config = $processor->processConfiguration(new Configuration(), [['areas' => $areas = [
-            'default' => ['path_patterns' => ['/foo'], 'host_patterns' => [], 'documentation' => []],
-            'internal' => ['path_patterns' => ['/internal'], 'host_patterns' => ['^swagger\.'], 'documentation' => []],
-            'commercial' => ['path_patterns' => ['/internal'], 'host_patterns' => [], 'documentation' => []],
+            'default' => [
+                'path_patterns' => ['/foo'],
+                'host_patterns' => [],
+                'with_annotation' => false,
+                'documentation' => [],
+            ],
+            'internal' => [
+                'path_patterns' => ['/internal'],
+                'host_patterns' => ['^swagger\.'],
+                'with_annotation' => false,
+                'documentation' => [],
+            ],
+            'commercial' => [
+                'path_patterns' => ['/internal'],
+                'host_patterns' => [],
+                'with_annotation' => false,
+                'documentation' => [],
+            ],
         ]]]);
 
         $this->assertSame($areas, $config['areas']);
@@ -136,6 +161,16 @@ class ConfigurationTest extends TestCase
         $processor = new Processor();
         $config = $processor->processConfiguration(new Configuration(), [['routes' => ['path_patterns' => ['/foo']]]]);
 
-        $this->assertSame(['default' => ['path_patterns' => ['/foo'], 'host_patterns' => [], 'documentation' => []]], $config['areas']);
+        $this->assertSame(
+            [
+                'default' => [
+                    'path_patterns' => ['/foo'],
+                    'host_patterns' => [],
+                    'with_annotation' => false,
+                    'documentation' => [],
+                ],
+            ],
+            $config['areas']
+        );
     }
 }

--- a/Tests/Functional/Controller/ApiController.php
+++ b/Tests/Functional/Controller/ApiController.php
@@ -13,6 +13,7 @@ namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
 
 use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\RequestParam;
+use Nelmio\ApiDocBundle\Annotation\Areas;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use Nelmio\ApiDocBundle\Annotation\Operation;
 use Nelmio\ApiDocBundle\Annotation\Security;
@@ -209,6 +210,15 @@ class ApiController
      * @SWG\Response(response=200, description="Worked well!", @Model(type=DummyType::class))
      */
     public function operationsWithOtherAnnotations()
+    {
+    }
+
+    /**
+     * @Route("/areas/new", methods={"GET", "POST"})
+     *
+     * @Areas({"area", "area2"})
+     */
+    public function newAreaAction()
     {
     }
 }

--- a/Tests/Routing/FilteredRouteCollectionBuilderTest.php
+++ b/Tests/Routing/FilteredRouteCollectionBuilderTest.php
@@ -11,8 +11,14 @@
 
 namespace Nelmio\ApiDocBundle\Tests\Routing;
 
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\Reader;
+use Nelmio\ApiDocBundle\Annotation\Areas;
 use Nelmio\ApiDocBundle\Routing\FilteredRouteCollectionBuilder;
+use Nelmio\ApiDocBundle\Util\ControllerReflector;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -39,7 +45,15 @@ class FilteredRouteCollectionBuilderTest extends TestCase
             $routes->add($name, $route);
         }
 
-        $routeBuilder = new FilteredRouteCollectionBuilder($options);
+        $routeBuilder = new FilteredRouteCollectionBuilder(
+            new AnnotationReader(),
+            new ControllerReflector(
+                new Container(),
+                $this->createMock(ControllerNameParser::class)
+            ),
+            'areaName',
+            $options
+        );
         $filteredRoutes = $routeBuilder->filter($routes);
 
         $this->assertCount(4, $filteredRoutes);
@@ -61,7 +75,15 @@ class FilteredRouteCollectionBuilderTest extends TestCase
             $routes->add($name, $route);
         }
 
-        $routeBuilder = new FilteredRouteCollectionBuilder($pathPattern);
+        $routeBuilder = new FilteredRouteCollectionBuilder(
+            new AnnotationReader(),
+            new ControllerReflector(
+                new Container(),
+                $this->createMock(ControllerNameParser::class)
+            ),
+            'areaName',
+            $pathPattern
+        );
         $filteredRoutes = $routeBuilder->filter($routes);
 
         $this->assertCount(5, $filteredRoutes);
@@ -74,7 +96,15 @@ class FilteredRouteCollectionBuilderTest extends TestCase
      */
     public function testFilterWithInvalidOption(array $options)
     {
-        new FilteredRouteCollectionBuilder($options);
+        new FilteredRouteCollectionBuilder(
+            new AnnotationReader(),
+            new ControllerReflector(
+                new Container(),
+                $this->createMock(ControllerNameParser::class)
+            ),
+            'areaName',
+            $options
+        );
     }
 
     public function getInvalidOptions(): array
@@ -87,6 +117,9 @@ class FilteredRouteCollectionBuilderTest extends TestCase
             [['path_patterns' => [null]]],
             [['path_patterns' => [new \stdClass()]]],
             [['path_patterns' => ['^/foo$', 1]]],
+            [['with_annotation' => ['an array']]],
+            [['path_patterns' => 'a string']],
+            [['path_patterns' => 11]],
         ];
     }
 
@@ -102,6 +135,7 @@ class FilteredRouteCollectionBuilderTest extends TestCase
             'r7' => new Route('/api/bar/action1', [], [], [], 'www.example.com'),
             'r8' => new Route('/admin/bar/action1', [], [], [], 'api.example.com'),
             'r9' => new Route('/api/bar/action1', [], [], [], 'api.example.com'),
+            'r10' => new Route('/api/areas/new'),
         ];
     }
 
@@ -113,7 +147,15 @@ class FilteredRouteCollectionBuilderTest extends TestCase
         $routes = new RouteCollection();
         $routes->add($name, $route);
 
-        $routeBuilder = new FilteredRouteCollectionBuilder($options);
+        $routeBuilder = new FilteredRouteCollectionBuilder(
+            new AnnotationReader(),
+            new ControllerReflector(
+                new Container(),
+                $this->createMock(ControllerNameParser::class)
+            ),
+            'area',
+            $options
+        );
         $filteredRoutes = $routeBuilder->filter($routes);
 
         $this->assertCount(1, $filteredRoutes);
@@ -127,6 +169,55 @@ class FilteredRouteCollectionBuilderTest extends TestCase
             ['r3', new Route('/api/foo/action2'), ['path_patterns' => ['^/api/foo/action2$']]],
             ['r4', new Route('/api/demo'), ['path_patterns' => ['/api/demo']]],
             ['r9', new Route('/api/bar/action1', [], [], [], 'api.example.com'), ['path_patterns' => ['^/api/'], 'host_patterns' => ['^api\.ex']]],
+            ['r10', new Route('/api/areas/new'), ['path_patterns' => ['^/api']]],
+        ];
+    }
+
+    /**
+     * @group test
+     * @dataProvider getMatchingRoutesWithAnnotation
+     */
+    public function testMatchingRoutesWithAnnotation(string $name, Route $route, array $options = [])
+    {
+        $routes = new RouteCollection();
+        $routes->add($name, $route);
+        $area = 'area';
+
+        $reflectionMethodStub = $this->createMock(\ReflectionMethod::class);
+        $controllerReflectorStub = $this->createMock(ControllerReflector::class);
+        $controllerReflectorStub->method('getReflectionMethod')->willReturn($reflectionMethodStub);
+
+        $annotationReader = $this->createMock(Reader::class);
+        $annotationReader
+            ->method('getMethodAnnotation')
+            ->with($reflectionMethodStub, Areas::class)
+            ->willReturn(new Areas(['value' => [$area]]))
+        ;
+
+        $routeBuilder = new FilteredRouteCollectionBuilder(
+            $annotationReader,
+            $controllerReflectorStub,
+            $area,
+            $options
+        );
+        $filteredRoutes = $routeBuilder->filter($routes);
+
+        $this->assertCount(1, $filteredRoutes);
+    }
+
+    public function getMatchingRoutesWithAnnotation(): array
+    {
+        return [
+            'with annotation only' => [
+                'r10',
+                new Route('/api/areas/new', ['_controller' => 'ApiController::newAreaAction']),
+                ['with_annotation' => true],
+            ],
+            'with annotation and path patterns' => [
+                'r10',
+                new Route('/api/areas/new', ['_controller' => 'ApiController::newAreaAction']),
+                ['path_patterns' => ['^/api'], 'with_annotation' => true],
+            ],
         ];
     }
 
@@ -138,7 +229,15 @@ class FilteredRouteCollectionBuilderTest extends TestCase
         $routes = new RouteCollection();
         $routes->add($name, $route);
 
-        $routeBuilder = new FilteredRouteCollectionBuilder($options);
+        $routeBuilder = new FilteredRouteCollectionBuilder(
+            new AnnotationReader(),
+            new ControllerReflector(
+                new Container(),
+                $this->createMock(ControllerNameParser::class)
+            ),
+            'areaName',
+            $options
+        );
         $filteredRoutes = $routeBuilder->filter($routes);
 
         $this->assertCount(0, $filteredRoutes);

--- a/Util/ControllerReflector.php
+++ b/Util/ControllerReflector.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * @internal
  */
-final class ControllerReflector
+class ControllerReflector
 {
     private $container;
 


### PR DESCRIPTION
Fix https://github.com/nelmio/NelmioApiDocBundle/issues/1246

### Description

A new boolean configuration is available in the areas: `with_annotation`.
By setting it to true, every route will be filtered by annotation.
Every route to match will need to add the `@Areas` with the area name.

### Example

the `default` area would only match the testAction(), while the `area2` will match both.

```yaml
areas:
    default:
        path_patterns:
            - '^/api/'
        with_annotation: true
    area2:
        with_annotation: true
```

```php
class ApiController
{
    /**
     * @Areas({'default', 'area2'})
     */
    public function testAction()
    {
    }

    /**
     * @Areas({'area2'})
     */
    public function test2Action()
    {
    }
}
```