### PR TITLE
Add a check for Constraint class existing before using it

### DIFF
--- a/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
+++ b/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
@@ -166,7 +166,7 @@ class SymfonyConstraintAnnotationReader
      */
     private function getAnnotations($reflection): \Traversable
     {
-        if (\PHP_VERSION_ID >= 80000) {
+        if (\PHP_VERSION_ID >= 80000 && class_exists(Constraint::class)) {
             foreach ($reflection->getAttributes(Constraint::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
                 yield $attribute->newInstance();
             }


### PR DESCRIPTION
*Context*: NelmioApiDocBundle does not require clients to have the symfony/validator package. However it requires it in its dev dependencies.

*Problem*: If client of library does not have symfony/validator and uses PHP8, NelmioApiDocBundle will assume that symfony/validator is installed, in `SymfonyConstraintAnnotationReader.php`

*Solution*: We should not assume that client has symfony/validator. So before reading attributes of this class, we now try to see if class exists. 
- Tests still run.
- Tested in a project without symfony/validator and requiring this version, it now works.

The error before this fix was : 
Exception: `ClassNotFound`
Message for me: `Attempted to load class "Constraint" from namespace "Symfony\Component\Validator".
Did you forget a "use" statement for e.g. "JsonSchema\Constraints\Constraint" or "Doctrine\DBAL\Schema\Constraint"?`