### PR TITLE
Change the Expression's pattern from the message to the expression itself

### DIFF
--- a/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
+++ b/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
@@ -70,7 +70,7 @@ class SymfonyConstraintAnnotationReader
                 $values = $annotation->callback ? call_user_func(is_array($annotation->callback) ? $annotation->callback : [$reflectionProperty->class, $annotation->callback]) : $annotation->choices;
                 $property->enum = array_values($values);
             } elseif ($annotation instanceof Assert\Expression) {
-                $this->appendPattern($property, $annotation->message);
+                $this->appendPattern($property, $annotation->expression);
             } elseif ($annotation instanceof Assert\Range) {
                 $property->minimum = $annotation->min;
                 $property->maximum = $annotation->max;

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -371,7 +371,7 @@ class FunctionalTest extends WebTestCase
                 ],
                 'propertyExpression' => [
                     'type' => 'integer',
-                    'pattern' => 'If this is a tech post, the category should be either php or symfony!',
+                    'pattern' => 'this.getCategory() in [\'php\', \'symfony\'] or !this.isTechnicalPost()',
                 ],
                 'propertyRange' => [
                     'type' => 'integer',


### PR DESCRIPTION
### Fix #1641

I am still doubtful about the pattern. Is the expression maybe a little bit too technical to be displayed as it is in the documentation?

Or maybe it would be worth to create a configuration enable/disable annotations to let the user choose what should be displayed?