### PR TITLE
Fix access to api->components in RouteMetadataDescriber

### DIFF
--- a/RouteDescriber/RouteMetadataDescriber.php
+++ b/RouteDescriber/RouteMetadataDescriber.php
@@ -73,7 +73,7 @@ final class RouteMetadataDescriber implements RouteDescriberInterface
     private function getRefParams(OA\OpenApi $api, OA\Operation $operation): array
     {
         /** @var OA\Parameter[] $globalParams */
-        $globalParams = OA\UNDEFINED !== $api->components->parameters ? $api->components->parameters : [];
+        $globalParams = OA\UNDEFINED !== $api->components && OA\UNDEFINED !== $api->components->parameters ? $api->components->parameters : [];
         $existingParams = [];
 
         $operationParameters = OA\UNDEFINED !== $operation->parameters ? $operation->parameters : [];

--- a/Tests/RouteDescriber/RouteMetadataDescriberTest.php
+++ b/Tests/RouteDescriber/RouteMetadataDescriberTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\RouteDescriber;
+
+use Nelmio\ApiDocBundle\Describer\RouteDescriber;
+use Nelmio\ApiDocBundle\RouteDescriber\RouteDescriberInterface;
+use Nelmio\ApiDocBundle\RouteDescriber\RouteMetadataDescriber;
+use Nelmio\ApiDocBundle\Util\ControllerReflector;
+use OpenApi\Annotations\OpenApi;
+use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+use PHPUnit\Framework\TestCase;
+
+class RouteMetadataDescriberTest extends TestCase
+{
+    public function testUndefinedCheck()
+    {
+        $routeDescriber = new RouteMetadataDescriber();
+
+        $this->assertNull($routeDescriber->describe(new OpenApi([]), new Route('foo'), new \ReflectionMethod(__CLASS__, 'testUndefinedCheck')));
+    }
+}

--- a/Tests/RouteDescriber/RouteMetadataDescriberTest.php
+++ b/Tests/RouteDescriber/RouteMetadataDescriberTest.php
@@ -11,16 +11,10 @@
 
 namespace Nelmio\ApiDocBundle\Tests\RouteDescriber;
 
-use Nelmio\ApiDocBundle\Describer\RouteDescriber;
-use Nelmio\ApiDocBundle\RouteDescriber\RouteDescriberInterface;
 use Nelmio\ApiDocBundle\RouteDescriber\RouteMetadataDescriber;
-use Nelmio\ApiDocBundle\Util\ControllerReflector;
 use OpenApi\Annotations\OpenApi;
-use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
-use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\Routing\Route;
-use Symfony\Component\Routing\RouteCollection;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Route;
 
 class RouteMetadataDescriberTest extends TestCase
 {


### PR DESCRIPTION
Fixes https://github.com/nelmio/NelmioApiDocBundle/issues/1628#issuecomment-636150293 and https://github.com/nelmio/NelmioApiDocBundle/pull/1623#issuecomment-635522664