### PR TITLE
Fix nullable array properties

### DIFF
--- a/PropertyDescriber/ArrayPropertyDescriber.php
+++ b/PropertyDescriber/ArrayPropertyDescriber.php
@@ -19,6 +19,7 @@ use OpenApi\Annotations as OA;
 class ArrayPropertyDescriber implements PropertyDescriberInterface, ModelRegistryAwareInterface
 {
     use ModelRegistryAwareTrait;
+    use NullablePropertyTrait;
 
     /** @var PropertyDescriberInterface[] */
     private $propertyDescribers;
@@ -37,6 +38,7 @@ class ArrayPropertyDescriber implements PropertyDescriberInterface, ModelRegistr
 
         $property->type = 'array';
         $property = Util::getChild($property, OA\Items::class);
+        $this->setNullableProperty($types[0], $property);
 
         foreach ($this->propertyDescribers as $propertyDescriber) {
             if ($propertyDescriber instanceof ModelRegistryAwareInterface) {

--- a/PropertyDescriber/ArrayPropertyDescriber.php
+++ b/PropertyDescriber/ArrayPropertyDescriber.php
@@ -37,8 +37,8 @@ class ArrayPropertyDescriber implements PropertyDescriberInterface, ModelRegistr
         }
 
         $property->type = 'array';
-        $property = Util::getChild($property, OA\Items::class);
         $this->setNullableProperty($types[0], $property);
+        $property = Util::getChild($property, OA\Items::class);
 
         foreach ($this->propertyDescribers as $propertyDescriber) {
             if ($propertyDescriber instanceof ModelRegistryAwareInterface) {

--- a/Tests/Functional/Entity/User.php
+++ b/Tests/Functional/Entity/User.php
@@ -151,6 +151,10 @@ class User
     {
     }
 
+    public function setFriends(array $friends = [])
+    {
+    }
+
     public function setDummy(Dummy $dummy)
     {
     }

--- a/Tests/Functional/Entity/User.php
+++ b/Tests/Functional/Entity/User.php
@@ -81,6 +81,11 @@ class User
     private $friend;
 
     /**
+     * @var User[]|null
+     */
+    private $friends;
+
+    /**
      * @var string
      *
      * @OA\Property(enum = {"disabled", "enabled"})

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -195,6 +195,13 @@ class FunctionalTest extends WebTestCase
                             ['$ref' => '#/components/schemas/User'],
                         ],
                     ],
+                    'friends' => [
+                        'nullable' => true,
+                        'items' => [
+                            '$ref' => '#/components/schemas/User',
+                        ],
+                        'type' => 'array',
+                    ],
                     'dummy' => [
                         '$ref' => '#/components/schemas/Dummy2',
                     ],

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -467,7 +467,6 @@ class FunctionalTest extends WebTestCase
     public function testDefaultOperationId()
     {
         $operation = $this->getOperation('/api/article/{id}', 'get');
-        var_dump($operation->operationId);
         $this->assertNull($operation->operationId);
     }
 }


### PR DESCRIPTION
This PR fixes nullable array property descriptions:

```
/**
 * @var Class[]|null
 */
$property;
```

will be now described also with nullable flag in OA specs.