### PR TITLE
Fix Open API doc for DateTime requirements

### DIFF
--- a/RouteDescriber/FosRestDescriber.php
+++ b/RouteDescriber/FosRestDescriber.php
@@ -18,6 +18,7 @@ use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 use OpenApi\Annotations as OA;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\DateTime;
 use Symfony\Component\Validator\Constraints\Regex;
 
 final class FosRestDescriber implements RouteDescriberInterface
@@ -104,6 +105,11 @@ final class FosRestDescriber implements RouteDescriberInterface
     private function getFormat($requirements)
     {
         if ($requirements instanceof Constraint && !$requirements instanceof Regex) {
+            
+            if ($requirements instanceof DateTime) {
+                return 'date-time';
+            }
+            
             $reflectionClass = new \ReflectionClass($requirements);
 
             return $reflectionClass->getShortName();

--- a/RouteDescriber/FosRestDescriber.php
+++ b/RouteDescriber/FosRestDescriber.php
@@ -107,7 +107,7 @@ final class FosRestDescriber implements RouteDescriberInterface
         if ($requirements instanceof Constraint && !$requirements instanceof Regex) {
             if ($requirements instanceof DateTime) {
                 // As defined per RFC3339
-                if ('Y-m-d\TH:i:s' === $requirements->format) {
+                if ('Y-m-d\TH:i:s' === $requirements->format || 'c' === $requirements->format) {
                     return 'date-time';
                 } elseif ('Y-m-d' === $requirements->format) {
                     return 'date';

--- a/RouteDescriber/FosRestDescriber.php
+++ b/RouteDescriber/FosRestDescriber.php
@@ -107,7 +107,12 @@ final class FosRestDescriber implements RouteDescriberInterface
         if ($requirements instanceof Constraint && !$requirements instanceof Regex) {
             
             if ($requirements instanceof DateTime) {
-                return 'date-time';
+                // As defined per RFC3339
+                if ($requirements->format === 'Y-m-d\TH:i:s') {
+                    return 'date-time';
+                } else if ($requirements->format === 'Y-m-d') {
+                    return 'date';
+                }
             }
             
             $reflectionClass = new \ReflectionClass($requirements);

--- a/RouteDescriber/FosRestDescriber.php
+++ b/RouteDescriber/FosRestDescriber.php
@@ -105,7 +105,6 @@ final class FosRestDescriber implements RouteDescriberInterface
     private function getFormat($requirements)
     {
         if ($requirements instanceof Constraint && !$requirements instanceof Regex) {
-
             if ($requirements instanceof DateTime) {
                 // As defined per RFC3339
                 if ('Y-m-d\TH:i:s' === $requirements->format) {

--- a/RouteDescriber/FosRestDescriber.php
+++ b/RouteDescriber/FosRestDescriber.php
@@ -105,16 +105,16 @@ final class FosRestDescriber implements RouteDescriberInterface
     private function getFormat($requirements)
     {
         if ($requirements instanceof Constraint && !$requirements instanceof Regex) {
-            
+
             if ($requirements instanceof DateTime) {
                 // As defined per RFC3339
-                if ($requirements->format === 'Y-m-d\TH:i:s') {
+                if ('Y-m-d\TH:i:s' === $requirements->format) {
                     return 'date-time';
-                } else if ($requirements->format === 'Y-m-d') {
+                } elseif ('Y-m-d' === $requirements->format) {
                     return 'date';
                 }
             }
-            
+
             $reflectionClass = new \ReflectionClass($requirements);
 
             return $reflectionClass->getShortName();

--- a/RouteDescriber/FosRestDescriber.php
+++ b/RouteDescriber/FosRestDescriber.php
@@ -107,10 +107,12 @@ final class FosRestDescriber implements RouteDescriberInterface
         if ($requirements instanceof Constraint && !$requirements instanceof Regex) {
             if ($requirements instanceof DateTime) {
                 // As defined per RFC3339
-                if ('Y-m-d\TH:i:s' === $requirements->format || 'c' === $requirements->format) {
+                if (\DateTimeInterface::RFC3339 === $requirements->format || 'c' === $requirements->format) {
                     return 'date-time';
                 } elseif ('Y-m-d' === $requirements->format) {
                     return 'date';
+                } else {
+                    return null;
                 }
             }
 

--- a/RouteDescriber/FosRestDescriber.php
+++ b/RouteDescriber/FosRestDescriber.php
@@ -107,7 +107,7 @@ final class FosRestDescriber implements RouteDescriberInterface
         if ($requirements instanceof Constraint && !$requirements instanceof Regex) {
             if ($requirements instanceof DateTime) {
                 // As defined per RFC3339
-                if (\DateTimeInterface::RFC3339 === $requirements->format || 'c' === $requirements->format) {
+                if (\DateTime::RFC3339 === $requirements->format || 'c' === $requirements->format) {
                     return 'date-time';
                 } elseif ('Y-m-d' === $requirements->format) {
                     return 'date';

--- a/RouteDescriber/FosRestDescriber.php
+++ b/RouteDescriber/FosRestDescriber.php
@@ -109,11 +109,13 @@ final class FosRestDescriber implements RouteDescriberInterface
                 // As defined per RFC3339
                 if (\DateTime::RFC3339 === $requirements->format || 'c' === $requirements->format) {
                     return 'date-time';
-                } elseif ('Y-m-d' === $requirements->format) {
-                    return 'date';
-                } else {
-                    return null;
                 }
+                
+                if ('Y-m-d' === $requirements->format) {
+                    return 'date';
+                }
+
+                return null;
             }
 
             $reflectionClass = new \ReflectionClass($requirements);

--- a/Tests/Functional/Controller/FOSRestController.php
+++ b/Tests/Functional/Controller/FOSRestController.php
@@ -30,6 +30,7 @@ class FOSRestController
      * @RequestParam(name="Barraa", key="bar", requirements="\d+")
      * @RequestParam(name="baz", requirements=@IsTrue)
      * @RequestParam(name="datetime", requirements=@DateTime("Y-m-d\TH:i:s"))
+     * @RequestParam(name="datetimeAlt", requirements=@DateTime("c"))
      * @RequestParam(name="date", requirements=@DateTime("Y-m-d"))
      */
     public function fosrestAction()

--- a/Tests/Functional/Controller/FOSRestController.php
+++ b/Tests/Functional/Controller/FOSRestController.php
@@ -14,6 +14,7 @@ namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
 use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\RequestParam;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Validator\Constraints\DateTime;
 use Symfony\Component\Validator\Constraints\IsTrue;
 use Symfony\Component\Validator\Constraints\Regex;
 
@@ -28,6 +29,8 @@ class FOSRestController
      * @QueryParam(name="mapped", map=true)
      * @RequestParam(name="Barraa", key="bar", requirements="\d+")
      * @RequestParam(name="baz", requirements=@IsTrue)
+     * @RequestParam(name="datetime", requirements=@DateTime("Y-m-d\TH:i:s"))
+     * @RequestParam(name="date", requirements=@DateTime("Y-m-d"))
      */
     public function fosrestAction()
     {

--- a/Tests/Functional/Controller/FOSRestController.php
+++ b/Tests/Functional/Controller/FOSRestController.php
@@ -29,8 +29,9 @@ class FOSRestController
      * @QueryParam(name="mapped", map=true)
      * @RequestParam(name="Barraa", key="bar", requirements="\d+")
      * @RequestParam(name="baz", requirements=@IsTrue)
-     * @RequestParam(name="datetime", requirements=@DateTime("Y-m-d\TH:i:s"))
+     * @RequestParam(name="datetime", requirements=@DateTime("Y-m-d\TH:i:sP"))
      * @RequestParam(name="datetimeAlt", requirements=@DateTime("c"))
+     * @RequestParam(name="datetimeNoFormat", requirements=@DateTime())
      * @RequestParam(name="date", requirements=@DateTime("Y-m-d"))
      */
     public function fosrestAction()

--- a/Tests/Functional/FOSRestTest.php
+++ b/Tests/Functional/FOSRestTest.php
@@ -50,11 +50,11 @@ class FOSRestTest extends WebTestCase
         $this->assertEquals(OA\UNDEFINED, $bazProperty->pattern);
         $this->assertEquals('IsTrue', $bazProperty->format);
 
-        $barProperty = $this->getProperty($bodySchema, 'datetime');
-        $this->assertEquals('date-time', $barProperty->format);
+        $dateTimeProperty = $this->getProperty($bodySchema, 'datetime');
+        $this->assertEquals('date-time', $dateTimeProperty->format);
 
-        $barProperty = $this->getProperty($bodySchema, 'date');
-        $this->assertEquals('date', $barProperty->format);
+        $dateProperty = $this->getProperty($bodySchema, 'date');
+        $this->assertEquals('date', $dateProperty->format);
 
         // The _format path attribute should be removed
         $this->assertNotHasParameter('_format', 'path', $operation);

--- a/Tests/Functional/FOSRestTest.php
+++ b/Tests/Functional/FOSRestTest.php
@@ -50,6 +50,12 @@ class FOSRestTest extends WebTestCase
         $this->assertEquals(OA\UNDEFINED, $bazProperty->pattern);
         $this->assertEquals('IsTrue', $bazProperty->format);
 
+        $barProperty = $this->getProperty($bodySchema, 'datetime');
+        $this->assertEquals('date-time', $barProperty->format);
+
+        $barProperty = $this->getProperty($bodySchema, 'date');
+        $this->assertEquals('date', $barProperty->format);
+
         // The _format path attribute should be removed
         $this->assertNotHasParameter('_format', 'path', $operation);
     }

--- a/Tests/Functional/FOSRestTest.php
+++ b/Tests/Functional/FOSRestTest.php
@@ -56,6 +56,9 @@ class FOSRestTest extends WebTestCase
         $dateTimeAltProperty = $this->getProperty($bodySchema, 'datetimeAlt');
         $this->assertEquals('date-time', $dateTimeAltProperty->format);
 
+        $dateTimeNoFormatProperty = $this->getProperty($bodySchema, 'datetimeNoFormat');
+        $this->assertEquals(OA\UNDEFINED, $dateTimeNoFormatProperty->format);
+
         $dateProperty = $this->getProperty($bodySchema, 'date');
         $this->assertEquals('date', $dateProperty->format);
 

--- a/Tests/Functional/FOSRestTest.php
+++ b/Tests/Functional/FOSRestTest.php
@@ -53,6 +53,9 @@ class FOSRestTest extends WebTestCase
         $dateTimeProperty = $this->getProperty($bodySchema, 'datetime');
         $this->assertEquals('date-time', $dateTimeProperty->format);
 
+        $dateTimeAltProperty = $this->getProperty($bodySchema, 'datetimeAlt');
+        $this->assertEquals('date-time', $dateTimeAltProperty->format);
+
         $dateProperty = $this->getProperty($bodySchema, 'date');
         $this->assertEquals('date', $dateProperty->format);
 


### PR DESCRIPTION
When using the following requierement:

```
@Rest\QueryParam(name="updatedFrom", strict=true, nullable=true, requirements=@Constraints\DateTime("Y-m-d\TH:i:s"))
```

According to the OpenAPI 3.0 documentation https://swagger.io/specification/, 

We should have ``"format": "date-time"`` rather than ``"format": "DateTime"`` in the generated doc