### PR TITLE
Fix calls to nonexistent method `ControllerReflector::getReflectionClassAndMethod()`

### DIFF
--- a/Routing/FilteredRouteCollectionBuilder.php
+++ b/Routing/FilteredRouteCollectionBuilder.php
@@ -120,22 +120,20 @@ final class FilteredRouteCollectionBuilder
             return true;
         }
 
-        $classAndMethod = $this->controllerReflector->getReflectionClassAndMethod($route->getDefault('_controller'));
+        $reflectionMethod = $this->controllerReflector->getReflectionMethod($route->getDefault('_controller'));
 
-        if (null === $classAndMethod) {
+        if (null === $reflectionMethod) {
             return false;
         }
 
-        list($class, $method) = $classAndMethod;
-
         /** @var Areas|null $areas */
         $areas = $this->annotationReader->getMethodAnnotation(
-            $method,
+            $reflectionMethod,
             Areas::class
         );
 
         if (null === $areas) {
-            $areas = $this->annotationReader->getClassAnnotation($class, Areas::class);
+            $areas = $this->annotationReader->getClassAnnotation($reflectionMethod->getDeclaringClass(), Areas::class);
         }
 
         return (null !== $areas) ? $areas->has($this->area) : false;

--- a/Tests/Routing/FilteredRouteCollectionBuilderTest.php
+++ b/Tests/Routing/FilteredRouteCollectionBuilderTest.php
@@ -177,10 +177,9 @@ class FilteredRouteCollectionBuilderTest extends TestCase
         $routes->add($name, $route);
         $area = 'area';
 
-        $reflectionClassStub = $this->createMock(\ReflectionClass::class);
         $reflectionMethodStub = $this->createMock(\ReflectionMethod::class);
         $controllerReflectorStub = $this->createMock(ControllerReflector::class);
-        $controllerReflectorStub->method('getReflectionClassAndMethod')->willReturn([$reflectionClassStub, $reflectionMethodStub]);
+        $controllerReflectorStub->method('getReflectionMethod')->willReturn($reflectionMethodStub);
 
         $annotationReader = $this->createMock(Reader::class);
         $annotationReader


### PR DESCRIPTION
This issue was introduced in #1556.