### PR TITLE
Fix for missing basePath

### DIFF
--- a/Resources/doc/alternative_names.rst
+++ b/Resources/doc/alternative_names.rst
@@ -43,7 +43,7 @@ In this case the class ``App\Entity\User`` will be aliased into:
         class HomeController
         {
             /**
-             * @SWG\Response(response=200, @SWG\Schema(ref="MyModel"))
+             * @SWG\Response(response=200, @SWG\Schema(ref="#/definitions/MyModel"))
              */
             public function indexAction()
             {


### PR DESCRIPTION
If it is used without `#/definitions/` the documentation gives an error: `Could not resolve reference because of: Tried to resolve a relative URL, without having a basePath..`