### PR TITLE
Fix detection of what groups to use if object is empty but has discriminator map metadata

### DIFF
--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -314,6 +314,16 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
                     return true;
                 }
             }
+
+            foreach ($metadata->discriminatorMap as $childTypeName) {
+                $subType = ['name' => $childTypeName, 'params' => []];
+                if ($this->propertyTypeUsesGroups($subType)) {
+                    $this->propertyTypeUseGroupsCache[$type['name']] = true;
+
+                    return true;
+                }
+            }
+
             $this->propertyTypeUseGroupsCache[$type['name']] = false;
 
             return false;


### PR DESCRIPTION
When describing empty abstract class with JMS Discriminator map describer fails to compute groups correctly.