### PR TITLE
Allow "phpdocumentor/reflection-docblock:5.0"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/property-info": "^3.4|^4.0|^5.0",
         "exsyst/swagger": "^0.4.1",
         "zircote/swagger-php": "^2.0.9",
-        "phpdocumentor/reflection-docblock": "^3.1|^4.0"
+        "phpdocumentor/reflection-docblock": "^3.1|^4.0|^5.0"
     },
     "require-dev": {
         "symfony/templating": "^3.4|^4.0|^5.0",


### PR DESCRIPTION
There are no breaking changes at [phpdocumentor/reflection-docblock v5.0.0](https://github.com/phpDocumentor/ReflectionDocBlock/releases/tag/5.0.0).