### PR TITLE
(feat): add utf-8 charset to response

### DIFF
--- a/Controller/SwaggerUiController.php
+++ b/Controller/SwaggerUiController.php
@@ -65,10 +65,12 @@ final class SwaggerUiController
             $spec['basePath'] = $request->getBaseUrl();
         }
 
-        return new Response(
+        $response = new Response(
             $this->twig->render('@NelmioApiDoc/SwaggerUi/index.html.twig', ['swagger_data' => ['spec' => $spec]]),
             Response::HTTP_OK,
             ['Content-Type' => 'text/html']
         );
+
+        return $response->setCharset('UTF-8');
     }
 }

--- a/Tests/Functional/SwaggerUiTest.php
+++ b/Tests/Functional/SwaggerUiTest.php
@@ -33,6 +33,7 @@ class SwaggerUiTest extends WebTestCase
 
         $response = $this->client->getResponse();
         $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('UTF-8', $response->getCharset());
         $this->assertEquals('text/html; charset=UTF-8', $response->headers->get('Content-Type'));
 
         $expected = $this->getSwaggerDefinition()->toArray();


### PR DESCRIPTION
`swagger-ui-bundle` is very sensible to encoding changes because of the
RegExp performed.

ensuring UTF-8 on the response prevents end-user config to break it.

the annotations already needs to be UTF-8 compatible to generate the
JSON, so it should not break users applications.

when i was improving the tests to check the charset i saw that it was already tested using the `content-type` header, but using symfony 3.4.44 with the version 3.7.4 of this bundle the `getCharset` was returning `null`

(i dont know if i should open for this branch... but seemed the better option)