### PR TITLE
Help opcache.preload to load Swagger annotation class

### DIFF
--- a/Describer/SwaggerPhpDescriber.php
+++ b/Describer/SwaggerPhpDescriber.php
@@ -25,6 +25,9 @@ use Swagger\Annotations as SWG;
 use Swagger\Context;
 use Symfony\Component\Routing\RouteCollection;
 
+// Help opcache.preload discover Swagger\Annotations\Swagger
+class_exists(SWG\Swagger::class);
+
 final class SwaggerPhpDescriber implements ModelRegistryAwareInterface
 {
     use ModelRegistryAwareTrait;


### PR DESCRIPTION
I faced a problem when turned on opcache.preloader with Symfony 5.0: PHP failed with error about Anonymous class which extends non-preloaded `SWG\Swagger` class.