### PR TITLE
remove pattern added from the Expression Violation message.

### DIFF
--- a/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
+++ b/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
@@ -69,8 +69,6 @@ class SymfonyConstraintAnnotationReader
             } elseif ($annotation instanceof Assert\Choice) {
                 $values = $annotation->callback ? call_user_func(is_array($annotation->callback) ? $annotation->callback : [$reflectionProperty->class, $annotation->callback]) : $annotation->choices;
                 $property->enum = array_values($values);
-            } elseif ($annotation instanceof Assert\Expression) {
-                $this->appendPattern($property, $annotation->message);
             } elseif ($annotation instanceof Assert\Range) {
                 $property->minimum = $annotation->min;
                 $property->maximum = $annotation->max;

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -374,7 +374,6 @@ class FunctionalTest extends WebTestCase
                 ],
                 'propertyExpression' => [
                     'type' => 'integer',
-                    'pattern' => 'If this is a tech post, the category should be either php or symfony!',
                 ],
                 'propertyRange' => [
                     'type' => 'integer',


### PR DESCRIPTION
This error message inside the pattern, confuses the API client showing a violation message instead of having a Regex. Any informatory message for the client should be placed in "description"