### PR TITLE
Add entity fields translation support for ObjectDescriber / JMSDescriber

### DIFF
--- a/DependencyInjection/Compiler/ConfigurationPass.php
+++ b/DependencyInjection/Compiler/ConfigurationPass.php
@@ -12,6 +12,9 @@
 namespace Nelmio\ApiDocBundle\DependencyInjection\Compiler;
 
 use Nelmio\ApiDocBundle\ModelDescriber\FormModelDescriber;
+use Nelmio\ApiDocBundle\ModelDescriber\ObjectModelDescriber;
+use Nelmio\ApiDocBundle\Translator\EntityTranslator;
+use Nelmio\ApiDocBundle\Translator\NullTranslator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -25,11 +28,35 @@ final class ConfigurationPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
+        //check if translation is defined in Nelmio config
+        if ($container->hasParameter('nelmio_translator_paths')) {
+            $paths = $container->getParameter('nelmio_translator_paths');
+        } else {
+            $paths = [];
+        }
+
         if ($container->hasDefinition('form.factory')) {
             $container->register('nelmio_api_doc.model_describers.form', FormModelDescriber::class)
                 ->setPublic(false)
                 ->addArgument(new Reference('form.factory'))
                 ->addTag('nelmio_api_doc.model_describer', ['priority' => 100]);
         }
+
+        //translation path found for ObjectNormalizer, we inject EntityTranslator
+        if (isset($paths['entity'])) {
+            $container->register('nelmio_entity_translator', EntityTranslator::class)
+                        ->setPublic(false)
+                        ->addArgument($paths['entity']);
+        } else {
+            //no translation path for ObjectNormalizer, we inject NullObject Tranlator
+            $container->register('nelmio_entity_translator', NullTranslator::class);
+        }
+
+        $container->register('nelmio_api_doc.model_describers.object', ObjectModelDescriber::class)
+            ->setPublic(false)
+            ->addArgument(new Reference('property_info'))
+            ->addArgument(new Reference('annotation_reader'))
+            ->addArgument(new Reference('nelmio_entity_translator'))
+            ->addTag('nelmio_api_doc.model_describer');
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -53,6 +53,12 @@ final class Configuration implements ConfigurationInterface
                     ->example(['info' => ['title' => 'My App']])
                     ->prototype('variable')->end()
                 ->end()
+                ->arrayNode('translation')
+                    ->info('List of directory for translation files')
+                    ->scalarPrototype()
+                        ->defaultValue('')
+                    ->end()
+                ->end()
                 ->arrayNode('areas')
                     ->info('Filter the routes that are documented')
                     ->defaultValue(
@@ -139,6 +145,7 @@ final class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+
             ->end();
 
         return $treeBuilder;

--- a/ModelDescriber/Annotations/AnnotationsReader.php
+++ b/ModelDescriber/Annotations/AnnotationsReader.php
@@ -14,6 +14,7 @@ namespace Nelmio\ApiDocBundle\ModelDescriber\Annotations;
 use Doctrine\Common\Annotations\Reader;
 use EXSyst\Component\Swagger\Schema;
 use Nelmio\ApiDocBundle\Model\ModelRegistry;
+use Nelmio\ApiDocBundle\Translator\TranslatorInterface;
 
 /**
  * @internal
@@ -22,15 +23,21 @@ class AnnotationsReader
 {
     private $annotationsReader;
     private $modelRegistry;
+    private $translator;
 
     private $phpDocReader;
     private $swgAnnotationsReader;
     private $symfonyConstraintAnnotationReader;
 
-    public function __construct(Reader $annotationsReader, ModelRegistry $modelRegistry)
+    public function __construct(
+        Reader $annotationsReader,
+        ModelRegistry $modelRegistry,
+        TranslatorInterface $translator
+    )
     {
         $this->annotationsReader = $annotationsReader;
         $this->modelRegistry = $modelRegistry;
+        $this->translator = $translator;
 
         $this->phpDocReader = new PropertyPhpDocReader();
         $this->swgAnnotationsReader = new SwgAnnotationsReader($annotationsReader, $modelRegistry);
@@ -53,5 +60,6 @@ class AnnotationsReader
         $this->phpDocReader->updateProperty($reflectionProperty, $property);
         $this->swgAnnotationsReader->updateProperty($reflectionProperty, $property, $serializationGroups);
         $this->symfonyConstraintAnnotationReader->updateProperty($reflectionProperty, $property);
+        $this->translator->translate($reflectionProperty, $property);
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -39,13 +39,6 @@
         </service>
 
         <!-- Model Describers -->
-        <service id="nelmio_api_doc.model_describers.object" class="Nelmio\ApiDocBundle\ModelDescriber\ObjectModelDescriber" public="false">
-            <argument type="service" id="property_info" />
-            <argument type="service" id="annotation_reader" />
-
-            <tag name="nelmio_api_doc.model_describer" />
-        </service>
-
         <service id="nelmio_api_doc.model_describers.object_fallback" class="Nelmio\ApiDocBundle\ModelDescriber\FallbackObjectModelDescriber" public="false">
             <tag name="nelmio_api_doc.model_describer" priority="-1000" />
         </service>

--- a/Translator/EntityTranslator.php
+++ b/Translator/EntityTranslator.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Translator;
+
+use EXSyst\Component\Swagger\Schema;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Yaml\Yaml;
+
+class EntityTranslator implements TranslatorInterface
+{
+    /** @var string */
+    private $path;
+
+    /** @var array */
+    private $definitions;
+
+    public function __construct(string $path)
+    {
+        $this->path = $path;
+    }
+
+    /**
+     * Update property title on Schema.
+     *
+     * @param \ReflectionProperty $property
+     * @param Schema              $context
+     */
+    public function translate($property, $context = null)
+    {
+        if (isset($this->definitions[$property->name])) {
+            $context->setTitle($this->definitions[$property->name]);
+        }
+    }
+
+    /**
+     * populate $this->definitions
+     * Find good translation file and parse it.
+     *
+     * this method must be called before translate()
+     *
+     * @throws \Exception
+     *
+     * @return EntityTranslator
+     */
+    public function setDefinitions(string $class): self
+    {
+        $finder = new Finder();
+        $finder->files()->in($this->path)->contains($class);
+
+        if ($finder->hasResults()) {
+            //need have only one result (one file by entity)
+            if (1 != $finder->count()) {
+                throw new \Exception(sprintf('Error, multiple translation files found for entity %s', $class));
+            }
+
+            $definitions = Yaml::parse(current($finder)->getContents());
+            if (isset($definitions[$class]['attributes'])) {
+                $this->definitions = $definitions[$class]['attributes'];
+            }
+        }
+
+        return $this;
+    }
+}

