### PR TITLE
Fix Fos rest query param with map

### DIFF
--- a/RouteDescriber/FosRestDescriber.php
+++ b/RouteDescriber/FosRestDescriber.php
@@ -58,6 +58,10 @@ final class FosRestDescriber implements RouteDescriberInterface
                         $parameter->description = $annotation->description;
                     }
 
+                    if ($annotation->map) {
+                        $parameter->explode = true;
+                    }
+
                     $schema = Util::getChild($parameter, OA\Schema::class);
                     $this->describeCommonSchemaFromAnnotation($schema, $annotation);
                 } else {
@@ -153,7 +157,6 @@ final class FosRestDescriber implements RouteDescriberInterface
 
         if ($annotation->map) {
             $schema->type = 'array';
-            $schema->collectionFormat = 'multi';
             $schema->items = Util::getChild($schema, OA\Items::class);
         }
 


### PR DESCRIPTION
I was facing some errors using our swagger in json because of `collectionFormat` with `multi` value is invalid since it's part of Open Api 2 spec.
It comes from `@Rest\QueryParam` with map option which generate this.