### PR TITLE
Display non native form type childs description and title properly

### DIFF
--- a/ModelDescriber/FormModelDescriber.php
+++ b/ModelDescriber/FormModelDescriber.php
@@ -124,7 +124,14 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
                 null,
                 $config->getOptions()
             );
-            $property->ref = $this->modelRegistry->register($model);
+
+            $ref = $this->modelRegistry->register($model);
+            // We need to use allOf for description and title to be displayed
+            if ($config->hasOption('documentation') && !empty($config->getOption('documentation'))) {
+                $property->allOf = [new OA\Schema(['ref' => $ref])];
+            } else {
+                $property->ref = $ref;
+            }
 
             return;
         }


### PR DESCRIPTION
The form describer wasn't showing description and title for non native form type childs.
I'm really not an OpenApi expert, there is probably a better way to fix that.

Before
![image](https://user-images.githubusercontent.com/1221938/112988939-b1c27380-9164-11eb-97c7-e6cfa6c0facb.png)

After
![image](https://user-images.githubusercontent.com/1221938/112988841-9192b480-9164-11eb-8228-b62876077787.png)

I didn't see any tests related to the form describer, do I need to add some ?