### PR TITLE
Supports reflection for routes configured in PHP files.

### DIFF
--- a/Util/ControllerReflector.php
+++ b/Util/ControllerReflector.php
@@ -40,21 +40,31 @@ class ControllerReflector
      *
      * @return \ReflectionMethod|null
      */
-    public function getReflectionMethod(string $controller)
+    public function getReflectionMethod($controller)
     {
-        $callable = $this->getClassAndMethod($controller);
-        if (null === $callable) {
-            return;
+        if (is_string($controller)) {
+            $controller = $this->getClassAndMethod($controller);
+            if (null === $controller) {
+                return null;
+            }
         }
 
-        list($class, $method) = $callable;
+        return $this->geReflectionMethodByClassNameAndMethodName(...$controller);
+    }
 
+    /**
+     * @return \ReflectionMethod|null
+     */
+    public function geReflectionMethodByClassNameAndMethodName(string $class, string $method)
+    {
         try {
             return new \ReflectionMethod($class, $method);
         } catch (\ReflectionException $e) {
             // In case we can't reflect the controller, we just
             // ignore the route
         }
+
+        return null;
     }
 
     private function getClassAndMethod(string $controller)


### PR DESCRIPTION
PR for the issue #1698

By default the PHP configuration routes returns an array with the controller name and method, since the reflection class was typed for string only this was causing an exception when the user was not using YAML or XML configuration.
This changes removes the string type hint from the method and checks if it's an array or string to do the reflection.