### PR TITLE
Allow for generation of JSON spec from Documentation Controller when injected as a service

### DIFF
--- a/Controller/DocumentationController.php
+++ b/Controller/DocumentationController.php
@@ -29,6 +29,11 @@ final class DocumentationController
 
     public function __invoke(Request $request, $area = 'default')
     {
+        return new JsonResponse($this->generate($request, $area));
+    }
+
+    public function generate(Request $request, $area = 'default')
+    {
         if (!$this->generatorLocator->has($area)) {
             throw new BadRequestHttpException(sprintf('Area "%s" is not supported as it isn\'t defined in config.', $area));
         }
@@ -40,6 +45,6 @@ final class DocumentationController
             $spec->servers = [new Server(['url' => $request->getSchemeAndHttpHost().$request->getBaseUrl()])];
         }
 
-        return new JsonResponse($spec);
+        return $spec;
     }
 }


### PR DESCRIPTION
Hi,

I want to be able to generate the spec from within another controller and include it in a response from that controller. 

Currently, it's pretty easy to add configure the Documentation Controller so that it can be injected as a service:

config/packages/services.yaml:
```yaml
Nelmio\ApiDocBundle\Controller\DocumentationController: '@nelmio_api_doc.controller.swagger'
```

Controller:
```php
...
use Nelmio\ApiDocBundle\Controller\DocumentationController;
...
class SomeGenericController extends AbstractController
{
    public function __construct(
        DocumentationController $documentationController
    ) {
        $this->documentationController = $documentationController;
    }

    public function index(Request $request): Response
    {
        return $this->render(
            'abc/index.html.twig', [
                'spec' => $this->documentationController->generate($request, 'area')
            ]
        );
    }
}
```

I want to do this as I am actually generating code client side using the API spec.

Seeing as there isn't really much of a code change (beyond encapsulating the contents of the __invoke() function in another function I did not write any tests. The current tests that are in place do pass with this change.

I can add documentation if this pull request seems reasonable. 

closes #1782