### PR TITLE
fix compatibility with symfony 5

### DIFF
--- a/Tests/Describer/RouteDescriberTest.php
+++ b/Tests/Describer/RouteDescriberTest.php
@@ -41,11 +41,20 @@ class RouteDescriberTest extends AbstractDescriberTest
         $this->routes = new RouteCollection();
         $this->describer = new RouteDescriber(
             $this->routes,
-            new ControllerReflector(
-                new Container(),
-                $this->createMock(ControllerNameParser::class)
-            ),
+            $this->createControllerReflector(),
             [$this->routeDescriber]
         );
+    }
+
+    protected function createControllerReflector(): ControllerReflector
+    {
+        if (class_exists(ControllerNameParser::class)) {
+            return new ControllerReflector(
+                new Container(),
+                $this->createMock(ControllerNameParser::class)
+            );
+        }
+
+        return new ControllerReflector(new Container());
     }
 }

--- a/Tests/Functional/BazingaFunctionalTest.php
+++ b/Tests/Functional/BazingaFunctionalTest.php
@@ -15,6 +15,13 @@ use Hateoas\Configuration\Embedded;
 
 class BazingaFunctionalTest extends WebTestCase
 {
+    protected function setUp()
+    {
+        parent::setUp();
+
+        static::createClient([], ['HTTP_HOST' => 'api.example.com']);
+    }
+
     public function testModelComplexDocumentationBazinga()
     {
         $this->assertEquals([

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -15,6 +15,13 @@ use EXSyst\Component\Swagger\Tag;
 
 class FunctionalTest extends WebTestCase
 {
+    protected function setUp()
+    {
+        parent::setUp();
+
+        static::createClient([], ['HTTP_HOST' => 'api.example.com']);
+    }
+
     public function testConfiguredDocumentation()
     {
         $this->assertEquals('My Default App', $this->getSwaggerDefinition()->getInfo()->getTitle());

--- a/Tests/Functional/JMSFunctionalTest.php
+++ b/Tests/Functional/JMSFunctionalTest.php
@@ -13,6 +13,13 @@ namespace Nelmio\ApiDocBundle\Tests\Functional;
 
 class JMSFunctionalTest extends WebTestCase
 {
+    protected function setUp()
+    {
+        parent::setUp();
+
+        static::createClient([], ['HTTP_HOST' => 'api.example.com']);
+    }
+
     public function testModelPictureDocumentation()
     {
         $this->assertEquals([

--- a/Tests/Functional/SwaggerUiTest.php
+++ b/Tests/Functional/SwaggerUiTest.php
@@ -11,36 +11,46 @@
 
 namespace Nelmio\ApiDocBundle\Tests\Functional;
 
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
 class SwaggerUiTest extends WebTestCase
 {
-    protected static function createClient(array $options = [], array $server = [])
+    /**
+     * @var KernelBrowser
+     */
+    private $client;
+
+    protected function setUp()
     {
-        return parent::createClient([], $server + ['HTTP_HOST' => 'api.example.com', 'PHP_SELF' => '/app_dev.php/docs', 'SCRIPT_FILENAME' => '/var/www/app/web/app_dev.php']);
+        parent::setUp();
+
+        $this->client = static::createClient([], ['HTTP_HOST' => 'api.example.com', 'PHP_SELF' => '/app_dev.php/docs', 'SCRIPT_FILENAME' => '/var/www/app/web/app_dev.php']);
     }
 
-    /**
-     * @dataProvider areaProvider
-     */
-    public function testSwaggerUi($url, $area, $expected)
+    public function testSwaggerUi()
     {
-        $client = self::createClient();
-        $crawler = $client->request('GET', '/app_dev.php'.$url);
+        $crawler = $this->client->request('GET', '/app_dev.php/docs');
 
-        $response = $client->getResponse();
+        $response = $this->client->getResponse();
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('text/html; charset=UTF-8', $response->headers->get('Content-Type'));
+
+        $expected = $this->getSwaggerDefinition()->toArray();
+        $expected['basePath'] = '/app_dev.php';
 
         $this->assertEquals($expected, json_decode($crawler->filterXPath('//script[@id="swagger-data"]')->text(), true)['spec']);
     }
 
-    public function areaProvider()
+    public function testApiPlatformSwaggerUi()
     {
+        $crawler = $this->client->request('GET', '/app_dev.php/docs/test');
+
+        $response = $this->client->getResponse();
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('text/html; charset=UTF-8', $response->headers->get('Content-Type'));
+
         $expected = $this->getSwaggerDefinition()->toArray();
         $expected['basePath'] = '/app_dev.php';
-
-        yield ['/docs', 'default', $expected];
-
-        // Api-platform documentation
         $expected['info']['title'] = 'My Test App';
         $expected['paths'] = [
             '/api/dummies' => $expected['paths']['/api/dummies'],
@@ -57,15 +67,14 @@ class SwaggerUiTest extends WebTestCase
             'BazingaUser_grouped' => ['type' => 'object'],
         ];
 
-        yield ['/docs/test', 'test', $expected];
+        $this->assertEquals($expected, json_decode($crawler->filterXPath('//script[@id="swagger-data"]')->text(), true)['spec']);
     }
 
     public function testJsonDocs()
     {
-        $client = self::createClient();
-        $client->request('GET', '/app_dev.php/docs.json');
+        $this->client->request('GET', '/app_dev.php/docs.json');
 
-        $response = $client->getResponse();
+        $response = $this->client->getResponse();
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('application/json', $response->headers->get('Content-Type'));
 

--- a/Tests/Functional/WebTestCase.php
+++ b/Tests/Functional/WebTestCase.php
@@ -24,8 +24,6 @@ class WebTestCase extends BaseWebTestCase
 
     protected function getSwaggerDefinition($area = 'default')
     {
-        static::createClient([], ['HTTP_HOST' => 'api.example.com']);
-
         return static::$kernel->getContainer()->get(sprintf('nelmio_api_doc.generator.%s', $area))->generate();
     }
 

--- a/Tests/Routing/FilteredRouteCollectionBuilderTest.php
+++ b/Tests/Routing/FilteredRouteCollectionBuilderTest.php
@@ -47,10 +47,7 @@ class FilteredRouteCollectionBuilderTest extends TestCase
 
         $routeBuilder = new FilteredRouteCollectionBuilder(
             new AnnotationReader(),
-            new ControllerReflector(
-                new Container(),
-                $this->createMock(ControllerNameParser::class)
-            ),
+            $this->createControllerReflector(),
             'areaName',
             $options
         );
@@ -77,10 +74,7 @@ class FilteredRouteCollectionBuilderTest extends TestCase
 
         $routeBuilder = new FilteredRouteCollectionBuilder(
             new AnnotationReader(),
-            new ControllerReflector(
-                new Container(),
-                $this->createMock(ControllerNameParser::class)
-            ),
+            $this->createControllerReflector(),
             'areaName',
             $pathPattern
         );
@@ -98,10 +92,7 @@ class FilteredRouteCollectionBuilderTest extends TestCase
     {
         new FilteredRouteCollectionBuilder(
             new AnnotationReader(),
-            new ControllerReflector(
-                new Container(),
-                $this->createMock(ControllerNameParser::class)
-            ),
+            $this->createControllerReflector(),
             'areaName',
             $options
         );
@@ -154,10 +145,7 @@ class FilteredRouteCollectionBuilderTest extends TestCase
 
         $routeBuilder = new FilteredRouteCollectionBuilder(
             new AnnotationReader(),
-            new ControllerReflector(
-                new Container(),
-                $this->createMock(ControllerNameParser::class)
-            ),
+            $this->createControllerReflector(),
             'area',
             $options
         );
@@ -236,10 +224,7 @@ class FilteredRouteCollectionBuilderTest extends TestCase
 
         $routeBuilder = new FilteredRouteCollectionBuilder(
             new AnnotationReader(),
-            new ControllerReflector(
-                new Container(),
-                $this->createMock(ControllerNameParser::class)
-            ),
+            $this->createControllerReflector(),
             'areaName',
             $options
         );
@@ -258,5 +243,17 @@ class FilteredRouteCollectionBuilderTest extends TestCase
             ['r5_non_matching_path_and_matching_host', new Route('/admin/bar/action1', [], [], [], 'api.example.com'), ['path_patterns' => ['^/api/'], 'host_patterns' => ['^api\.']]],
             ['r6_non_matching_path_and_non_matching_host', new Route('/admin/bar/action1', [], [], [], 'www.example.com'), ['path_patterns' => ['^/api/'], 'host_patterns' => ['^api\.ex']]],
         ];
+    }
+
+    private function createControllerReflector(): ControllerReflector
+    {
+        if (class_exists(ControllerNameParser::class)) {
+            return new ControllerReflector(
+                new Container(),
+                $this->createMock(ControllerNameParser::class)
+            );
+        }
+
+        return  new ControllerReflector(new Container());
     }
 }


### PR DESCRIPTION
FOSRestBundle prevents installing some symfony components in version 5 as it is not compatible yet. I removed the dev requirement locally on FOSRestBundle and got a few incompatibility issues.

-  `Booting the kernel before calling %s() is not supported, the kernel should only be booted once.` on some functional tests
- removed/missing `Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser`-class