### PR TITLE
Support typed embedded relation with willdurand/hateoas 3.0

### DIFF
--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -118,6 +118,9 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
         $context->popClassMetadata();
     }
 
+    /**
+     * @internal
+     */
     public function getSerializationContext(Model $model): SerializationContext
     {
         if (isset($this->contexts[$model->getHash()])) {
@@ -178,6 +181,10 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
         return false;
     }
 
+    /**
+     * @internal
+     * @return void
+     */
     public function describeItem(array $type, $property, Context $context)
     {
         $nestedTypeInfo = $this->getNestedTypeInArray($type);

--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -118,7 +118,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
         $context->popClassMetadata();
     }
 
-    private function getSerializationContext(Model $model): SerializationContext
+    public function getSerializationContext(Model $model): SerializationContext
     {
         if (isset($this->contexts[$model->getHash()])) {
             $context = $this->contexts[$model->getHash()];
@@ -178,7 +178,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
         return false;
     }
 
-    private function describeItem(array $type, $property, Context $context)
+    public function describeItem(array $type, $property, Context $context)
     {
         $nestedTypeInfo = $this->getNestedTypeInArray($type);
         if (null !== $nestedTypeInfo) {

--- a/Tests/Functional/BazingaFunctionalTest.php
+++ b/Tests/Functional/BazingaFunctionalTest.php
@@ -11,6 +11,8 @@
 
 namespace Nelmio\ApiDocBundle\Tests\Functional;
 
+use Hateoas\Configuration\Embedded;
+
 class BazingaFunctionalTest extends WebTestCase
 {
     public function testModelComplexDocumentationBazinga()
@@ -57,10 +59,58 @@ class BazingaFunctionalTest extends WebTestCase
                         'route' => [
                             'type' => 'object',
                         ],
+                        'embed_with_group' => [
+                            'type' => 'object',
+                        ],
                     ],
                 ],
             ],
         ], $this->getModel('BazingaUser')->toArray());
+    }
+
+    public function testWithGroup()
+    {
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                '_embedded' => [
+                    'readOnly' => true,
+                    'properties' => [
+                        'embed_with_group' => [
+                            'type' => 'object',
+                        ],
+                    ],
+                ],
+            ],
+        ], $this->getModel('BazingaUser_grouped')->toArray());
+    }
+
+    public function testWithType()
+    {
+        try {
+            new \ReflectionMethod(Embedded::class, 'getType');
+        } catch (\ReflectionException $e) {
+            $this->markTestSkipped('Typed embedded properties require at least willdurand/hateoas 3.0');
+        }
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                '_embedded' => [
+                    'readOnly' => true,
+                    'properties' => [
+                        'typed_bazinga_users' => [
+                            'items' => [
+                                '$ref' => '#/definitions/BazingaUser',
+                            ],
+                            'type' => 'array',
+                        ],
+                        'typed_bazinga_name' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ], $this->getModel('BazingaUserTyped')->toArray());
     }
 
     protected static function createKernel(array $options = [])

--- a/Tests/Functional/Controller/BazingaTypedController.php
+++ b/Tests/Functional/Controller/BazingaTypedController.php
@@ -12,36 +12,24 @@
 namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
 
 use Nelmio\ApiDocBundle\Annotation\Model;
-use Nelmio\ApiDocBundle\Tests\Functional\Entity\BazingaUser;
+use Nelmio\ApiDocBundle\Tests\Functional\EntityExcluded\BazingaUserTyped;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Swagger\Annotations as SWG;
 
 /**
  * @Route(host="api.example.com")
  */
-class BazingaController
+class BazingaTypedController
 {
     /**
-     * @Route("/api/bazinga", methods={"GET"})
+     * @Route("/api/bazinga_typed", methods={"GET"})
      * @SWG\Response(
      *     response=200,
      *     description="Success",
-     *     @Model(type=BazingaUser::class)
+     *     @Model(type=BazingaUserTyped::class)
      * )
      */
-    public function userAction()
-    {
-    }
-
-    /**
-     * @Route("/api/bazinga_foo", methods={"GET"})
-     * @SWG\Response(
-     *     response=200,
-     *     description="Success",
-     *     @Model(type=BazingaUser::class, groups={"foo"})
-     * )
-     */
-    public function userGroupAction()
+    public function userTypedAction()
     {
     }
 }

--- a/Tests/Functional/Entity/BazingaUser.php
+++ b/Tests/Functional/Entity/BazingaUser.php
@@ -18,7 +18,21 @@ use Hateoas\Configuration\Annotation as Hateoas;
  *
  * @Hateoas\Relation(name="example", attributes={"str_att":"bar", "float_att":5.6, "bool_att": false}, href="http://www.example.com")
  * @Hateoas\Relation(name="route", href=@Hateoas\Route("foo"))
