### PR TITLE
Remove the @internal tag to avoid deprecations on symfony 5.1 (#1673)

### DIFF
--- a/RouteDescriber/RouteDescriberTrait.php
+++ b/RouteDescriber/RouteDescriberTrait.php
@@ -15,9 +15,6 @@ use EXSyst\Component\Swagger\Operation;
 use EXSyst\Component\Swagger\Swagger;
 use Symfony\Component\Routing\Route;
 
-/**
- * @internal
- */
 trait RouteDescriberTrait
 {
     /**


### PR DESCRIPTION
Fix #1673

Looking at the discussion of the issue, this was the proposed fix.