### PR TITLE
Fix schema in SwaggerDocblockConvertCommand

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -123,7 +123,7 @@ class SwaggerDocblockConvertCommand extends ContainerAwareCommand
 
             if ('POST' !== $apiDoc->getMethod()) {
                 $annotation .= ',
-     *         schema=""';
+     *         @SWG\Schema(type="'.$this->determineDataType($parameter).'")';
             }
 
             $annotation .= '


### PR DESCRIPTION
The generated "schema" did not follow the standard resulting in the following error: 

> Argument 1 passed to EXSyst\Component\Swagger\Schema::mergeExtensions() must be of the type array, string given

