### PR TITLE
Allow psr/cache versions 2 and 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=7.1.3",
         "ext-json": "*",
         "doctrine/annotations": "^1.11",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0|^2.0|^3.0",
         "psr/container": "^1.0",
         "psr/log": "^1.0",
         "symfony/config": "^4.4|^5.0",


### PR DESCRIPTION
Follows #1790.

This library is able to consume implementations of `psr/cache` versions 2 and 3 as well, so it should not block their installation.