--- a/Translator/FormTranslator.php
+++ b/Translator/FormTranslator.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Translator;
+
+class FormTranslator implements TranslatorInterface
+{
+    private $path;
+
+    public function __construct(string $path)
+    {
+        $this->path = $path;
+    }
+
+    public function translate($property, $context = null)
+    {
+    }
+}

--- a/Translator/NullTranslator.php
+++ b/Translator/NullTranslator.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Translator;
+
+class NullTranslator implements TranslatorInterface
+{
+    public function translate($property, $context = null)
+    {
+    }
+
+    public function setDefinitions(string $class): self
+    {
+        return $this;
+    }
+}

--- a/Translator/TranslatorInterface.php
+++ b/Translator/TranslatorInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Translator;
+
+interface TranslatorInterface
+{
+    public function translate($property, $context = null);
+}

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,8 @@
         "symfony/framework-bundle": "^3.4|^4.0",
         "symfony/options-resolver": "^3.4.4|^4.0",
         "symfony/property-info": "^3.4|^4.0",
+        "symfony/finder": "^3.4|^4.0",
+        "symfony/yaml": "^3.4|^4.0",
         "exsyst/swagger": "^0.4.1",
         "zircote/swagger-php": "^2.0.9",
         "phpdocumentor/reflection-docblock": "^3.1|^4.0"


### PR DESCRIPTION
Hi,
I'm facing to a problem at work, I need to have translation of the title of my entity in Nelmio (code comment are written in english but client want see the swagger in French) 

At work I solution the problem with decorating swagger_ui_controller service and add translation layer, but this solution introduct coupling.

I have learn about Nelmio, if you want I propose the following PR : 
Add support translation for entity field (title fetched in phpdocblock) for JMSSerializer / Object ModelDescriber

The idea is to configure the translation in config.yml file like this : 
```
nelmio_api_doc:
    translation:
        entity: "%kernel.root_dir%/translation"
```
Write your translation file in directory configured in config.yml like this : 
```
translation/User.yml

EchoSystems\CommonBundle\Entity\User:
    attributes:
        faxNumber: Faxnummer
        phoneNumber: Telefonnummer
```
Otherwise, if you omit the translation key in config.yml, translation is ignored.

If PR is accepted I will update the FormModelDescriber to add support, It can possible to just update config.yml like this : 
```
nelmio_api_doc:
    translation:
        entity: "%kernel.root_dir%/translation/entity"
	form: "%kernel.root_dir%/translation/form"
```
And update the strategy translator / modelDescriber for form.

- Unit tests are Ok,
- PSR1 & PSR2 are Ok

cordially.