### PR TITLE
Apply `enum` from Choice Constraints to Items When Choice is Multiple

### DIFF
--- a/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
+++ b/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
@@ -11,9 +11,11 @@
 
 namespace Nelmio\ApiDocBundle\ModelDescriber\Annotations;
 
+use LogicException;
 use Doctrine\Common\Annotations\Reader;
 use OpenApi\Annotations as OA;
 use Symfony\Component\Validator\Constraints as Assert;
+use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 
 /**
  * @internal
@@ -77,8 +79,7 @@ class SymfonyConstraintAnnotationReader
                 $property->minItems = (int) $annotation->min;
                 $property->maxItems = (int) $annotation->max;
             } elseif ($annotation instanceof Assert\Choice) {
-                $values = $annotation->callback ? call_user_func(is_array($annotation->callback) ? $annotation->callback : [$reflection->class, $annotation->callback]) : $annotation->choices;
-                $property->enum = array_values($values);
+                $this->applyEnumFromChoiceConstraint($property, $annotation, $reflection);
             } elseif ($annotation instanceof Assert\Range) {
                 $property->minimum = (int) $annotation->min;
                 $property->maximum = (int) $annotation->max;
@@ -126,5 +127,24 @@ class SymfonyConstraintAnnotationReader
         } else {
             $property->pattern = $newPattern;
         }
+    }
+
+    /**
+     * @var ReflectionProperty|ReflectionClass $reflection
+     */
+    private function applyEnumFromChoiceConstraint(OA\Schema $property, Assert\Choice $choice, $reflection) : void
+    {
+        if ($choice->callback) {
+            $enumValues = call_user_func(is_array($choice->callback) ? $choice->callback : [$reflection->class, $choice->callback]);
+        } else {
+            $enumValues = $choice->choices;
+        }
+
+        $setEnumOnThis = $property;
+        if ($choice->multiple) {
+            $setEnumOnThis = Util::getChild($property, OA\Items::class);
+        }
+
+        $setEnumOnThis->enum = array_values($enumValues);
     }
 }

--- a/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
+++ b/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
@@ -11,11 +11,10 @@
 
 namespace Nelmio\ApiDocBundle\ModelDescriber\Annotations;
 
-use LogicException;
 use Doctrine\Common\Annotations\Reader;
+use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 use OpenApi\Annotations as OA;
 use Symfony\Component\Validator\Constraints as Assert;
-use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 
 /**
  * @internal
@@ -130,9 +129,9 @@ class SymfonyConstraintAnnotationReader
     }
 
     /**
-     * @var ReflectionProperty|ReflectionClass $reflection
+     * @var ReflectionProperty|ReflectionClass
      */
-    private function applyEnumFromChoiceConstraint(OA\Schema $property, Assert\Choice $choice, $reflection) : void
+    private function applyEnumFromChoiceConstraint(OA\Schema $property, Assert\Choice $choice, $reflection): void
     {
         if ($choice->callback) {
             $enumValues = call_user_func(is_array($choice->callback) ? $choice->callback : [$reflection->class, $choice->callback]);

--- a/Tests/Functional/Entity/SymfonyConstraints.php
+++ b/Tests/Functional/Entity/SymfonyConstraints.php
@@ -72,6 +72,13 @@ class SymfonyConstraints
     private $propertyChoiceWithCallbackWithoutClass;
 
     /**
+     * @var string[]
+     *
+     * @Assert\Choice(multiple=true, choices={"choice1", "choice2"})
+     */
+    private $propertyChoiceWithMultiple;
+
+    /**
      * @var int
      *
      * @Assert\Expression(
@@ -143,6 +150,11 @@ class SymfonyConstraints
     public function setPropertyChoiceWithCallbackWithoutClass(int $propertyChoiceWithCallbackWithoutClass): void
     {
         $this->propertyChoiceWithCallbackWithoutClass = $propertyChoiceWithCallbackWithoutClass;
+    }
+
+    public function setPropertyChoiceWithMultiple(array $propertyChoiceWithMultiple) : void
+    {
+        $this->propertyChoiceWithMultiple = $propertyChoiceWithMultiple;
     }
 
     public function setPropertyExpression(int $propertyExpression): void

--- a/Tests/Functional/Entity/SymfonyConstraints.php
+++ b/Tests/Functional/Entity/SymfonyConstraints.php
@@ -152,7 +152,7 @@ class SymfonyConstraints
         $this->propertyChoiceWithCallbackWithoutClass = $propertyChoiceWithCallbackWithoutClass;
     }
 
-    public function setPropertyChoiceWithMultiple(array $propertyChoiceWithMultiple) : void
+    public function setPropertyChoiceWithMultiple(array $propertyChoiceWithMultiple): void
     {
         $this->propertyChoiceWithMultiple = $propertyChoiceWithMultiple;
     }

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -395,6 +395,13 @@ class FunctionalTest extends WebTestCase
                     'type' => 'integer',
                     'enum' => ['choice1', 'choice2'],
                 ],
+                'propertyChoiceWithMultiple' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'string',
+                        'enum' => ['choice1', 'choice2'],
+                    ],
+                ],
                 'propertyExpression' => [
                     'type' => 'integer',
                 ],

--- a/Tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
+++ b/Tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
@@ -105,4 +105,25 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         // expect enum to be numeric array with sequential keys (not [1 => "active", 2 => "active"])
         $this->assertEquals($schema->properties[0]->enum, ['active', 'blocked']);
     }
+
+    public function testMultipleChoiceConstraintsApplyEnumToItems()
+    {
+        $entity = new class() {
+            /**
+             * @Assert\Choice(choices={"one", "two"}, multiple=true)
+             */
+            private $property1;
+        };
+
+        $schema = new OA\Schema([]);
+        $schema->merge([new OA\Property(['property' => 'property1'])]);
+
+        $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader(new AnnotationReader());
+        $symfonyConstraintAnnotationReader->setSchema($schema);
+
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+
+        $this->assertInstanceOf(OA\Items::class, $schema->properties[0]->items);
+        $this->assertEquals($schema->properties[0]->items->enum, ['one', 'two']);
+    }
 }

