### PR TITLE
Fix invalid tag which doesn't has description

### DIFF
--- a/ModelDescriber/Annotations/PropertyPhpDocReader.php
+++ b/ModelDescriber/Annotations/PropertyPhpDocReader.php
@@ -45,7 +45,7 @@ class PropertyPhpDocReader
         if (!$title = $docBlock->getSummary()) {
             /** @var Var_ $var */
             foreach ($docBlock->getTagsByName('var') as $var) {
-                if (!$description = $var->getDescription()) {
+                if (!method_exists($var, 'getDescription') || !$description = $var->getDescription()) {
                     continue;
                 }
                 $title = $description->render();


### PR DESCRIPTION
Solved this error on last update (3.6.0) due to InvalidTag which doesn't has description method
```
[2020-03-05 11:24:55] php.CRITICAL: Uncaught Error: Call to undefined method phpDocumentor\Reflection\DocBlock\Tags\InvalidTag::getDescription() {"exception":"[object] (Error(code: 0): Call to undefined method phpDocumentor\\Reflection\\DocBlock\\Tags\\InvalidTag::getDescription() at /home/wwwroot/capsule_back/vendor/nelmio/api-doc-bundle/ModelDescriber/Annotations/PropertyPhpDocReader.php:48)"} []
[2020-03-05 11:24:55] app.ERROR: {"code":0,"message":"Attempted to call an undefined method named \"getDescription\" of class \"phpDocumentor\\Reflection\\DocBlock\\Tags\\InvalidTag\".","called":{"file":"\/home\/wwwroot\/capsule_back\/vendor\/nelmio\/api-doc-bundle\/ModelDescriber\/Annotations\/AnnotationsReader.php","line":53},"occurred":{"file":"\/home\/wwwroot\/capsule_back\/vendor\/nelmio\/api-doc-bundle\/ModelDescriber\/Annotations\/PropertyPhpDocReader.php","line":48}} [] []
```