### PR TITLE
Improve jms testing by checking that collisions are not generated

### DIFF
--- a/Tests/Functional/Entity/JMSUser.php
+++ b/Tests/Functional/Entity/JMSUser.php
@@ -50,6 +50,8 @@ class JMSUser
     /**
      * User Roles Comment.
      *
+     * @var string[]
+     *
      * @Serializer\Type("array<string>")
      * @Serializer\Accessor(getter="getRoles", setter="setRoles")
      * @Serializer\Expose

--- a/Tests/Functional/JMSFunctionalTest.php
+++ b/Tests/Functional/JMSFunctionalTest.php
@@ -237,7 +237,7 @@ class JMSFunctionalTest extends WebTestCase
                     'type' => 'integer',
                 ],
                 'complex' => [
-                    '$ref' => '#/components/schemas/JMSComplex2',
+                    '$ref' => '#/components/schemas/JMSComplexDefault',
                 ],
                 'user' => [
                     '$ref' => '#/components/schemas/JMSUser',
@@ -304,6 +304,17 @@ class JMSFunctionalTest extends WebTestCase
             ],
             'schema' => 'VirtualProperty',
         ], json_decode($this->getModel('VirtualProperty')->toJson(), true));
+    }
+
+    public function testNoCollisionsAreGenerated()
+    {
+        self::assertFalse($this->hasModel('JMSComplex2'));
+        self::assertFalse($this->hasModel('JMSUser2'));
+        self::assertFalse($this->hasModel('JMSChatRoom2'));
+        self::assertFalse($this->hasModel('JMSChatRoomUser2'));
+        self::assertFalse($this->hasModel('JMSChatLivingRoom2'));
+
+        self::assertFalse($this->hasModel('JMSPicture2'));
     }
 
     public function testNamingStrategyWithConstraints()

--- a/Tests/Functional/TestKernel.php
+++ b/Tests/Functional/TestKernel.php
@@ -18,6 +18,7 @@ use Hateoas\Configuration\Embedded;
 use JMS\SerializerBundle\JMSSerializerBundle;
 use Nelmio\ApiDocBundle\NelmioApiDocBundle;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\BazingaUser;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSComplex;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup\JMSPicture;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\PrivateProtectedExposure;
 use Nelmio\ApiDocBundle\Tests\Functional\ModelDescriber\VirtualTypeClassDoesNotExistsHandlerDefinedDescriber;
@@ -247,6 +248,20 @@ class TestKernel extends Kernel
                         'alias' => 'BazingaUser_grouped',
                         'type' => BazingaUser::class,
                         'groups' => ['foo'],
+                    ],
+                    [
+                        'alias' => 'JMSComplex',
+                        'type' => JMSComplex::class,
+                        'groups' => [
+                            'list',
+                            'details',
+                            'User' => ['list'],
+                        ],
+                    ],
+                    [
+                        'alias' => 'JMSComplexDefault',
+                        'type' => JMSComplex::class,
+                        'groups' => null,
                     ],
                 ],
             ],

--- a/Tests/Functional/WebTestCase.php
+++ b/Tests/Functional/WebTestCase.php
@@ -26,6 +26,14 @@ class WebTestCase extends BaseWebTestCase
         return static::$kernel->getContainer()->get(sprintf('nelmio_api_doc.generator.%s', $area))->generate();
     }
 
+    public function hasModel(string $name): bool
+    {
+        $api = $this->getOpenApiDefinition();
+        $key = array_search($name, array_column($api->components->schemas, 'schema'));
+
+        return false !== $key;
+    }
+
     protected function getModel($name): OA\Schema
     {
         $api = $this->getOpenApiDefinition();


### PR DESCRIPTION
This PR improves the tests checking that no "automatic" names are generated if all the other params (as aliases) are well defined