### PR TITLE
Support oauth2 scopes in Security annotation

### DIFF
--- a/Annotation/Security.php
+++ b/Annotation/Security.php
@@ -21,6 +21,7 @@ class Security extends AbstractAnnotation
     /** {@inheritdoc} */
     public static $_types = [
         'name' => 'string',
+        'scopes' => '[string]',
     ];
 
     public static $_required = ['name'];
@@ -29,4 +30,9 @@ class Security extends AbstractAnnotation
      * @var string
      */
     public $name;
+
+    /**
+     * @var string[]
+     */
+    public $scopes = [];
 }

--- a/Describer/OpenApiPhpDescriber.php
+++ b/Describer/OpenApiPhpDescriber.php
@@ -102,7 +102,7 @@ final class OpenApiPhpDescriber
 
                 if ($annotation instanceof Security) {
                     $annotation->validate();
-                    $mergeProperties->security[] = [$annotation->name => []];
+                    $mergeProperties->security[] = [$annotation->name => $annotation->scopes];
 
                     continue;
                 }

--- a/Tests/Functional/Controller/ApiController.php
+++ b/Tests/Functional/Controller/ApiController.php
@@ -160,6 +160,7 @@ class ApiController
      * @OA\Response(response="201", description="")
      * @Security(name="api_key")
      * @Security(name="basic")
+     * @Security(name="oauth2", scopes={"scope_1"})
      */
     public function securityAction()
     {

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -338,6 +338,7 @@ class FunctionalTest extends WebTestCase
         $expected = [
             ['api_key' => []],
             ['basic' => []],
+            ['oauth2' => ['scope_1']],
         ];
         $this->assertEquals($expected, $operation->security);
     }


### PR DESCRIPTION
This PR aims at supporting a value in Security annotation, to follow [OpenApi specification](https://swagger.io/specification/#patterned-fields-3).