### PR TITLE
Provide default host to generated .json documentation

### DIFF
--- a/Controller/DocumentationController.php
+++ b/Controller/DocumentationController.php
@@ -48,8 +48,13 @@ final class DocumentationController
         }
 
         $spec = $this->generatorLocator->get($area)->generate()->toArray();
+
         if ('' !== $request->getBaseUrl()) {
             $spec['basePath'] = $request->getBaseUrl();
+        }
+
+        if (empty($spec['host'])) {
+            $spec['host'] = $request->getHost();
         }
 
         return new JsonResponse($spec);

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -214,7 +214,7 @@ class FunctionalTest extends WebTestCase
                         '$ref' => '#/definitions/User',
                     ],
                     'dummy' => [
-                        '$ref' => '#/definitions/Dummy2',
+                        '$ref' => '#/definitions/Dummy',
                     ],
                     'status' => [
                         'type' => 'string',

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -214,7 +214,7 @@ class FunctionalTest extends WebTestCase
                         '$ref' => '#/definitions/User',
                     ],
                     'dummy' => [
-                        '$ref' => '#/definitions/Dummy',
+                        '$ref' => '#/definitions/Dummy2',
                     ],
                     'status' => [
                         'type' => 'string',

--- a/Tests/Functional/SwaggerUiTest.php
+++ b/Tests/Functional/SwaggerUiTest.php
@@ -43,9 +43,6 @@ class SwaggerUiTest extends WebTestCase
         // Api-platform documentation
         $expected['info']['title'] = 'My Test App';
         $expected['paths'] = [
-            '/api/dummies' => $expected['paths']['/api/dummies'],
-            '/api/foo' => $expected['paths']['/api/foo'],
-            '/api/dummies/{id}' => $expected['paths']['/api/dummies/{id}'],
             '/test/test/' => ['get' => [
                 'responses' => ['200' => ['description' => 'Test']],
             ]],
@@ -58,7 +55,7 @@ class SwaggerUiTest extends WebTestCase
     public function testJsonDocs()
     {
         $client = self::createClient();
-        $crawler = $client->request('GET', '/app_dev.php/docs.json');
+        $client->request('GET', '/app_dev.php/docs.json');
 
         $response = $client->getResponse();
         $this->assertEquals(200, $response->getStatusCode());
@@ -66,6 +63,7 @@ class SwaggerUiTest extends WebTestCase
 
         $expected = $this->getSwaggerDefinition()->toArray();
         $expected['basePath'] = '/app_dev.php';
+        $expected['host'] = 'api.example.com';
 
         $this->assertEquals($expected, json_decode($response->getContent(), true));
     }

--- a/Tests/Functional/SwaggerUiTest.php
+++ b/Tests/Functional/SwaggerUiTest.php
@@ -43,6 +43,9 @@ class SwaggerUiTest extends WebTestCase
         // Api-platform documentation
         $expected['info']['title'] = 'My Test App';
         $expected['paths'] = [
+            '/api/dummies' => $expected['paths']['/api/dummies'],
+            '/api/foo' => $expected['paths']['/api/foo'],
+            '/api/dummies/{id}' => $expected['paths']['/api/dummies/{id}'],
             '/test/test/' => ['get' => [
                 'responses' => ['200' => ['description' => 'Test']],
             ]],


### PR DESCRIPTION
In our scenario we can have multiples `urls` leading to the same project, and in the docs we can only provide one host to the complete documentation. To swagger ui it's not problem because the javascript if the `host` it's not provided, the `window.location` is used instead. So this pr is just to add the same behaviour to the .json generation. 

Another idea is provide a configuration to say something like `auto_discover_host`.

What do you think about it?

about build:
I don't from where this error is coming from.