### PR TITLE
Fix User Warning: Multiple definitions for @OA\\Property()->title

### DIFF
--- a/ModelDescriber/Annotations/AnnotationsReader.php
+++ b/ModelDescriber/Annotations/AnnotationsReader.php
@@ -50,8 +50,8 @@ class AnnotationsReader
 
     public function updateProperty(\ReflectionProperty $reflectionProperty, OA\Property $property, array $serializationGroups = null): void
     {
-        $this->phpDocReader->updateProperty($reflectionProperty, $property);
         $this->openApiAnnotationsReader->updateProperty($reflectionProperty, $property, $serializationGroups);
+        $this->phpDocReader->updateProperty($reflectionProperty, $property);
         $this->symfonyConstraintAnnotationReader->updateProperty($reflectionProperty, $property);
     }
 }

--- a/Tests/Functional/Entity/JMSUser.php
+++ b/Tests/Functional/Entity/JMSUser.php
@@ -48,7 +48,7 @@ class JMSUser
     private $email;
 
     /**
-     * User Roles Comment
+     * User Roles Comment.
      *
      * @Serializer\Type("array<string>")
      * @Serializer\Accessor(getter="getRoles", setter="setRoles")
@@ -59,7 +59,7 @@ class JMSUser
     private $roles;
 
     /**
-     * User Location
+     * User Location.
      *
      * @Serializer\Type("string")
      * @Serializer\Expose

--- a/Tests/Functional/Entity/JMSUser.php
+++ b/Tests/Functional/Entity/JMSUser.php
@@ -48,6 +48,8 @@ class JMSUser
     private $email;
 
     /**
+     * User Roles Comment
+     *
      * @Serializer\Type("array<string>")
      * @Serializer\Accessor(getter="getRoles", setter="setRoles")
      * @Serializer\Expose
@@ -55,6 +57,14 @@ class JMSUser
      * @OA\Property(default = {"user"}, description = "Roles list", example="[""ADMIN"",""SUPERUSER""]", title="roles")
      */
     private $roles;
+
+    /**
+     * User Location
+     *
+     * @Serializer\Type("string")
+     * @Serializer\Expose
+     */
+    private $location;
 
     /**
      * @Serializer\Type("string")

--- a/Tests/Functional/Entity/User.php
+++ b/Tests/Functional/Entity/User.php
@@ -31,6 +31,8 @@ class User
     private $email;
 
     /**
+     * User Roles Comment
+     *
      * @var string[]
      *
      * @OA\Property(
@@ -41,6 +43,13 @@ class User
      * )
      */
     private $roles;
+
+    /**
+     * User Location
+     *
+     * @OA\Property(type = "string")
+     */
+    private $location;
 
     /**
      * @var int

--- a/Tests/Functional/Entity/User.php
+++ b/Tests/Functional/Entity/User.php
@@ -31,7 +31,7 @@ class User
     private $email;
 
     /**
-     * User Roles Comment
+     * User Roles Comment.
      *
      * @var string[]
      *
@@ -45,7 +45,7 @@ class User
     private $roles;
 
     /**
-     * User Location
+     * User Location.
      *
      * @OA\Property(type = "string")
      */
@@ -119,6 +119,10 @@ class User
     public function setRoles(array $roles)
     {
         $this->roles = $roles;
+    }
+
+    public function setLocation(string $location)
+    {
     }
 
     /**

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -171,6 +171,10 @@ class FunctionalTest extends WebTestCase
                         'items' => ['type' => 'string'],
                         'default' => ['user'],
                     ],
+                    'location' => [
+                        'title' => 'User Location',
+                        'type' => 'string',
+                    ],
                     'friendsNumber' => [
                         'type' => 'string',
                     ],

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -172,7 +172,7 @@ class FunctionalTest extends WebTestCase
                         'default' => ['user'],
                     ],
                     'location' => [
-                        'title' => 'User Location',
+                        'title' => 'User Location.',
                         'type' => 'string',
                     ],
                     'friendsNumber' => [

--- a/Tests/Functional/JMSFunctionalTest.php
+++ b/Tests/Functional/JMSFunctionalTest.php
@@ -105,7 +105,7 @@ class JMSFunctionalTest extends WebTestCase
                 ],
                 'location' => [
                     'type' => 'string',
-                    'title' => 'User Location',
+                    'title' => 'User Location.',
                 ],
                 'friendsNumber' => [
                     'type' => 'string',

--- a/Tests/Functional/JMSFunctionalTest.php
+++ b/Tests/Functional/JMSFunctionalTest.php
@@ -103,6 +103,10 @@ class JMSFunctionalTest extends WebTestCase
                     'default' => ['user'],
                     'description' => 'Roles list',
                 ],
+                'location' => [
+                    'type' => 'string',
+                    'title' => 'User Location',
+                ],
                 'friendsNumber' => [
                     'type' => 'string',
                     'maxLength' => 100,


### PR DESCRIPTION
Fix for #1623

Phpdoc reader update property checks for title and if blank updates the property.
This should therefore run after the OA3 Annotations processing of title.