### PR TITLE
Register the fallback object model describer only when using jms

### DIFF
--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -18,6 +18,7 @@ use Nelmio\ApiDocBundle\Describer\ExternalDocDescriber;
 use Nelmio\ApiDocBundle\Describer\RouteDescriber;
 use Nelmio\ApiDocBundle\Describer\SwaggerPhpDescriber;
 use Nelmio\ApiDocBundle\ModelDescriber\BazingaHateoasModelDescriber;
+use Nelmio\ApiDocBundle\ModelDescriber\FallbackObjectModelDescriber;
 use Nelmio\ApiDocBundle\ModelDescriber\JMSModelDescriber;
 use Nelmio\ApiDocBundle\Routing\FilteredRouteCollectionBuilder;
 use Symfony\Component\Config\FileLocator;
@@ -163,6 +164,10 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
                     new Reference('annotation_reader'),
                 ])
                 ->addTag('nelmio_api_doc.model_describer', ['priority' => 50]);
+
+            $container->register('nelmio_api_doc.model_describers.object_fallback', FallbackObjectModelDescriber::class)
+                ->setPublic(false)
+                ->addTag('nelmio_api_doc.model_describer', ['priority' => -1000]);
 
             // Bazinga Hateoas metadata support
             if (isset($bundles['BazingaHateoasBundle'])) {

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -47,10 +47,6 @@
             <tag name="nelmio_api_doc.model_describer" />
         </service>
 
-        <service id="nelmio_api_doc.model_describers.object_fallback" class="Nelmio\ApiDocBundle\ModelDescriber\FallbackObjectModelDescriber" public="false">
-            <tag name="nelmio_api_doc.model_describer" priority="-1000" />
-        </service>
-
         <!-- Property Describers -->
         <service id="nelmio_api_doc.object_model.property_describers.array" class="Nelmio\ApiDocBundle\PropertyDescriber\ArrayPropertyDescriber" public="false">
             <argument type="tagged" tag="nelmio_api_doc.object_model.property_describer" />


### PR DESCRIPTION
I believe this should have been done when this class was introduced as this may hide issues when using the symfony serializer.

@goetas if you want to have a look at this :)