### PR TITLE
Allow model describers on jms custom types

### DIFF
--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -173,6 +173,8 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
                         new Reference('nelmio_api_doc.model_describers.jms.inner'),
                     ]);
             }
+        } else {
+            $container->removeDefinition('nelmio_api_doc.model_describers.object_fallback');
         }
 
         // Import the base configuration

--- a/ModelDescriber/FallbackObjectModelDescriber.php
+++ b/ModelDescriber/FallbackObjectModelDescriber.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\ModelDescriber;
+
+use EXSyst\Component\Swagger\Schema;
+use Nelmio\ApiDocBundle\Model\Model;
+use Symfony\Component\PropertyInfo\Type;
+
+class FallbackObjectModelDescriber implements ModelDescriberInterface
+{
+    public function describe(Model $model, Schema $schema)
+    {
+    }
+
+    public function supports(Model $model): bool
+    {
+        return Type::BUILTIN_TYPE_OBJECT === $model->getType()->getBuiltinType();
+    }
+}

--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -177,11 +177,6 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
             $property->setType('string');
             $property->setFormat('date-time');
         } else {
-            // we can use property type also for custom handlers, then we don't have here real class name
-            if (!class_exists($type['name'])) {
-                return null;
-            }
-
             $model = new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, $type['name']), $groups);
             $property->setRef($this->modelRegistry->register($model));
 

--- a/ModelDescriber/ObjectModelDescriber.php
+++ b/ModelDescriber/ObjectModelDescriber.php
@@ -124,6 +124,6 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
 
     public function supports(Model $model): bool
     {
-        return Type::BUILTIN_TYPE_OBJECT === $model->getType()->getBuiltinType();
+        return Type::BUILTIN_TYPE_OBJECT === $model->getType()->getBuiltinType() && class_exists($model->getType()->getClassName());
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -46,6 +46,10 @@
             <tag name="nelmio_api_doc.model_describer" />
         </service>
 
+        <service id="nelmio_api_doc.model_describers.object_fallback" class="Nelmio\ApiDocBundle\ModelDescriber\FallbackObjectModelDescriber" public="false">
+            <tag name="nelmio_api_doc.model_describer" priority="-1000" />
+        </service>
+
         <!-- Form Type Extensions -->
 
         <service id="nelmio_api_doc.form.documentation_extension" class="Nelmio\ApiDocBundle\Form\Extension\DocumentationExtension">

--- a/Tests/Functional/Entity/JMSUser.php
+++ b/Tests/Functional/Entity/JMSUser.php
@@ -127,6 +127,24 @@ class JMSUser
     private $status;
 
     /**
+     * JMS custom types handled via Custom Type Handlers.
+     *
+     * @var string
+     * @Serializer\Type("VirtualTypeClassDoesNotExistsHandlerDefined")
+     * @Serializer\Expose
+     */
+    private $virtualType1;
+
+    /**
+     * JMS custom types handled via Custom Type Handlers.
+     *
+     * @var string
+     * @Serializer\Type("VirtualTypeClassDoesNotExistsHandlerNotDefined")
+     * @Serializer\Expose
+     */
+    private $virtualType2;
+
+    /**
      * @Serializer\Type("array<array<float>>")
      * @Serializer\Expose
      */

--- a/Tests/Functional/JMSFunctionalTest.php
+++ b/Tests/Functional/JMSFunctionalTest.php
@@ -121,6 +121,12 @@ class JMSFunctionalTest extends WebTestCase
                     'description' => 'Only enabled users may be used in actions.',
                     'enum' => ['disabled', 'enabled'],
                 ],
+                'virtual_type1' => [
+                    '$ref' => '#/definitions/VirtualTypeClassDoesNotExistsHandlerDefined',
+                ],
+                'virtual_type2' => [
+                    '$ref' => '#/definitions/VirtualTypeClassDoesNotExistsHandlerNotDefined',
+                ],
                 'last_update' => [
                     'type' => 'date',
                 ],
@@ -174,6 +180,18 @@ class JMSFunctionalTest extends WebTestCase
                 ],
             ],
         ], $this->getModel('JMSUser')->toArray());
+
+        $this->assertEquals([
+        ], $this->getModel('VirtualTypeClassDoesNotExistsHandlerNotDefined')->toArray());
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'custom_prop' => [
+                    'type' => 'string',
+                ],
+            ],
+        ], $this->getModel('VirtualTypeClassDoesNotExistsHandlerDefined')->toArray());
     }
 
     public function testModelComplexDualDocumentation()

--- a/Tests/Functional/ModelDescriber/VirtualTypeClassDoesNotExistsHandlerDefinedDescriber.php
+++ b/Tests/Functional/ModelDescriber/VirtualTypeClassDoesNotExistsHandlerDefinedDescriber.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\ModelDescriber;
+
+use EXSyst\Component\Swagger\Schema;
+use Nelmio\ApiDocBundle\Model\Model;
+use Nelmio\ApiDocBundle\ModelDescriber\ModelDescriberInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+class VirtualTypeClassDoesNotExistsHandlerDefinedDescriber implements ModelDescriberInterface
+{
+    public function describe(Model $model, Schema $schema)
+    {
+        $schema->setType('object');
+        $schema->getProperties()->get('custom_prop')->setType('string');
+    }
+
+    public function supports(Model $model): bool
+    {
+        return Type::BUILTIN_TYPE_OBJECT === $model->getType()->getBuiltinType()
+            && 'VirtualTypeClassDoesNotExistsHandlerDefined' === $model->getType()->getClassName();
+    }
+}

--- a/Tests/Functional/TestKernel.php
+++ b/Tests/Functional/TestKernel.php
@@ -16,12 +16,14 @@ use Bazinga\Bundle\HateoasBundle\BazingaHateoasBundle;
 use FOS\RestBundle\FOSRestBundle;
 use JMS\SerializerBundle\JMSSerializerBundle;
 use Nelmio\ApiDocBundle\NelmioApiDocBundle;
+use Nelmio\ApiDocBundle\Tests\Functional\ModelDescriber\VirtualTypeClassDoesNotExistsHandlerDefinedDescriber;
 use Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 
@@ -163,6 +165,10 @@ class TestKernel extends Kernel
                ],
             ],
         ]);
+
+        $def = new Definition(VirtualTypeClassDoesNotExistsHandlerDefinedDescriber::class);
+        $def->addTag('nelmio_api_doc.model_describer');
+        $c->setDefinition('nelmio.test.jms.virtual_type.describer', $def);
     }
 
     /**


### PR DESCRIPTION
Currently is not possible to describe at all custom jms type handlers (they are pretty common in complex apis). This change allows to describe via custom describers jms virtual types.


The change in behavior from the current status is substantial.
The current implementation will just not define the type for a property, while with this change sill throw an exception saying something as "Schema of type "...." can't be generated, no describer supports it".
This obliges the user to have all the types defined. Not sure if it is the best approach.

Solution used here is to add a fallback describer, defined for all the types, that just does nothing and emulates the current behavior.
The only drawback from this solution is that will create empty types jms virtual types... that could be a not bad thing.

@GuilhemN what do you think?
If you are ok with this changes I can add tests for this.