### PR TITLE
Added a class to the nelmio_api_doc.generator_locator service definition

### DIFF
--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -27,6 +27,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -127,7 +128,7 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
             }
         }
 
-        $container->register('nelmio_api_doc.generator_locator')
+        $container->register('nelmio_api_doc.generator_locator', ServiceLocator::class)
             ->setPublic(false)
             ->addTag('container.service_locator')
             ->addArgument(array_combine(


### PR DESCRIPTION
I've upgraded an application that uses this bundle to Symfony 5.3, which resulted in the following error:

```
The definition for "nelmio_api_doc.generator_locator" has no class. If you intend to inject this service dynamically at runtime, please mark it as synthetic=true. If this is an abstract definition solely used by child definitions, please add abstract=true, otherwise specify a class to get rid of this error.
```

Symfony's [documentation on service locators](https://symfony.com/doc/4.4/service_container/service_subscribers_locators.html#reusing-a-service-locator-in-multiple-services) uses a dedicated class, but `NelmioApiDocExtension` doesn't.

I've fixed the error by adding the documented class to the service definition.

Fixes #1807