### PR TITLE
Compatibility with Symfony 4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: php
 
 sudo: false

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -31,7 +31,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('motd')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('template')->defaultValue('NelmioApiDocBundle::Components/motd.html.twig')->end()
+                        ->scalarNode('template')->defaultValue('@NelmioApiDoc/Components/motd.html.twig')->end()
                     ->end()
                 ->end()
                 ->arrayNode('request_listener')

--- a/Formatter/HtmlFormatter.php
+++ b/Formatter/HtmlFormatter.php
@@ -12,6 +12,7 @@
 namespace Nelmio\ApiDocBundle\Formatter;
 
 use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment as TwigEnvironment;
 
 class HtmlFormatter extends AbstractFormatter
 {
@@ -31,7 +32,7 @@ class HtmlFormatter extends AbstractFormatter
     protected $defaultRequestFormat;
 
     /**
-     * @var EngineInterface
+     * @var EngineInterface|TwigEnvironment
      */
     protected $engine;
 
@@ -113,9 +114,9 @@ class HtmlFormatter extends AbstractFormatter
     }
 
     /**
-     * @param EngineInterface $engine
+     * @param EngineInterface|TwigEnvironment $engine
      */
-    public function setTemplatingEngine(EngineInterface $engine)
+    public function setTemplatingEngine($engine)
     {
         $this->engine = $engine;
     }

--- a/Formatter/HtmlFormatter.php
+++ b/Formatter/HtmlFormatter.php
@@ -198,7 +198,7 @@ class HtmlFormatter extends AbstractFormatter
      */
     protected function renderOne(array $data)
     {
-        return $this->engine->render('NelmioApiDocBundle::resource.html.twig', array_merge(
+        return $this->engine->render('@NelmioApiDoc/resource.html.twig', array_merge(
             array(
                 'data'           => $data,
                 'displayContent' => true,
@@ -212,7 +212,7 @@ class HtmlFormatter extends AbstractFormatter
      */
     protected function render(array $collection)
     {
-        return $this->engine->render('NelmioApiDocBundle::resources.html.twig', array_merge(
+        return $this->engine->render('@NelmioApiDoc/resources.html.twig', array_merge(
             array(
                 'resources' => $collection,
             ),

--- a/Resources/config/formatters.xml
+++ b/Resources/config/formatters.xml
@@ -21,7 +21,7 @@
         <service id="nelmio_api_doc.formatter.html_formatter" class="%nelmio_api_doc.formatter.html_formatter.class%"
             parent="nelmio_api_doc.formatter.abstract_formatter" public="true">
             <call method="setTemplatingEngine">
-                <argument type="service" id="templating" />
+                <argument type="service" id="twig" />
             </call>
             <call method="setMotdTemplate">
                 <argument>%nelmio_api_doc.motd.template%</argument>

--- a/Resources/doc/configuration-reference.rst
+++ b/Resources/doc/configuration-reference.rst
@@ -8,7 +8,7 @@ Configuration Reference
         exclude_sections:     []
         default_sections_opened:  true
         motd:
-            template:             'NelmioApiDocBundle::Components/motd.html.twig'
+            template:             '@NelmioApiDoc/Components/motd.html.twig'
         request_listener:
             enabled:              true
             parameter:            _doc

--- a/Resources/views/method.html.twig
+++ b/Resources/views/method.html.twig
@@ -189,7 +189,7 @@
                         <tr>
                             <td>{{ name }}</td>
                             <td>{{ infos.dataType }}</td>
-                            <td>{% include 'NelmioApiDocBundle:Components:version.html.twig' with {'sinceVersion': infos.sinceVersion, 'untilVersion': infos.untilVersion} only %}</td>
+                            <td>{% include '@NelmioApiDoc/Components/version.html.twig' with {'sinceVersion': infos.sinceVersion, 'untilVersion': infos.untilVersion} only %}</td>
                             <td>{{ infos.description }}</td>
                         </tr>
                     {% endfor %}

--- a/Resources/views/resource.html.twig
+++ b/Resources/views/resource.html.twig
@@ -1,11 +1,11 @@
-{% extends "NelmioApiDocBundle::layout.html.twig" %}
+{% extends "@NelmioApiDoc/layout.html.twig" %}
 
 {% block content %}
     <li class="resource">
         <ul class="endpoints">
             <li class="endpoint">
                 <ul class="operations">
-                    {% include 'NelmioApiDocBundle::method.html.twig' %}
+                    {% include '@NelmioApiDoc/method.html.twig' %}
                 </ul>
             </li>
         </ul>

--- a/Resources/views/resources.html.twig
+++ b/Resources/views/resources.html.twig
@@ -1,4 +1,4 @@
-{% extends "NelmioApiDocBundle::layout.html.twig" %}
+{% extends "@NelmioApiDoc/layout.html.twig" %}
 
 {% block content %}
     <div id="summary">
@@ -33,7 +33,7 @@
                     <li class="endpoint">
                         <ul class="operations">
                             {% for data in methods %}
-                                {% include 'NelmioApiDocBundle::method.html.twig' %}
+                                {% include '@NelmioApiDoc/method.html.twig' %}
                             {% endfor %}
                         </ul>
                     </li>

--- a/Tests/Formatter/testFormat-result-no-dunglas.markdown
+++ b/Tests/Formatter/testFormat-result-no-dunglas.markdown
@@ -622,6 +622,9 @@ dependency_type[a]:
 
 _This method is useful to test if the getDocComment works._
 
+This method is useful to test if the getDocComment works.
+And, it supports multilines until the first '@' char.
+
 #### Requirements ####
 
 **id**

--- a/Tests/Formatter/testFormat-result.markdown
+++ b/Tests/Formatter/testFormat-result.markdown
@@ -706,6 +706,9 @@ dependency_type[a]:
 
 _This method is useful to test if the getDocComment works._
 
+This method is useful to test if the getDocComment works.
+And, it supports multilines until the first '@' char.
+
 #### Requirements ####
 
 **id**


### PR DESCRIPTION
The `templating` service has been deprecated.
It needs to be replaced by `twig`.

Since `TwigEnvironment` is used, it needs the namespaced paths (the old syntax is not supported anymore).

This is blocking for API Platform.

I fixed at least one test suite in Travis.