- * @Hateoas\Relation(name="route", attributes={"foo":"bar"}, embedded=@Hateoas\Embedded("expr(service('xx'))"))
+ * @Hateoas\Relation(
+ *     name="route",
+ *     attributes={"foo":"bar"},
+ *     embedded=@Hateoas\Embedded(
+ *      "expr(service('xx'))"
+ *     )
+ * )
+ * @Hateoas\Relation(
+ *     name="embed_with_group",
+ *     attributes={"foo":"with_groups"},
+ *     exclusion=@Hateoas\Exclusion(groups={"foo"}),
+ *     embedded=@Hateoas\Embedded(
+ *      "expr(service('xx'))"
+ *     )
+ * )
  */
 class BazingaUser
 {

--- a/Tests/Functional/EntityExcluded/BazingaUserTyped.php
+++ b/Tests/Functional/EntityExcluded/BazingaUserTyped.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\EntityExcluded;
+
+use Hateoas\Configuration\Annotation as Hateoas;
+
+/**
+ * @Hateoas\Relation(
+ *     name="typed_bazinga_users",
+ *     embedded=@Hateoas\Embedded(
+ *      "expr(service('zz'))",
+ *      type="array<Nelmio\ApiDocBundle\Tests\Functional\Entity\BazingaUser>"
+ *     )
+ * )
+ * @Hateoas\Relation(
+ *     name="typed_bazinga_name",
+ *     embedded=@Hateoas\Embedded(
+ *      "expr(service('yy'))",
+ *      type="string"
+ *     )
+ * )
+ */
+class BazingaUserTyped
+{
+}

--- a/Tests/Functional/SwaggerUiTest.php
+++ b/Tests/Functional/SwaggerUiTest.php
@@ -54,6 +54,7 @@ class SwaggerUiTest extends WebTestCase
             'Dummy' => $expected['definitions']['Dummy'],
             'Test' => ['type' => 'string'],
             'JMSPicture_mini' => ['type' => 'object'],
+            'BazingaUser_grouped' => ['type' => 'object'],
         ];
 
         yield ['/docs/test', 'test', $expected];

--- a/Tests/Functional/TestKernel.php
+++ b/Tests/Functional/TestKernel.php
@@ -14,8 +14,10 @@ namespace Nelmio\ApiDocBundle\Tests\Functional;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\ApiPlatformBundle;
 use Bazinga\Bundle\HateoasBundle\BazingaHateoasBundle;
 use FOS\RestBundle\FOSRestBundle;
+use Hateoas\Configuration\Embedded;
 use JMS\SerializerBundle\JMSSerializerBundle;
 use Nelmio\ApiDocBundle\NelmioApiDocBundle;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\BazingaUser;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup\JMSPicture;
 use Nelmio\ApiDocBundle\Tests\Functional\ModelDescriber\VirtualTypeClassDoesNotExistsHandlerDefinedDescriber;
 use Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle;
@@ -88,6 +90,12 @@ class TestKernel extends Kernel
 
         if ($this->useBazinga) {
             $routes->import(__DIR__.'/Controller/BazingaController.php', '/', 'annotation');
+
+            try {
+                new \ReflectionMethod(Embedded::class, 'getType');
+                $routes->import(__DIR__.'/Controller/BazingaTypedController.php', '/', 'annotation');
+            } catch (\ReflectionException $e) {
+            }
         }
     }
 
@@ -171,6 +179,11 @@ class TestKernel extends Kernel
                         'alias' => 'JMSPicture_mini',
                         'type' => JMSPicture::class,
                         'groups' => ['mini'],
+                    ],
+                    [
+                        'alias' => 'BazingaUser_grouped',
+                        'type' => BazingaUser::class,
+                        'groups' => ['foo'],
                     ],
                 ],
             ],

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,9 @@
         "api-platform/core": "For using an API oriented framework.",
         "friendsofsymfony/rest-bundle": "For using the parameters annotations."
     },
+    "conflict": {
+        "symfony/framework-bundle": "4.2.7"
+    },
     "autoload": {
         "psr-4": {
             "Nelmio\\ApiDocBundle\\": ""


### PR DESCRIPTION
This "documents" the type on an embedded relation in hateoas 3.0

Previously the embedded relations were just simple `object` types.
As of hateoas 3.0 is possible to declare via metadata the type of an embedded relation, so that type can be used in the api doc.

![image](https://user-images.githubusercontent.com/776743/56634745-5c6db580-6663-11e9-9c6a-b70676f4b039.png)
