### PR TITLE
Disable the OperationId processor

### DIFF
--- a/ApiDocGenerator.php
+++ b/ApiDocGenerator.php
@@ -15,6 +15,7 @@ use Nelmio\ApiDocBundle\Describer\DescriberInterface;
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
 use Nelmio\ApiDocBundle\Model\ModelRegistry;
 use Nelmio\ApiDocBundle\ModelDescriber\ModelDescriberInterface;
+use Nelmio\ApiDocBundle\OpenApiPhp\DefaultOperationId;
 use Nelmio\ApiDocBundle\OpenApiPhp\ModelRegister;
 use OpenApi\Analysis;
 use OpenApi\Annotations\OpenApi;
@@ -97,6 +98,9 @@ final class ApiDocGenerator
 
         // Calculate the associated schemas
         $modelRegistry->registerSchemas();
+
+        $defaultOperationIdProcessor = new DefaultOperationId();
+        $defaultOperationIdProcessor($analysis);
 
         $analysis->process();
         $analysis->validate();

--- a/OpenApiPhp/DefaultOperationId.php
+++ b/OpenApiPhp/DefaultOperationId.php
@@ -27,7 +27,7 @@ final class DefaultOperationId
         $allOperations = $analysis->getAnnotationsOfType(OA\Operation::class);
 
         foreach ($allOperations as $operation) {
-            if ($operation->operationId === OA\UNDEFINED) {
+            if (OA\UNDEFINED === $operation->operationId) {
                 $operation->operationId = null;
             }
         }

--- a/OpenApiPhp/DefaultOperationId.php
+++ b/OpenApiPhp/DefaultOperationId.php
@@ -11,12 +11,8 @@
 
 namespace Nelmio\ApiDocBundle\OpenApiPhp;
 
-use Nelmio\ApiDocBundle\Annotation\Model as ModelAnnotation;
-use Nelmio\ApiDocBundle\Model\Model;
-use Nelmio\ApiDocBundle\Model\ModelRegistry;
 use OpenApi\Analysis;
 use OpenApi\Annotations as OA;
-use Symfony\Component\PropertyInfo\Type;
 
 /**
  * Disable the OperationId processor from zircote/swagger-php as it breaks our documentation by setting non-unique operation ids.

--- a/OpenApiPhp/DefaultOperationId.php
+++ b/OpenApiPhp/DefaultOperationId.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\OpenApiPhp;
+
+use Nelmio\ApiDocBundle\Annotation\Model as ModelAnnotation;
+use Nelmio\ApiDocBundle\Model\Model;
+use Nelmio\ApiDocBundle\Model\ModelRegistry;
+use OpenApi\Analysis;
+use OpenApi\Annotations as OA;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Disable the OperationId processor from zircote/swagger-php as it breaks our documentation by setting non-unique operation ids.
+ * See https://github.com/zircote/swagger-php/pull/483#issuecomment-360739260 for the solution used here.
+ *
+ * @internal
+ */
+final class DefaultOperationId
+{
+    public function __invoke(Analysis $analysis)
+    {
+        $allOperations = $analysis->getAnnotationsOfType(OA\Operation::class);
+
+        foreach ($allOperations as $operation) {
+            if ($operation->operationId === OA\UNDEFINED) {
+                $operation->operationId = null;
+            }
+        }
+    }
+}

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -456,4 +456,11 @@ class FunctionalTest extends WebTestCase
         $operation = $this->getOperation('/api/invoke', 'get');
         $this->assertSame('Invokable!', $this->getOperationResponse($operation, 200)->description);
     }
+
+    public function testDefaultOperationId()
+    {
+        $operation = $this->getOperation('/api/article/{id}', 'get');
+        var_dump($operation->operationId);
+        $this->assertNull($operation->operationId);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/nelmio/NelmioApiDocBundle/issues/1676 by disabling the OperationId from zircote/swagger-php (see https://github.com/zircote/swagger-php/blob/91bfae956a5db9f777f5cd091f46c900928fc5e0/src/Processors/OperationId.php).

It's been enabled by default in swagger-php 3.x but it is not working well with the custom contexts we use, so I think it's better to shortcut this processor.