### PR TITLE
Fix branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.0.x-dev"
+            "dev-master": "4.x-dev"
         }
     }
 }


### PR DESCRIPTION
The master branch currently contains a post-4.2.0 codebase. Yet, composer is told that the master contains 4.0.x.

This PR proposes to fix this by telling composer that the master branch contains 4.x instead. I assume that this comes closer to your current development workflow.