### PR TITLE
Add dump command to print out swagger JSON. (#1537)

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -18,8 +18,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ServiceLocator;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 class DumpCommand extends Command
@@ -60,7 +58,7 @@ class DumpCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $area = $input->getOption( 'area' );
+        $area = $input->getOption('area');
 
         if (!$this->generatorLocator->has($area)) {
             throw new BadRequestHttpException(sprintf('Area "%s" is not supported.', $area));
@@ -68,10 +66,10 @@ class DumpCommand extends Command
 
         $spec = $this->generatorLocator->get($area)->generate()->toArray();
 
-        if( $input->hasParameterOption(['--no-pretty']) ) {
-            $output->writeln( json_encode( $spec ) );
+        if( $input->hasParameterOption(['--no-pretty'])) {
+            $output->writeln(json_encode($spec));
         } else {
-            $output->writeln( json_encode( $spec, JSON_PRETTY_PRINT ) );
+            $output->writeln(json_encode($spec, JSON_PRETTY_PRINT));
         }
     }
 }

--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -26,22 +26,8 @@ class DumpCommand extends Command
 
     private $generatorLocator;
 
-    /**
-     * @param ContainerInterface $generatorLocator
-     */
-    public function __construct($generatorLocator)
+    public function __construct(ContainerInterface $generatorLocator)
     {
-        if (!$generatorLocator instanceof ContainerInterface) {
-            if (!$generatorLocator instanceof ApiDocGenerator) {
-                throw new \InvalidArgumentException(sprintf('Providing an instance of "%s" to "%s" is not supported.', get_class($generatorLocator), __METHOD__));
-            }
-
-            @trigger_error(sprintf('Providing an instance of "%s" to "%s()" is deprecated since version 3.1. Provide it an instance of "%s" instead.', ApiDocGenerator::class, __METHOD__, ContainerInterface::class), E_USER_DEPRECATED);
-            $generatorLocator = new ServiceLocator(['default' => function () use ($generatorLocator): ApiDocGenerator {
-                return $generatorLocator;
-            }]);
-        }
-
         $this->generatorLocator = $generatorLocator;
 
         parent::__construct();
@@ -66,7 +52,7 @@ class DumpCommand extends Command
 
         $spec = $this->generatorLocator->get($area)->generate()->toArray();
 
-        if( $input->hasParameterOption(['--no-pretty'])) {
+        if ($input->hasParameterOption(['--no-pretty'])) {
             $output->writeln(json_encode($spec));
         } else {
             $output->writeln(json_encode($spec, JSON_PRETTY_PRINT));

--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -21,11 +21,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 class DumpCommand extends Command
 {
     /**
-     * @var string command name
-     */
-    protected static $defaultName = 'app:doc:dump';
-
-    /**
      * @var ContainerInterface
      */
     private $generatorLocator;
@@ -77,5 +72,7 @@ class DumpCommand extends Command
         } else {
             $output->writeln(json_encode($spec, JSON_PRETTY_PRINT));
         }
+
+        return 0;
     }
 }

--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -11,21 +11,30 @@
 
 namespace Nelmio\ApiDocBundle\Command;
 
-use Nelmio\ApiDocBundle\ApiDocGenerator;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\DependencyInjection\ServiceLocator;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 class DumpCommand extends Command
 {
+    /**
+     * @var string command name
+     */
     protected static $defaultName = 'app:doc:dump';
 
+    /**
+     * @var ContainerInterface
+     */
     private $generatorLocator;
 
+    /**
+     * DumpCommand constructor.
+     *
+     * @param ContainerInterface $generatorLocator
+     */
     public function __construct(ContainerInterface $generatorLocator)
     {
         $this->generatorLocator = $generatorLocator;
@@ -33,21 +42,32 @@ class DumpCommand extends Command
         parent::__construct();
     }
 
+    /**
+     * Configures the dump command.
+     */
     protected function configure()
     {
         $this
-            ->setDescription('Dumps API documentation in Swagger JSON format')
+            ->setDescription('Dumps documentation in OpenAPI JSON format')
             ->addOption('area', '', InputOption::VALUE_OPTIONAL, '', 'default')
             ->addOption('--no-pretty', '', InputOption::VALUE_NONE, 'Do not pretty format output')
         ;
     }
 
+    /**
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @throws InvalidArgumentException If the area to dump is not valid
+     *
+     * @return int|void
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $area = $input->getOption('area');
 
         if (!$this->generatorLocator->has($area)) {
-            throw new BadRequestHttpException(sprintf('Area "%s" is not supported.', $area));
+            throw new InvalidArgumentException(sprintf('Area "%s" is not supported.', $area));
         }
 
         $spec = $this->generatorLocator->get($area)->generate()->toArray();

--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -65,7 +65,7 @@ class DumpCommand extends Command
             throw new InvalidArgumentException(sprintf('Area "%s" is not supported.', $area));
         }
 
-        $spec = $this->generatorLocator->get($area)->generate()->toArray();
+        $spec = $this->generatorLocator->get($area)->generate();
 
         if ($input->hasParameterOption(['--no-pretty'])) {
             $output->writeln(json_encode($spec));

--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -45,7 +45,7 @@ class DumpCommand extends Command
         $this
             ->setDescription('Dumps documentation in OpenAPI JSON format')
             ->addOption('area', '', InputOption::VALUE_OPTIONAL, '', 'default')
-            ->addOption('--no-pretty', '', InputOption::VALUE_NONE, 'Do not pretty format output')
+            ->addOption('no-pretty', '', InputOption::VALUE_NONE, 'Do not pretty format output')
         ;
     }
 

--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Command;
+
+use Nelmio\ApiDocBundle\ApiDocGenerator;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+class DumpCommand extends Command
+{
+    protected static $defaultName = 'app:doc:dump';
+
+    private $generatorLocator;
+
+    /**
+     * @param ContainerInterface $generatorLocator
+     */
+    public function __construct($generatorLocator)
+    {
+        if (!$generatorLocator instanceof ContainerInterface) {
+            if (!$generatorLocator instanceof ApiDocGenerator) {
+                throw new \InvalidArgumentException(sprintf('Providing an instance of "%s" to "%s" is not supported.', get_class($generatorLocator), __METHOD__));
+            }
+
+            @trigger_error(sprintf('Providing an instance of "%s" to "%s()" is deprecated since version 3.1. Provide it an instance of "%s" instead.', ApiDocGenerator::class, __METHOD__, ContainerInterface::class), E_USER_DEPRECATED);
+            $generatorLocator = new ServiceLocator(['default' => function () use ($generatorLocator): ApiDocGenerator {
+                return $generatorLocator;
+            }]);
+        }
+
+        $this->generatorLocator = $generatorLocator;
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Dumps API documentation in Swagger JSON format')
+            ->addOption('area', '', InputOption::VALUE_OPTIONAL, '', 'default')
+            ->addOption('--no-pretty', '', InputOption::VALUE_NONE, 'Do not pretty format output')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $area = $input->getOption( 'area' );
+
+        if (!$this->generatorLocator->has($area)) {
+            throw new BadRequestHttpException(sprintf('Area "%s" is not supported.', $area));
+        }
+
+        $spec = $this->generatorLocator->get($area)->generate()->toArray();
+
+        if( $input->hasParameterOption(['--no-pretty']) ) {
+            $output->writeln( json_encode( $spec ) );
+        } else {
+            $output->writeln( json_encode( $spec, JSON_PRETTY_PRINT ) );
+        }
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,7 +7,7 @@
         <!-- Commands -->
         <service id="nelmio_api_doc.command.dump" class="Nelmio\ApiDocBundle\Command\DumpCommand" public="true">
             <argument type="service" id="nelmio_api_doc.generator_locator" />
-            <tag name="console.command" command="api:doc:dump" />
+            <tag name="console.command" command="nelmio:apidoc:dump" />
         </service>
 
         <!-- Controllers -->

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -4,6 +4,12 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <!-- Commands -->
+        <service id="nelmio_api_doc.command.dump" class="Nelmio\ApiDocBundle\Command\DumpCommand" public="true">
+            <argument type="service" id="nelmio_api_doc.generator_locator" />
+            <tag name="console.command" command="api:doc:dump" />
+        </service>
+
         <!-- Controllers -->
         <service id="nelmio_api_doc.controller.swagger_ui" class="Nelmio\ApiDocBundle\Controller\SwaggerUiController" public="true">
             <argument type="service" id="nelmio_api_doc.generator_locator" />

--- a/Tests/Command/DumpCommandTest.php
+++ b/Tests/Command/DumpCommandTest.php
@@ -22,7 +22,7 @@ class DumpCommandTest extends WebTestCase
         $kernel = static::bootKernel();
         $application = new Application($kernel);
 
-        $command = $application->find('api:doc:dump');
+        $command = $application->find('nelmio:apidoc:dump');
         $commandTester = new CommandTester($command);
         $commandTester->execute([
             '--area' => 'test',

--- a/Tests/Command/DumpCommandTest.php
+++ b/Tests/Command/DumpCommandTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Command;
+
+use Nelmio\ApiDocBundle\Tests\Functional\WebTestCase; // for the creation of the kernel
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DumpCommandTest extends WebTestCase
+{
+    public function testExecute()
+    {
+        $kernel = static::bootKernel();
+        $application = new Application($kernel);
+
+        $command = $application->find('api:doc:dump');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            '--area' => 'test',
+            '--no-pretty' => '',
+        ]);
+
+        // the output of the command in the console
+        $output = $commandTester->getDisplay();
+        $this->assertEquals(json_encode($this->getOpenApiDefinition('test'))."\n", $output);
+    }
+}


### PR DESCRIPTION
Command outputs to stdout, so can be redirected to a file.
Pretty prints output by default.
--no-pretty can be passed to remove whitespace from json output if it does not need to be human readable