### PR TITLE
Add support for JMS Serializer inline property feature

### DIFF
--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -93,8 +93,20 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
                     $reflection = new \ReflectionProperty($item->class, $item->name);
                 }
 
-                $property = $properties->get($annotationsReader->getPropertyName($reflection, $name));
                 $groups = $this->computeGroups($context, $item->type);
+
+                if (true === $item->inline && isset($item->type['name'])) {
+                    // currently array types can not be documented :-/
+                    if (!in_array($item->type['name'], ['array', 'ArrayCollection'], true)) {
+                        $inlineModel = new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, $item->type['name']), $groups);
+                        $this->describe($inlineModel, $schema);
+                    }
+                    $context->popPropertyMetadata();
+
+                    continue;
+                }
+
+                $property = $properties->get($annotationsReader->getPropertyName($reflection, $name));
                 $annotationsReader->updateProperty($reflection, $property, $groups);
             } catch (\ReflectionException $e) {
                 $property = $properties->get($name);

--- a/Tests/Functional/Entity/JMSNote.php
+++ b/Tests/Functional/Entity/JMSNote.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * JMSNote.
+ *
+ * @Serializer\ExclusionPolicy("all")
+ */
+class JMSNote
+{
+    /**
+     * @Serializer\Type("string")
+     * @Serializer\Expose
+     */
+    private $long;
+
+    /**
+     * @Serializer\Type("int")
+     * @Serializer\Expose
+     */
+    private $short;
+}

--- a/Tests/Functional/Entity/JMSUser.php
+++ b/Tests/Functional/Entity/JMSUser.php
@@ -180,6 +180,13 @@ class JMSUser
      */
     private $deepFreeFormObjectCollection;
 
+    /**
+     * @Serializer\Type("Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSNote")
+     * @Serializer\Inline()
+     * @Serializer\Expose
+     */
+    private $notes;
+
     public function setRoles($roles)
     {
     }

--- a/Tests/Functional/JMSFunctionalTest.php
+++ b/Tests/Functional/JMSFunctionalTest.php
@@ -192,6 +192,12 @@ class JMSFunctionalTest extends WebTestCase
                         ],
                     ],
                 ],
+                'long' => [
+                    'type' => 'string',
+                ],
+                'short' => [
+                    'type' => 'integer',
+                ],
             ],
         ], $this->getModel('JMSUser')->toArray());
 


### PR DESCRIPTION
https://jmsyst.com/libs/serializer/master/reference/annotations#inline

When this feature is used, properties are declare in the parent class