### PR TITLE
[Doc] Some minor fixes in index.rst

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -72,7 +72,7 @@ Open a command console, enter your project directory and execute the following c
             defaults: { _controller: nelmio_api_doc.controller.swagger }
 
     As you just installed the bundle, you'll likely see routes you don't want in
-    your documentation such as `/_profiler/`. To fix this, you can filter the
+    your documentation such as ``/_profiler/``. To fix this, you can filter the
     routes that are documented by configuring the bundle:
 
     .. code-block:: yaml
@@ -140,8 +140,8 @@ To document your routes, you can use the SwaggerPHP annotations and the
 
     class UserController
     {
-        /**
-         * List the rewards of the specified user.
+        /**
+         * List the rewards of the specified user.
          *
          * This call takes into account all confirmed awards, but not pending or refused awards.
          *
@@ -179,48 +179,49 @@ Use it instead of a definition reference and the bundle will deduce your model p
 
 .. note::
 
-    A model can be a Symfony form type, a Doctrine ORM entity or a general PHP object.
+    A model can be a Symfony form type, a Doctrine ORM entity or a general PHP object.
 
 This annotation has two options:
 
 * ``type`` to specify your model's type::
 
     /**
-     * @SWG\Response(
-     *     response=200,
-     *     @Model(type=User::class)
-     * )
-     */
+     * @SWG\Response(
+     *     response=200,
+     *     @Model(type=User::class)
+     * )
+     */
 
 * ``groups`` to specify the serialization groups used to (de)serialize your model::
 
-    /**
-     * @SWG\Response(
-     *     response=200,
-     *     @Model(type=User::class, groups={"non_sensitive_data"})
-     * )
-     */
+    /**
+     * @SWG\Response(
+     *     response=200,
+     *     @Model(type=User::class, groups={"non_sensitive_data"})
+     * )
+     */
 
- .. tip::
+.. tip::
 
-     When used at the root of ``@SWG\Response`` and ``@SWG\Parameter``, ``@Model`` is automatically nested
-     in a ``@SWG\Schema``.
+    When used at the root of ``@SWG\Response`` and ``@SWG\Parameter``, ``@Model``
+    is automatically nested in a ``@SWG\Schema``.
 
-     To use ``@Model`` directly within a ``@SWG\Schema``, ``@SWG\Items`` or ``@SWG\Property``, you have to use the ``$ref`` field::
+    To use ``@Model`` directly within a ``@SWG\Schema``, ``@SWG\Items`` or
+    ``@SWG\Property``, you have to use the ``$ref`` field::
 
-         /**
-          * @SWG\Response(
-          *     @SWG\Schema(ref=@Model(type=User::class))
-          * )
-          *
-          * or
-          *
-          * @SWG\Response(
-          *     @SWG\Schema(type="object",
-          *         @SWG\Property(property="foo", ref=@Model(type=FooClass::class))
-          *     )
-          * )
-          */
+        /**
+         * @SWG\Response(
+         *     @SWG\Schema(ref=@Model(type=User::class))
+         * )
+         *
+         * or
+         *
+         * @SWG\Response(
+         *     @SWG\Schema(type="object",
+         *         @SWG\Property(property="foo", ref=@Model(type=FooClass::class))
+         *     )
+         * )
+         */
 
 Symfony Form types
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR fixes some minor issues in this RST doc. The main issue was the use of `<0xa0>` instead of normal white spaces. My text editor showed it like this:

![image](https://user-images.githubusercontent.com/73419/112204759-54826b80-8c14-11eb-8960-1f02960a3306.png)
