### PR TITLE
[Doc] Fix some minor RST issues

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -260,6 +260,7 @@ General PHP objects
     NOTE: If you are using serialization contexts (e.g. Groups) each permutation will be treated as a separate Path. For example if you have the following two variations defined in different places in your code:
     
     .. code-block:: php
+
         /**
          * A nested serializer property with no context group
          *
@@ -274,7 +275,8 @@ General PHP objects
             return $this->items;
         }
 
-    .. code-block::
+    .. code-block:: php
+
        @OA\Schema(ref=@Model(type="App\Response\ItemResponse", groups=["Default"])),
 
     It will generate two different component schemas (ItemResponse, ItemResponse2), even though Default and blank are the same. This is by design.


### PR DESCRIPTION
The real issue is the lack of `php` in the second `.. code-block::`.

The blank line added after the first `.. code-block::` is to keep it consistent with the rest of code blocks.