### PR TITLE
Fix documentation decoration with API Platform

### DIFF
--- a/Describer/ApiPlatformDescriber.php
+++ b/Describer/ApiPlatformDescriber.php
@@ -12,19 +12,17 @@
 namespace Nelmio\ApiDocBundle\Describer;
 
 use ApiPlatform\Core\Documentation\Documentation;
-use ApiPlatform\Core\Swagger\Serializer\ApiGatewayNormalizer;
-use ApiPlatform\Core\Swagger\Serializer\DocumentationNormalizer;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 final class ApiPlatformDescriber extends ExternalDocDescriber
 {
-    public function __construct(Documentation $documentation, $normalizer, UrlGeneratorInterface $urlGenerator)
+    public function __construct(Documentation $documentation, NormalizerInterface $normalizer)
     {
-        if (!$normalizer instanceof ApiGatewayNormalizer && !$normalizer instanceof DocumentationNormalizer) {
-            throw new \InvalidArgumentException(sprintf('Argument 2 passed to %s() must be an instance of %s or %s, %s given.', __METHOD__, ApiGatewayNormalizer::class, DocumentationNormalizer::class, get_class($normalizer)));
+        if (!$normalizer->supportsNormalization($documentation, 'json')) {
+            throw new \InvalidArgumentException(sprintf('Argument 2 passed to %s() must implement %s and support normalization of %s, %s given.', __METHOD__, NormalizerInterface::class, Documentation::class, get_class($normalizer)));
         }
 
-        parent::__construct(function () use ($documentation, $normalizer, $urlGenerator) {
+        parent::__construct(function () use ($documentation, $normalizer) {
             $documentation = (array) $normalizer->normalize($documentation);
             unset($documentation['basePath']);
 

--- a/Resources/config/api_platform.xml
+++ b/Resources/config/api_platform.xml
@@ -7,7 +7,6 @@
         <service id="nelmio_api_doc.describers.api_platform" class="Nelmio\ApiDocBundle\Describer\ApiPlatformDescriber" public="false">
             <argument type="service" id="nelmio_api_doc.describers.api_platform.documentation" />
             <argument type="service" id="api_platform.swagger.normalizer.documentation" />
-            <argument type="service" id="router" />
 
             <tag name="nelmio_api_doc.describer" priority="-100" />
         </service>

--- a/Tests/Describer/ApiPlatformDescriberTest.php
+++ b/Tests/Describer/ApiPlatformDescriberTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Describer;
+
+use ApiPlatform\Core\Documentation\Documentation;
+use ApiPlatform\Core\Metadata\Resource\ResourceNameCollection;
+use EXSyst\Component\Swagger\Swagger;
+use Nelmio\ApiDocBundle\Describer\ApiPlatformDescriber;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class ApiPlatformDescriberTest extends AbstractDescriberTest
+{
+    private $documentation;
+
+    private $normalizer;
+
+    public function testDescribe()
+    {
+        $this->normalizer->expects($this->once())
+            ->method('normalize')
+            ->with($this->documentation)
+            ->willReturn(['info' => ['title' => 'My Test App']]);
+
+        $expectedApi = new Swagger(['info' => ['title' => 'My Test App']]);
+        $this->assertEquals($expectedApi->toArray(), $this->getSwaggerDoc()->toArray());
+    }
+
+    public function testDescribeRemovesBasePathAfterNormalization()
+    {
+        $this->normalizer->expects($this->once())
+            ->method('normalize')
+            ->with($this->documentation)
+            ->willReturn(['info' => ['title' => 'My Test App'], 'basePath' => '/foo']);
+
+        $expectedApi = new Swagger(['info' => ['title' => 'My Test App']]);
+        $this->assertEquals($expectedApi->toArray(), $this->getSwaggerDoc()->toArray());
+    }
+
+    protected function setUp()
+    {
+        $this->documentation = new Documentation(new ResourceNameCollection(['dummy' => 'dummy']));
+
+        $this->normalizer = $this->createMock(NormalizerInterface::class);
+        $this->normalizer->expects($this->once())
+            ->method('supportsNormalization')
+            ->willReturn(true);
+
+        $this->describer = new ApiPlatformDescriber($this->documentation, $this->normalizer);
+    }
+}


### PR DESCRIPTION
Fixes #1462
Adjust ApiPlatformDescriber to allow any implementation of NormalizerInterface that supports normalization of the ApiPlatform Documentation class.

Also added a unit test for the class.