### PR TITLE
Add support for compound properties

### DIFF
--- a/Model/ModelRegistry.php
+++ b/Model/ModelRegistry.php
@@ -40,10 +40,9 @@ final class ModelRegistry
     {
         $this->modelDescribers = $modelDescribers;
         $this->api = $api;
-        $this->alternativeNames = []; // last rule wins
 
         foreach (array_reverse($alternativeNames) as $alternativeName => $criteria) {
-            $this->alternativeNames[] = $model = new Model(new Type('object', $criteria['nullable'] ?? false, $criteria['type']), $criteria['groups']);
+            $this->alternativeNames[] = $model = new Model(new Type('object', false, $criteria['type']), $criteria['groups']);
             $this->names[$model->getHash()] = $alternativeName;
             Util::getSchema($this->api, $alternativeName);
         }

--- a/Model/ModelRegistry.php
+++ b/Model/ModelRegistry.php
@@ -43,7 +43,7 @@ final class ModelRegistry
         $this->alternativeNames = []; // last rule wins
 
         foreach (array_reverse($alternativeNames) as $alternativeName => $criteria) {
-            $this->alternativeNames[] = $model = new Model(new Type('object', false, $criteria['type']), $criteria['groups']);
+            $this->alternativeNames[] = $model = new Model(new Type('object', $criteria['nullable'] ?? false, $criteria['type']), $criteria['groups']);
             $this->names[$model->getHash()] = $alternativeName;
             Util::getSchema($this->api, $alternativeName);
         }

--- a/Model/ModelRegistry.php
+++ b/Model/ModelRegistry.php
@@ -40,9 +40,10 @@ final class ModelRegistry
     {
         $this->modelDescribers = $modelDescribers;
         $this->api = $api;
+        $this->alternativeNames = []; // last rule wins
 
         foreach (array_reverse($alternativeNames) as $alternativeName => $criteria) {
-            $this->alternativeNames[] = $model = new Model(new Type('object', false, $criteria['type']), $criteria['groups']);
+            $this->alternativeNames[] = $model = new Model(new Type('object', $criteria['nullable'] ?? false, $criteria['type']), $criteria['groups']);
             $this->names[$model->getHash()] = $alternativeName;
             Util::getSchema($this->api, $alternativeName);
         }

--- a/ModelDescriber/ObjectModelDescriber.php
+++ b/ModelDescriber/ObjectModelDescriber.php
@@ -43,7 +43,7 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
     public function __construct(
         PropertyInfoExtractorInterface $propertyInfo,
         Reader $reader,
-        $propertyDescribers,
+        iterable $propertyDescribers,
         array $mediaTypes,
         NameConverterInterface $nameConverter = null
     ) {
@@ -99,7 +99,7 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
 
             $types = $this->propertyInfo->getTypes($class, $propertyName);
             if (null === $types || 0 === count($types)) {
-                throw new \LogicException(sprintf('The PropertyInfo component was not able to guess the type of %s::$%s. You may need to add a `@var` annotation or use `@SWG\Property(type="")` to make its type explicit.', $class, $propertyName));
+                throw new \LogicException(sprintf('The PropertyInfo component was not able to guess the type of %s::$%s. You may need to add a `@var` annotation or use `@OA\Property(type="")` to make its type explicit.', $class, $propertyName));
             }
 
             $this->describeProperty($types, $model, $property, $propertyName);

--- a/ModelDescriber/ObjectModelDescriber.php
+++ b/ModelDescriber/ObjectModelDescriber.php
@@ -58,6 +58,10 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
     {
         $schema->type = 'object';
 
+        if ($model->getType()->isNullable()) {
+            $schema->nullable = true;
+        }
+
         $class = $model->getType()->getClassName();
         $schema->_context->class = $class;
 
@@ -118,7 +122,7 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
             if ($propertyDescriber->supports($types)) {
                 $propertyDescriber->describe($types, $property, $model->getGroups());
 
-                if (1 === count($types) && $types[0]->isNullable()) {
+                if (1 === count($types) && $types[0]->isNullable() && Type::BUILTIN_TYPE_OBJECT !== $types[0]->getBuiltinType()) {
                     $property->nullable = true;
                 }
 

--- a/ModelDescriber/ObjectModelDescriber.php
+++ b/ModelDescriber/ObjectModelDescriber.php
@@ -118,6 +118,9 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
             if ($propertyDescriber->supports($types)) {
                 $propertyDescriber->describe($types, $property, $model->getGroups());
 
+                if (count($types) === 1 && $types[0]->isNullable()) {
+                    $property->nullable = true;
+                }
                 return;
             }
         }

--- a/ModelDescriber/ObjectModelDescriber.php
+++ b/ModelDescriber/ObjectModelDescriber.php
@@ -58,6 +58,10 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
     {
         $schema->type = 'object';
 
+        if ($model->getType()->isNullable()) {
+            $schema->nullable = true;
+        }
+
         $class = $model->getType()->getClassName();
         $schema->_context->class = $class;
 

--- a/ModelDescriber/ObjectModelDescriber.php
+++ b/ModelDescriber/ObjectModelDescriber.php
@@ -58,10 +58,6 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
     {
         $schema->type = 'object';
 
-        if ($model->getType()->isNullable()) {
-            $schema->nullable = true;
-        }
-
         $class = $model->getType()->getClassName();
         $schema->_context->class = $class;
 

--- a/ModelDescriber/ObjectModelDescriber.php
+++ b/ModelDescriber/ObjectModelDescriber.php
@@ -122,10 +122,6 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
             if ($propertyDescriber->supports($types)) {
                 $propertyDescriber->describe($types, $property, $model->getGroups());
 
-                if (1 === count($types) && $types[0]->isNullable() && Type::BUILTIN_TYPE_OBJECT !== $types[0]->getBuiltinType()) {
-                    $property->nullable = true;
-                }
-
                 return;
             }
         }

--- a/ModelDescriber/ObjectModelDescriber.php
+++ b/ModelDescriber/ObjectModelDescriber.php
@@ -101,29 +101,28 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
             if (null === $types || 0 === count($types)) {
                 throw new \LogicException(sprintf('The PropertyInfo component was not able to guess the type of %s::$%s. You may need to add a `@var` annotation or use `@SWG\Property(type="")` to make its type explicit.', $class, $propertyName));
             }
-            if (count($types) > 1) {
-                throw new \LogicException(sprintf('Property %s::$%s defines more than one type. You can specify the one that should be documented using `@SWG\Property(type="")`.', $class, $propertyName));
-            }
 
-            $type = $types[0];
-            $this->describeProperty($type, $model, $property, $propertyName);
+            $this->describeProperty($types, $model, $property, $propertyName);
         }
     }
 
-    private function describeProperty(Type $type, Model $model, OA\Schema $property, string $propertyName)
+    /**
+     * @param Type[] $types
+     */
+    private function describeProperty(array $types, Model $model, OA\Schema $property, string $propertyName)
     {
         foreach ($this->propertyDescribers as $propertyDescriber) {
             if ($propertyDescriber instanceof ModelRegistryAwareInterface) {
                 $propertyDescriber->setModelRegistry($this->modelRegistry);
             }
-            if ($propertyDescriber->supports($type)) {
-                $propertyDescriber->describe($type, $property, $model->getGroups());
+            if ($propertyDescriber->supports($types)) {
+                $propertyDescriber->describe($types, $property, $model->getGroups());
 
                 return;
             }
         }
 
-        throw new \Exception(sprintf('Type "%s" is not supported in %s::$%s. You may use the `@OA\Property(type="")` annotation to specify it manually.', $type->getBuiltinType(), $model->getType()->getClassName(), $propertyName));
+        throw new \Exception(sprintf('Type "%s" is not supported in %s::$%s. You may use the `@OA\Property(type="")` annotation to specify it manually.', $types[0]->getBuiltinType(), $model->getType()->getClassName(), $propertyName));
     }
 
     public function supports(Model $model): bool

--- a/ModelDescriber/ObjectModelDescriber.php
+++ b/ModelDescriber/ObjectModelDescriber.php
@@ -118,7 +118,7 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
             if ($propertyDescriber->supports($types)) {
                 $propertyDescriber->describe($types, $property, $model->getGroups());
 
-                if (count($types) === 1 && $types[0]->isNullable()) {
+                if (1 === count($types) && $types[0]->isNullable()) {
                     $property->nullable = true;
                 }
                 return;

--- a/ModelDescriber/ObjectModelDescriber.php
+++ b/ModelDescriber/ObjectModelDescriber.php
@@ -121,6 +121,7 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
                 if (1 === count($types) && $types[0]->isNullable()) {
                     $property->nullable = true;
                 }
+
                 return;
             }
         }

--- a/PropertyDescriber/ArrayPropertyDescriber.php
+++ b/PropertyDescriber/ArrayPropertyDescriber.php
@@ -29,9 +29,9 @@ class ArrayPropertyDescriber implements PropertyDescriberInterface, ModelRegistr
         $this->propertyDescribers = $propertyDescribers;
     }
 
-    public function describe(Type $type, OA\Schema $property, array $groups = null)
+    public function describe(array $types, OA\Schema $property, array $groups = null)
     {
-        $type = $type->getCollectionValueType();
+        $type = $types[0]->getCollectionValueType();
         if (null === $type) {
             throw new \LogicException(sprintf('Property "%s" is an array, but its items type isn\'t specified. You can specify that by using the type `string[]` for instance or `@SWG\Property(type="array", @SWG\Items(type="string"))`.', $property->title));
         }
@@ -51,8 +51,8 @@ class ArrayPropertyDescriber implements PropertyDescriberInterface, ModelRegistr
         }
     }
 
-    public function supports(Type $type): bool
+    public function supports(array $types): bool
     {
-        return $type->isCollection();
+        return count($types) === 1 && $types[0]->isCollection();
     }
 }

--- a/PropertyDescriber/ArrayPropertyDescriber.php
+++ b/PropertyDescriber/ArrayPropertyDescriber.php
@@ -32,7 +32,7 @@ class ArrayPropertyDescriber implements PropertyDescriberInterface, ModelRegistr
     {
         $type = $types[0]->getCollectionValueType();
         if (null === $type) {
-            throw new \LogicException(sprintf('Property "%s" is an array, but its items type isn\'t specified. You can specify that by using the type `string[]` for instance or `@SWG\Property(type="array", @SWG\Items(type="string"))`.', $property->title));
+            throw new \LogicException(sprintf('Property "%s" is an array, but its items type isn\'t specified. You can specify that by using the type `string[]` for instance or `@OA\Property(type="array", @OA\Items(type="string"))`.', $property->title));
         }
 
         $property->type = 'array';

--- a/PropertyDescriber/ArrayPropertyDescriber.php
+++ b/PropertyDescriber/ArrayPropertyDescriber.php
@@ -15,7 +15,6 @@ use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareTrait;
 use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 use OpenApi\Annotations as OA;
-use Symfony\Component\PropertyInfo\Type;
 
 class ArrayPropertyDescriber implements PropertyDescriberInterface, ModelRegistryAwareInterface
 {
@@ -43,8 +42,8 @@ class ArrayPropertyDescriber implements PropertyDescriberInterface, ModelRegistr
             if ($propertyDescriber instanceof ModelRegistryAwareInterface) {
                 $propertyDescriber->setModelRegistry($this->modelRegistry);
             }
-            if ($propertyDescriber->supports($type)) {
-                $propertyDescriber->describe($type, $property, $groups);
+            if ($propertyDescriber->supports([$type])) {
+                $propertyDescriber->describe([$type], $property, $groups);
 
                 break;
             }
@@ -53,6 +52,6 @@ class ArrayPropertyDescriber implements PropertyDescriberInterface, ModelRegistr
 
     public function supports(array $types): bool
     {
-        return count($types) === 1 && $types[0]->isCollection();
+        return 1 === count($types) && $types[0]->isCollection();
     }
 }

--- a/PropertyDescriber/BooleanPropertyDescriber.php
+++ b/PropertyDescriber/BooleanPropertyDescriber.php
@@ -12,6 +12,7 @@
 namespace Nelmio\ApiDocBundle\PropertyDescriber;
 
 use OpenApi\Annotations as OA;
+use Symfony\Component\PropertyInfo\Type;
 
 class BooleanPropertyDescriber implements PropertyDescriberInterface
 {
@@ -22,6 +23,6 @@ class BooleanPropertyDescriber implements PropertyDescriberInterface
 
     public function supports(array $types): bool
     {
-        return 1 === count($types) && $types[0]->getBuiltinType();
+        return 1 === count($types) && Type::BUILTIN_TYPE_BOOL === $types[0]->getBuiltinType();
     }
 }

--- a/PropertyDescriber/BooleanPropertyDescriber.php
+++ b/PropertyDescriber/BooleanPropertyDescriber.php
@@ -16,13 +16,13 @@ use Symfony\Component\PropertyInfo\Type;
 
 class BooleanPropertyDescriber implements PropertyDescriberInterface
 {
-    public function describe(Type $type, OA\Schema $property, array $groups = null)
+    public function describe(array $types, OA\Schema $property, array $groups = null)
     {
         $property->type = 'boolean';
     }
 
-    public function supports(Type $type): bool
+    public function supports(array $types): bool
     {
-        return Type::BUILTIN_TYPE_BOOL === $type->getBuiltinType();
+        return count($types) === 1 && $types[0]->getBuiltinType();
     }
 }

--- a/PropertyDescriber/BooleanPropertyDescriber.php
+++ b/PropertyDescriber/BooleanPropertyDescriber.php
@@ -16,9 +16,12 @@ use Symfony\Component\PropertyInfo\Type;
 
 class BooleanPropertyDescriber implements PropertyDescriberInterface
 {
+    use NullablePropertyTrait;
+
     public function describe(array $types, OA\Schema $property, array $groups = null)
     {
         $property->type = 'boolean';
+        $this->setNullableProperty($types[0], $property);
     }
 
     public function supports(array $types): bool

--- a/PropertyDescriber/BooleanPropertyDescriber.php
+++ b/PropertyDescriber/BooleanPropertyDescriber.php
@@ -12,7 +12,6 @@
 namespace Nelmio\ApiDocBundle\PropertyDescriber;
 
 use OpenApi\Annotations as OA;
-use Symfony\Component\PropertyInfo\Type;
 
 class BooleanPropertyDescriber implements PropertyDescriberInterface
 {
@@ -23,6 +22,6 @@ class BooleanPropertyDescriber implements PropertyDescriberInterface
 
     public function supports(array $types): bool
     {
-        return count($types) === 1 && $types[0]->getBuiltinType();
+        return 1 === count($types) && $types[0]->getBuiltinType();
     }
 }

--- a/PropertyDescriber/CompoundPropertyDescriber.php
+++ b/PropertyDescriber/CompoundPropertyDescriber.php
@@ -1,0 +1,60 @@
+<?php
+
+
+namespace Nelmio\ApiDocBundle\PropertyDescriber;
+
+
+use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
+use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareTrait;
+use Nelmio\ApiDocBundle\Model\Model;
+use Nelmio\ApiDocBundle\OpenApiPhp\Util;
+use OpenApi\Annotations as OA;
+use Symfony\Component\PropertyInfo\Type;
+
+class CompoundPropertyDescriber implements PropertyDescriberInterface, ModelRegistryAwareInterface
+{
+    use ModelRegistryAwareTrait;
+
+    public function describe(array $types, OA\Schema $property, array $groups = null)
+    {
+        if ($types[0]->getBuiltinType() === Type::BUILTIN_TYPE_ARRAY) {
+            $property->type = 'array';
+            $property = Util::getChild($property, OA\Items::class);
+        }
+
+        $property->oneOf = $property->oneOf !== OA\UNDEFINED ? $property->oneOf : [];
+
+        foreach ($types as $type) {
+            $ref = $this->modelRegistry->register(new Model(
+                new Type($types[0]->getBuiltinType(), false, $type->getClassName(), $type->isCollection(), $type->getCollectionKeyType(), $type->getCollectionValueType()),
+                $groups
+            ));
+
+            $property->oneOf[] = ['$ref' => $ref];
+        }
+    }
+
+    public function supports(array $types): bool
+    {
+        if (count($types) < 2) {
+            return false;
+        }
+
+        $onlyArrays = false;
+        $onlyObjects = false;
+        /** @var Type $type */
+        foreach ($types as $type) {
+            if ($type->getBuiltinType() === Type::BUILTIN_TYPE_OBJECT) {
+                $onlyObjects = true;
+            } elseif ($type->getBuiltinType() === Type::BUILTIN_TYPE_ARRAY && $type->getCollectionValueType() === Type::BUILTIN_TYPE_OBJECT) {
+                $onlyArrays = true;
+            } else {
+                return false;
+            }
+        }
+
+        return ($onlyArrays && !$onlyObjects) || (!$onlyArrays && $onlyObjects);
+    }
+
+
+}

--- a/PropertyDescriber/CompoundPropertyDescriber.php
+++ b/PropertyDescriber/CompoundPropertyDescriber.php
@@ -29,7 +29,7 @@ class CompoundPropertyDescriber implements PropertyDescriberInterface, ModelRegi
             $property = Util::getChild($property, OA\Items::class);
         }
 
-        $property->oneOf = $property->oneOf !== OA\UNDEFINED ? $property->oneOf : [];
+        $property->oneOf = OA\UNDEFINED !== $property->oneOf ? $property->oneOf : [];
 
         foreach ($types as $type) {
             $ref = $this->modelRegistry->register(new Model(

--- a/PropertyDescriber/CompoundPropertyDescriber.php
+++ b/PropertyDescriber/CompoundPropertyDescriber.php
@@ -1,8 +1,15 @@
 <?php
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace Nelmio\ApiDocBundle\PropertyDescriber;
-
 
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareTrait;
@@ -17,7 +24,7 @@ class CompoundPropertyDescriber implements PropertyDescriberInterface, ModelRegi
 
     public function describe(array $types, OA\Schema $property, array $groups = null)
     {
-        if ($types[0]->getBuiltinType() === Type::BUILTIN_TYPE_ARRAY) {
+        if (Type::BUILTIN_TYPE_ARRAY === $types[0]->getBuiltinType()) {
             $property->type = 'array';
             $property = Util::getChild($property, OA\Items::class);
         }
@@ -36,7 +43,7 @@ class CompoundPropertyDescriber implements PropertyDescriberInterface, ModelRegi
 
     public function supports(array $types): bool
     {
-        if (count($types) < 2) {
+        if (2 < count($types)) {
             return false;
         }
 
@@ -44,9 +51,9 @@ class CompoundPropertyDescriber implements PropertyDescriberInterface, ModelRegi
         $onlyObjects = false;
         /** @var Type $type */
         foreach ($types as $type) {
-            if ($type->getBuiltinType() === Type::BUILTIN_TYPE_OBJECT) {
+            if (Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType()) {
                 $onlyObjects = true;
-            } elseif ($type->getBuiltinType() === Type::BUILTIN_TYPE_ARRAY && $type->getCollectionValueType() === Type::BUILTIN_TYPE_OBJECT) {
+            } elseif (Type::BUILTIN_TYPE_ARRAY === $type->getBuiltinType() && Type::BUILTIN_TYPE_OBJECT === $type->getCollectionValueType()) {
                 $onlyArrays = true;
             } else {
                 return false;

--- a/PropertyDescriber/CompoundPropertyDescriber.php
+++ b/PropertyDescriber/CompoundPropertyDescriber.php
@@ -13,10 +13,8 @@ namespace Nelmio\ApiDocBundle\PropertyDescriber;
 
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareTrait;
-use Nelmio\ApiDocBundle\Model\Model;
 use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 use OpenApi\Annotations as OA;
-use Symfony\Component\PropertyInfo\Type;
 
 class CompoundPropertyDescriber implements PropertyDescriberInterface, ModelRegistryAwareInterface
 {

--- a/PropertyDescriber/CompoundPropertyDescriber.php
+++ b/PropertyDescriber/CompoundPropertyDescriber.php
@@ -62,6 +62,4 @@ class CompoundPropertyDescriber implements PropertyDescriberInterface, ModelRegi
 
         return ($onlyArrays && !$onlyObjects) || (!$onlyArrays && $onlyObjects);
     }
-
-
 }

--- a/PropertyDescriber/DateTimePropertyDescriber.php
+++ b/PropertyDescriber/DateTimePropertyDescriber.php
@@ -16,15 +16,16 @@ use Symfony\Component\PropertyInfo\Type;
 
 class DateTimePropertyDescriber implements PropertyDescriberInterface
 {
-    public function describe(Type $type, OA\Schema $property, array $groups = null)
+    public function describe(array $types, OA\Schema $property, array $groups = null)
     {
         $property->type = 'string';
         $property->format = 'date-time';
     }
 
-    public function supports(Type $type): bool
+    public function supports(array $types): bool
     {
-        return Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType()
-            && is_a($type->getClassName(), \DateTimeInterface::class, true);
+        return count($types) === 1
+            && $types[0]->getBuiltinType() === Type::BUILTIN_TYPE_OBJECT
+            && is_a($types[0]->getClassName(), \DateTimeInterface::class, true);
     }
 }

--- a/PropertyDescriber/DateTimePropertyDescriber.php
+++ b/PropertyDescriber/DateTimePropertyDescriber.php
@@ -16,10 +16,13 @@ use Symfony\Component\PropertyInfo\Type;
 
 class DateTimePropertyDescriber implements PropertyDescriberInterface
 {
+    use NullablePropertyTrait;
+
     public function describe(array $types, OA\Schema $property, array $groups = null)
     {
         $property->type = 'string';
         $property->format = 'date-time';
+        $this->setNullableProperty($types[0], $property);
     }
 
     public function supports(array $types): bool

--- a/PropertyDescriber/DateTimePropertyDescriber.php
+++ b/PropertyDescriber/DateTimePropertyDescriber.php
@@ -24,8 +24,8 @@ class DateTimePropertyDescriber implements PropertyDescriberInterface
 
     public function supports(array $types): bool
     {
-        return count($types) === 1
-            && $types[0]->getBuiltinType() === Type::BUILTIN_TYPE_OBJECT
+        return 1 === count($types)
+            && Type::BUILTIN_TYPE_OBJECT === $types[0]->getBuiltinType()
             && is_a($types[0]->getClassName(), \DateTimeInterface::class, true);
     }
 }

--- a/PropertyDescriber/FloatPropertyDescriber.php
+++ b/PropertyDescriber/FloatPropertyDescriber.php
@@ -24,6 +24,6 @@ class FloatPropertyDescriber implements PropertyDescriberInterface
 
     public function supports(array $types): bool
     {
-        return count($types) === 1 && $types[0]->getBuiltinType() === Type::BUILTIN_TYPE_FLOAT;
+        return 1 === count($types) && Type::BUILTIN_TYPE_FLOAT === $types[0]->getBuiltinType();
     }
 }

--- a/PropertyDescriber/FloatPropertyDescriber.php
+++ b/PropertyDescriber/FloatPropertyDescriber.php
@@ -16,10 +16,13 @@ use Symfony\Component\PropertyInfo\Type;
 
 class FloatPropertyDescriber implements PropertyDescriberInterface
 {
+    use NullablePropertyTrait;
+
     public function describe(array $types, OA\Schema $property, array $groups = null)
     {
         $property->type = 'number';
         $property->format = 'float';
+        $this->setNullableProperty($types[0], $property);
     }
 
     public function supports(array $types): bool

--- a/PropertyDescriber/FloatPropertyDescriber.php
+++ b/PropertyDescriber/FloatPropertyDescriber.php
@@ -16,14 +16,14 @@ use Symfony\Component\PropertyInfo\Type;
 
 class FloatPropertyDescriber implements PropertyDescriberInterface
 {
-    public function describe(Type $type, OA\Schema $property, array $groups = null)
+    public function describe(array $types, OA\Schema $property, array $groups = null)
     {
         $property->type = 'number';
         $property->format = 'float';
     }
 
-    public function supports(Type $type): bool
+    public function supports(array $types): bool
     {
-        return Type::BUILTIN_TYPE_FLOAT === $type->getBuiltinType();
+        return count($types) === 1 && $types[0]->getBuiltinType() === Type::BUILTIN_TYPE_FLOAT;
     }
 }

--- a/PropertyDescriber/IntegerPropertyDescriber.php
+++ b/PropertyDescriber/IntegerPropertyDescriber.php
@@ -16,13 +16,13 @@ use Symfony\Component\PropertyInfo\Type;
 
 class IntegerPropertyDescriber implements PropertyDescriberInterface
 {
-    public function describe(Type $type, OA\Schema $property, array $groups = null)
+    public function describe(array $types, OA\Schema $property, array $groups = null)
     {
         $property->type = 'integer';
     }
 
-    public function supports(Type $type): bool
+    public function supports(array $types): bool
     {
-        return Type::BUILTIN_TYPE_INT === $type->getBuiltinType();
+        return count($types) === 1 && $types[0]->getBuiltinType() === Type::BUILTIN_TYPE_INT;
     }
 }

--- a/PropertyDescriber/IntegerPropertyDescriber.php
+++ b/PropertyDescriber/IntegerPropertyDescriber.php
@@ -23,6 +23,6 @@ class IntegerPropertyDescriber implements PropertyDescriberInterface
 
     public function supports(array $types): bool
     {
-        return count($types) === 1 && $types[0]->getBuiltinType() === Type::BUILTIN_TYPE_INT;
+        return 1 === count($types) && Type::BUILTIN_TYPE_INT === $types[0]->getBuiltinType();
     }
 }

--- a/PropertyDescriber/IntegerPropertyDescriber.php
+++ b/PropertyDescriber/IntegerPropertyDescriber.php
@@ -16,9 +16,12 @@ use Symfony\Component\PropertyInfo\Type;
 
 class IntegerPropertyDescriber implements PropertyDescriberInterface
 {
+    use NullablePropertyTrait;
+
     public function describe(array $types, OA\Schema $property, array $groups = null)
     {
         $property->type = 'integer';
+        $this->setNullableProperty($types[0], $property);
     }
 
     public function supports(array $types): bool

--- a/PropertyDescriber/NullablePropertyTrait.php
+++ b/PropertyDescriber/NullablePropertyTrait.php
@@ -11,8 +11,8 @@
 
 namespace Nelmio\ApiDocBundle\PropertyDescriber;
 
-use Symfony\Component\PropertyInfo\Type;
 use OpenApi\Annotations as OA;
+use Symfony\Component\PropertyInfo\Type;
 
 trait NullablePropertyTrait
 {

--- a/PropertyDescriber/NullablePropertyTrait.php
+++ b/PropertyDescriber/NullablePropertyTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\PropertyDescriber;
+
+use Symfony\Component\PropertyInfo\Type;
+use OpenApi\Annotations as OA;
+
+trait NullablePropertyTrait
+{
+    protected function setNullableProperty(Type $type, OA\Schema $property): void
+    {
+        if ($type->isNullable()) {
+            $property->nullable = true;
+        }
+    }
+}

--- a/PropertyDescriber/ObjectPropertyDescriber.php
+++ b/PropertyDescriber/ObjectPropertyDescriber.php
@@ -28,7 +28,6 @@ class ObjectPropertyDescriber implements PropertyDescriberInterface, ModelRegist
         if ($types[0]->isNullable()) {
             $property->nullable = true;
             $property->anyOf = [['$ref' => $this->modelRegistry->register(new Model($type, $groups))]];
-
             return;
         }
 

--- a/PropertyDescriber/ObjectPropertyDescriber.php
+++ b/PropertyDescriber/ObjectPropertyDescriber.php
@@ -28,6 +28,7 @@ class ObjectPropertyDescriber implements PropertyDescriberInterface, ModelRegist
         if ($types[0]->isNullable()) {
             $property->nullable = true;
             $property->anyOf = [['$ref' => $this->modelRegistry->register(new Model($type, $groups))]];
+
             return;
         }
 

--- a/PropertyDescriber/ObjectPropertyDescriber.php
+++ b/PropertyDescriber/ObjectPropertyDescriber.php
@@ -23,9 +23,7 @@ class ObjectPropertyDescriber implements PropertyDescriberInterface, ModelRegist
 
     public function describe(array $types, OA\Schema $property, array $groups = null)
     {
-        $type = new Type($types[0]->getBuiltinType(), false, $types[0]->getClassName(), $types[0]->isCollection(), $types[0]->getCollectionKeyType(), $types[0]->getCollectionValueType()); // ignore nullable field
-
-        $property->ref = $this->modelRegistry->register(new Model($type, $groups));
+        $property->ref = $this->modelRegistry->register(new Model($types[0], $groups));
     }
 
     public function supports(array $types): bool

--- a/PropertyDescriber/ObjectPropertyDescriber.php
+++ b/PropertyDescriber/ObjectPropertyDescriber.php
@@ -21,15 +21,15 @@ class ObjectPropertyDescriber implements PropertyDescriberInterface, ModelRegist
 {
     use ModelRegistryAwareTrait;
 
-    public function describe(Type $type, OA\Schema $property, array $groups = null)
+    public function describe(array $types, OA\Schema $property, array $groups = null)
     {
-        $type = new Type($type->getBuiltinType(), false, $type->getClassName(), $type->isCollection(), $type->getCollectionKeyType(), $type->getCollectionValueType()); // ignore nullable field
+        $type = new Type($types[0]->getBuiltinType(), false, $types[0]->getClassName(), $types[0]->isCollection(), $types[0]->getCollectionKeyType(), $types[0]->getCollectionValueType()); // ignore nullable field
 
         $property->ref = $this->modelRegistry->register(new Model($type, $groups));
     }
 
-    public function supports(Type $type): bool
+    public function supports(array $types): bool
     {
-        return Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType();
+        return count($types) === 1 && $types[0]->getBuiltinType() === Type::BUILTIN_TYPE_OBJECT;
     }
 }

--- a/PropertyDescriber/ObjectPropertyDescriber.php
+++ b/PropertyDescriber/ObjectPropertyDescriber.php
@@ -23,15 +23,7 @@ class ObjectPropertyDescriber implements PropertyDescriberInterface, ModelRegist
 
     public function describe(array $types, OA\Schema $property, array $groups = null)
     {
-        $type = new Type($types[0]->getBuiltinType(), false, $types[0]->getClassName(), $types[0]->isCollection(), $types[0]->getCollectionKeyType(), $types[0]->getCollectionValueType()); // ignore nullable field
-
-        if ($types[0]->isNullable()) {
-            $property->nullable = true;
-            $property->anyOf = [['$ref' => $this->modelRegistry->register(new Model($type, $groups))]];
-            return;
-        }
-
-        $property->ref = $this->modelRegistry->register(new Model($type, $groups));
+        $property->ref = $this->modelRegistry->register(new Model($types[0], $groups));
     }
 
     public function supports(array $types): bool

--- a/PropertyDescriber/ObjectPropertyDescriber.php
+++ b/PropertyDescriber/ObjectPropertyDescriber.php
@@ -30,6 +30,6 @@ class ObjectPropertyDescriber implements PropertyDescriberInterface, ModelRegist
 
     public function supports(array $types): bool
     {
-        return count($types) === 1 && $types[0]->getBuiltinType() === Type::BUILTIN_TYPE_OBJECT;
+        return 1 === count($types) && Type::BUILTIN_TYPE_OBJECT === $types[0]->getBuiltinType();
     }
 }

--- a/PropertyDescriber/ObjectPropertyDescriber.php
+++ b/PropertyDescriber/ObjectPropertyDescriber.php
@@ -27,7 +27,7 @@ class ObjectPropertyDescriber implements PropertyDescriberInterface, ModelRegist
 
         if ($types[0]->isNullable()) {
             $property->nullable = true;
-            $property->anyOf = [['$ref' => $this->modelRegistry->register(new Model($type, $groups))]];
+            $property->allOf = [['$ref' => $this->modelRegistry->register(new Model($type, $groups))]];
 
             return;
         }

--- a/PropertyDescriber/ObjectPropertyDescriber.php
+++ b/PropertyDescriber/ObjectPropertyDescriber.php
@@ -23,7 +23,15 @@ class ObjectPropertyDescriber implements PropertyDescriberInterface, ModelRegist
 
     public function describe(array $types, OA\Schema $property, array $groups = null)
     {
-        $property->ref = $this->modelRegistry->register(new Model($types[0], $groups));
+        $type = new Type($types[0]->getBuiltinType(), false, $types[0]->getClassName(), $types[0]->isCollection(), $types[0]->getCollectionKeyType(), $types[0]->getCollectionValueType()); // ignore nullable field
+
+        if ($types[0]->isNullable()) {
+            $property->nullable = true;
+            $property->anyOf = [['$ref' => $this->modelRegistry->register(new Model($type, $groups))]];
+            return;
+        }
+
+        $property->ref = $this->modelRegistry->register(new Model($type, $groups));
     }
 
     public function supports(array $types): bool

--- a/PropertyDescriber/PropertyDescriberInterface.php
+++ b/PropertyDescriber/PropertyDescriberInterface.php
@@ -18,15 +18,11 @@ interface PropertyDescriberInterface
 {
     /**
      * @param Type[] $types
-     *
-     * @return bool
      */
     public function describe(array $types, Schema $property, array $groups = null);
 
     /**
      * @param Type[] $types
-     *
-     * @return bool
      */
     public function supports(array $types): bool;
 }

--- a/PropertyDescriber/PropertyDescriberInterface.php
+++ b/PropertyDescriber/PropertyDescriberInterface.php
@@ -18,12 +18,14 @@ interface PropertyDescriberInterface
 {
     /**
      * @param Type[] $types
+     *
      * @return bool
      */
     public function describe(array $types, Schema $property, array $groups = null);
 
     /**
      * @param Type[] $types
+     *
      * @return bool
      */
     public function supports(array $types): bool;

--- a/PropertyDescriber/PropertyDescriberInterface.php
+++ b/PropertyDescriber/PropertyDescriberInterface.php
@@ -16,7 +16,15 @@ use Symfony\Component\PropertyInfo\Type;
 
 interface PropertyDescriberInterface
 {
-    public function describe(Type $type, Schema $property, array $groups = null);
+    /**
+     * @param Type[] $types
+     * @return bool
+     */
+    public function describe(array $types, Schema $property, array $groups = null);
 
-    public function supports(Type $type): bool;
+    /**
+     * @param Type[] $types
+     * @return bool
+     */
+    public function supports(array $types): bool;
 }

--- a/PropertyDescriber/StringPropertyDescriber.php
+++ b/PropertyDescriber/StringPropertyDescriber.php
@@ -23,6 +23,6 @@ class StringPropertyDescriber implements PropertyDescriberInterface
 
     public function supports(array $types): bool
     {
-        return count($types) === 1 && $types[0]->getBuiltinType() === Type::BUILTIN_TYPE_STRING;
+        return 1 === count($types) && Type::BUILTIN_TYPE_STRING === $types[0]->getBuiltinType();
     }
 }

--- a/PropertyDescriber/StringPropertyDescriber.php
+++ b/PropertyDescriber/StringPropertyDescriber.php
@@ -17,6 +17,7 @@ use Symfony\Component\PropertyInfo\Type;
 class StringPropertyDescriber implements PropertyDescriberInterface
 {
     use NullablePropertyTrait;
+
     public function describe(array $types, OA\Schema $property, array $groups = null)
     {
         $property->type = 'string';

--- a/PropertyDescriber/StringPropertyDescriber.php
+++ b/PropertyDescriber/StringPropertyDescriber.php
@@ -16,13 +16,13 @@ use Symfony\Component\PropertyInfo\Type;
 
 class StringPropertyDescriber implements PropertyDescriberInterface
 {
-    public function describe(Type $type, OA\Schema $property, array $groups = null)
+    public function describe(array $types, OA\Schema $property, array $groups = null)
     {
         $property->type = 'string';
     }
 
-    public function supports(Type $type): bool
+    public function supports(array $types): bool
     {
-        return Type::BUILTIN_TYPE_STRING === $type->getBuiltinType();
+        return count($types) === 1 && $types[0]->getBuiltinType() === Type::BUILTIN_TYPE_STRING;
     }
 }

--- a/PropertyDescriber/StringPropertyDescriber.php
+++ b/PropertyDescriber/StringPropertyDescriber.php
@@ -16,9 +16,11 @@ use Symfony\Component\PropertyInfo\Type;
 
 class StringPropertyDescriber implements PropertyDescriberInterface
 {
+    use NullablePropertyTrait;
     public function describe(array $types, OA\Schema $property, array $groups = null)
     {
         $property->type = 'string';
+        $this->setNullableProperty($types[0], $property);
     }
 
     public function supports(array $types): bool

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -90,6 +90,8 @@
         </service>
 
         <service id="nelmio_api_doc.object_model.property_describers.compound" class="Nelmio\ApiDocBundle\PropertyDescriber\CompoundPropertyDescriber" public="false">
+            <argument type="tagged" tag="nelmio_api_doc.object_model.property_describer" />
+
             <tag name="nelmio_api_doc.object_model.property_describer" priority="-1001" />
         </service>
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -89,6 +89,10 @@
             <tag name="nelmio_api_doc.object_model.property_describer" priority="-1000" />
         </service>
 
+        <service id="nelmio_api_doc.object_model.property_describers.compound" class="Nelmio\ApiDocBundle\PropertyDescriber\CompoundPropertyDescriber" public="false">
+            <tag name="nelmio_api_doc.object_model.property_describer" priority="-1001" />
+        </service>
+
         <!-- Form Type Extensions -->
 
         <service id="nelmio_api_doc.form.documentation_extension" class="Nelmio\ApiDocBundle\Form\Extension\DocumentationExtension">

--- a/Tests/Functional/Controller/ApiController.php
+++ b/Tests/Functional/Controller/ApiController.php
@@ -16,6 +16,7 @@ use Nelmio\ApiDocBundle\Annotation\Model;
 use Nelmio\ApiDocBundle\Annotation\Operation;
 use Nelmio\ApiDocBundle\Annotation\Security;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\Article;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\CompoundEntity;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\SymfonyConstraints;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\User;
 use Nelmio\ApiDocBundle\Tests\Functional\Form\DummyType;
@@ -199,6 +200,15 @@ class ApiController
      * @Areas({"area", "area2"})
      */
     public function newAreaAction()
+    {
+    }
+
+    /**
+     * @Route("/compound", methods={"GET", "POST"})
+     *
+     * @OA\Response(response=200, description="Worked well!", @Model(type=CompoundEntity::class))
+     */
+    public function compoundEntityAction()
     {
     }
 }

--- a/Tests/Functional/Entity/CompoundEntity.php
+++ b/Tests/Functional/Entity/CompoundEntity.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
+
+class CompoundEntity
+{
+    /**
+     * @var int|CompoundEntity[]
+     */
+    public $complex;
+}

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -190,7 +190,7 @@ class FunctionalTest extends WebTestCase
                         'type' => 'array',
                     ],
                     'friend' => [
-                        '$ref' => '#/components/schemas/User',
+                        '$ref' => '#/components/schemas/User3',
                     ],
                     'dummy' => [
                         '$ref' => '#/components/schemas/Dummy2',

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -190,7 +190,10 @@ class FunctionalTest extends WebTestCase
                         'type' => 'array',
                     ],
                     'friend' => [
-                        '$ref' => '#/components/schemas/User',
+                        'nullable' => true,
+                        'anyOf' => [
+                            ['$ref' => '#/components/schemas/User']
+                        ]
                     ],
                     'dummy' => [
                         '$ref' => '#/components/schemas/Dummy2',

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -192,8 +192,8 @@ class FunctionalTest extends WebTestCase
                     'friend' => [
                         'nullable' => true,
                         'anyOf' => [
-                            ['$ref' => '#/components/schemas/User']
-                        ]
+                            ['$ref' => '#/components/schemas/User'],
+                        ],
                     ],
                     'dummy' => [
                         '$ref' => '#/components/schemas/Dummy2',

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -191,7 +191,7 @@ class FunctionalTest extends WebTestCase
                     ],
                     'friend' => [
                         'nullable' => true,
-                        'anyOf' => [
+                        'allOf' => [
                             ['$ref' => '#/components/schemas/User'],
                         ],
                     ],

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -192,8 +192,8 @@ class FunctionalTest extends WebTestCase
                     'friend' => [
                         'nullable' => true,
                         'anyOf' => [
-                            ['$ref' => '#/components/schemas/User'],
-                        ],
+                            ['$ref' => '#/components/schemas/User']
+                        ]
                     ],
                     'dummy' => [
                         '$ref' => '#/components/schemas/Dummy2',

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -190,7 +190,7 @@ class FunctionalTest extends WebTestCase
                         'type' => 'array',
                     ],
                     'friend' => [
-                        '$ref' => '#/components/schemas/User3',
+                        '$ref' => '#/components/schemas/User',
                     ],
                     'dummy' => [
                         '$ref' => '#/components/schemas/Dummy2',

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -430,4 +430,19 @@ class FunctionalTest extends WebTestCase
         $this->assertNotHasProperty('bar', $model);
         $this->assertHasProperty('notwhatyouthink', $model);
     }
+
+    public function testCompoundEntityAction()
+    {
+        $model = $this->getModel('CompoundEntity');
+        $this->assertCount(1, $model->properties);
+
+        $this->assertHasProperty('complex', $model);
+
+        $property = $model->properties[0];
+        $this->assertCount(2, $property->oneOf);
+
+        $this->assertSame('integer', $property->oneOf[0]->type);
+        $this->assertSame('array', $property->oneOf[1]->type);
+        $this->assertSame('#/components/schemas/CompoundEntity', $property->oneOf[1]->items->ref);
+    }
 }

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -190,10 +190,7 @@ class FunctionalTest extends WebTestCase
                         'type' => 'array',
                     ],
                     'friend' => [
-                        'nullable' => true,
-                        'anyOf' => [
-                            ['$ref' => '#/components/schemas/User']
-                        ]
+                        '$ref' => '#/components/schemas/User',
                     ],
                     'dummy' => [
                         '$ref' => '#/components/schemas/Dummy2',

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -26,3 +26,12 @@ Here are some additional advices that are more likely to apply to NelmioApiDocBu
   ``@OA\Response(..., @OA\JsonContent(...))`` or ``@OA\Response(..., @OA\XmlContent(...))``.
 
   When you use ``@Model`` directly (``@OA\Response(..., @Model(...)))``), the media type is set by default to ``json``.
+
+BC Breaks
+---------
+
+There are also BC breaks that were introduced in 4.0:
+
+- We migrated from `EXSyst\Component\Swagger\Swagger` to `OpenApi\Annotations\OpenApi` to describe the api in all our describers signature (`DescriberInterface`, `RouteDescriberInterface`, `ModelDescriberInterface`, `PropertyDescriberInterface`).
+
+- `PropertyDescriberInterface` now takes several types as input to leverage compound types support in OpenApi 3.0 (`int|string` for instance).


### PR DESCRIPTION
This PR adds support for Compound types like: `@var Object1|Object2` in Object properties.
It leverages OA3 `oneOf` polymophism feature