### PR TITLE
Fix incorrect media types in FosRestDescriber

### DIFF
--- a/RouteDescriber/FosRestDescriber.php
+++ b/RouteDescriber/FosRestDescriber.php
@@ -113,11 +113,11 @@ final class FosRestDescriber implements RouteDescriberInterface
         $requestBody->content = OA\UNDEFINED !== $requestBody->content ? $requestBody->content : [];
         switch ($type) {
             case 'json':
-                $contentType = 'application\json';
+                $contentType = 'application/json';
 
                 break;
             case 'xml':
-                $contentType = 'application\xml';
+                $contentType = 'application/xml';
 
                 break;
             default:

--- a/Tests/Functional/FOSRestTest.php
+++ b/Tests/Functional/FOSRestTest.php
@@ -29,7 +29,7 @@ class FOSRestTest extends WebTestCase
         $this->assertHasParameter('foo', 'query', $operation);
         $this->assertInstanceOf(OA\RequestBody::class, $operation->requestBody);
 
-        $bodySchema = $operation->requestBody->content['application\json']->schema;
+        $bodySchema = $operation->requestBody->content['application/json']->schema;
 
         $this->assertHasProperty('bar', $bodySchema);
         $this->assertHasProperty('baz', $bodySchema);


### PR DESCRIPTION
Hello, 

i came across this incorrect backslash in `application\json` media type, when i was using FOSRest @ReqeustParam annotation to define request body.