--- a/Tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
+++ b/Tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
@@ -106,7 +106,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $this->assertEquals($schema->properties[0]->enum, ['active', 'blocked']);
     }
 
-    public function testMultieChoiceConstraintsApplyEnumToItems()
+    public function testMultipleChoiceConstraintsApplyEnumToItems()
     {
         $entity = new class() {
             /**
@@ -123,7 +123,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
 
         $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
 
-        $this->asertInstanceOf(OA\Items::class, $schema->properties[0]->items);
+        $this->assertInstanceOf(OA\Items::class, $schema->properties[0]->items);
         $this->assertEquals($schema->properties[0]->items->enum, ['one', 'two']);
     }
 

--- a/Tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
+++ b/Tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
@@ -125,7 +125,6 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
 
         $this->asertInstanceOf(OA\Items::class, $schema->properties[0]->items);
         $this->assertEquals($schema->properties[0]->items->enum, ['one', 'two']);
-
     }
 
     /**
@@ -174,6 +173,5 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
 
         $this->assertSame(OA\UNDEFINED, $schema->properties[0]->minLength);
         $this->assertSame(100, $schema->properties[0]->maxLength);
-
     }
 }

--- a/Tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
+++ b/Tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
@@ -106,7 +106,6 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $this->assertEquals($schema->properties[0]->enum, ['active', 'blocked']);
     }
 
-
     public function testMultieChoiceConstraintsApplyEnumToItems()
     {
         $entity = new class() {
@@ -124,12 +123,11 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
 
         $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
 
-
         $this->asertInstanceOf(OA\Items::class, $schema->properties[0]->items);
         $this->assertEquals($schema->properties[0]->items->enum, ['one', 'two']);
 
     }
-  
+
     /**
      * @group https://github.com/nelmio/NelmioApiDocBundle/issues/1780
      */
@@ -138,7 +136,6 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $entity = new class() {
             /**
              * @Assert\Length(min = 1)
-
              */
             private $property1;
         };
@@ -150,9 +147,6 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $symfonyConstraintAnnotationReader->setSchema($schema);
 
         $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
-
-
-
 
         $this->assertSame(OA\UNDEFINED, $schema->properties[0]->maxLength);
         $this->assertSame(1, $schema->properties[0]->minLength);


### PR DESCRIPTION
Should fix https://github.com/nelmio/NelmioApiDocBundle/issues/1783 (sick of me yet?! 🙃 )

Otherwise JSON schema like this is generated:

```
"property": {
  "type": "array",
  "enum": ["one", "two", "three"],
  "items": {
    "type": "string"
  }
}
```

With this change, however, this schema is generated:

```
"property": {
  "type": "array",
  "items": {
    "type": "string",
    "enum": ["one", "two", "three"]
  }
}
```

A possible downside here is that the symfony constraint stuff happens
before types are figured out from PHPDoc. So it's _possible_ to end up
with something that won't validated. Take something like this:

```
/**
 * @Assert\Choice(multiple=true, choices={"..."})
 * @var string
 */
```

This would generate:

```
"property": {
  "type": "string",
  "items": {
    "enum": ["..."]
  }
}
```