### PR TITLE
Always provide a context to swagger-php

### DIFF
--- a/ApiDocGenerator.php
+++ b/ApiDocGenerator.php
@@ -17,6 +17,7 @@ use Nelmio\ApiDocBundle\Model\ModelRegistry;
 use Nelmio\ApiDocBundle\ModelDescriber\ModelDescriberInterface;
 use Nelmio\ApiDocBundle\OpenApiPhp\DefaultOperationId;
 use Nelmio\ApiDocBundle\OpenApiPhp\ModelRegister;
+use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 use OpenApi\Analysis;
 use OpenApi\Annotations\OpenApi;
 use Psr\Cache\CacheItemPoolInterface;
@@ -89,8 +90,9 @@ final class ApiDocGenerator
             $describer->describe($this->openApi);
         }
 
-        $analysis = new Analysis();
-        $analysis->addAnnotation($this->openApi, null);
+        $context = Util::createContext();
+        $analysis = new Analysis([], $context);
+        $analysis->addAnnotation($this->openApi, $context);
 
         // Register model annotations
         $modelRegister = new ModelRegister($modelRegistry, $this->mediaTypes);

--- a/ModelDescriber/Annotations/OpenApiAnnotationsReader.php
+++ b/ModelDescriber/Annotations/OpenApiAnnotationsReader.php
@@ -14,6 +14,7 @@ namespace Nelmio\ApiDocBundle\ModelDescriber\Annotations;
 use Doctrine\Common\Annotations\Reader;
 use Nelmio\ApiDocBundle\Model\ModelRegistry;
 use Nelmio\ApiDocBundle\OpenApiPhp\ModelRegister;
+use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 use OpenApi\Analyser;
 use OpenApi\Analysis;
 use OpenApi\Annotations as OA;
@@ -41,7 +42,7 @@ class OpenApiAnnotationsReader
         }
 
         // Read @Model annotations
-        $this->modelRegister->__invoke(new Analysis([$oaSchema]));
+        $this->modelRegister->__invoke(new Analysis([$oaSchema], Util::createContext()));
 
         if (!$oaSchema->validate()) {
             return;
@@ -82,7 +83,7 @@ class OpenApiAnnotationsReader
         Analyser::$context = null;
 
         // Read @Model annotations
-        $this->modelRegister->__invoke(new Analysis([$oaProperty]), $serializationGroups);
+        $this->modelRegister->__invoke(new Analysis([$oaProperty], Util::createContext()), $serializationGroups);
 
         if (!$oaProperty->validate()) {
             return;

--- a/OpenApiPhp/ModelRegister.php
+++ b/OpenApiPhp/ModelRegister.php
@@ -166,6 +166,6 @@ final class ModelRegister
         }
 
         $annotation->merge([$modelAnnotation]);
-        $analysis->addAnnotation($modelAnnotation, null);
+        $analysis->addAnnotation($modelAnnotation, $properties['_context']);
     }
 }


### PR DESCRIPTION
Upcoming changes in swagger-php will make `context` a required parameter for instantiating `Analysis` and when adding annotations to the created `Analysis` instance.

See https://github.com/zircote/swagger-php/pull/963 for more details.