### PR TITLE
[3.x]: Hide the default section per area with new config parameter

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -63,6 +63,7 @@ final class Configuration implements ConfigurationInterface
                                 'with_annotation' => false,
                                 'documentation' => [],
                                 'name_patterns' => [],
+                                'disable_default_routes' => false,
                             ],
                         ]
                     )
@@ -102,6 +103,10 @@ final class Configuration implements ConfigurationInterface
                             ->booleanNode('with_annotation')
                                 ->defaultFalse()
                                 ->info('whether to filter by annotation')
+                            ->end()
+                            ->booleanNode('disable_default_routes')
+                                ->defaultFalse()
+                                ->info('if set disables default routes without annotations')
                             ->end()
                             ->arrayNode('documentation')
                                 ->useAttributeAsKey('key')

--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -74,14 +74,16 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
                     new TaggedIteratorArgument('nelmio_api_doc.model_describer'),
                 ]);
 
-            $container->register(sprintf('nelmio_api_doc.describers.route.%s', $area), RouteDescriber::class)
-                ->setPublic(false)
-                ->setArguments([
-                    new Reference(sprintf('nelmio_api_doc.routes.%s', $area)),
-                    new Reference('nelmio_api_doc.controller_reflector'),
-                    new TaggedIteratorArgument('nelmio_api_doc.route_describer'),
-                ])
-                ->addTag(sprintf('nelmio_api_doc.describer.%s', $area), ['priority' => -400]);
+            if (!array_key_exists('disable_default_routes', $areaConfig) || true !== $areaConfig['disable_default_routes']) {
+                $container->register(sprintf('nelmio_api_doc.describers.route.%s', $area), RouteDescriber::class)
+                    ->setPublic(false)
+                    ->setArguments([
+                        new Reference(sprintf('nelmio_api_doc.routes.%s', $area)),
+                        new Reference('nelmio_api_doc.controller_reflector'),
+                        new TaggedIteratorArgument('nelmio_api_doc.route_describer'),
+                    ])
+                    ->addTag(sprintf('nelmio_api_doc.describer.%s', $area), ['priority' => -400]);
+            }
 
             $container->register(sprintf('nelmio_api_doc.describers.swagger_php.%s', $area), SwaggerPhpDescriber::class)
                 ->setPublic(false)

--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -74,16 +74,14 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
                     new TaggedIteratorArgument('nelmio_api_doc.model_describer'),
                 ]);
 
-            if (!array_key_exists('disable_default_routes', $areaConfig) || true !== $areaConfig['disable_default_routes']) {
-                $container->register(sprintf('nelmio_api_doc.describers.route.%s', $area), RouteDescriber::class)
-                    ->setPublic(false)
-                    ->setArguments([
-                        new Reference(sprintf('nelmio_api_doc.routes.%s', $area)),
-                        new Reference('nelmio_api_doc.controller_reflector'),
-                        new TaggedIteratorArgument('nelmio_api_doc.route_describer'),
-                    ])
-                    ->addTag(sprintf('nelmio_api_doc.describer.%s', $area), ['priority' => -400]);
-            }
+            $container->register(sprintf('nelmio_api_doc.describers.route.%s', $area), RouteDescriber::class)
+                ->setPublic(false)
+                ->setArguments([
+                    new Reference(sprintf('nelmio_api_doc.routes.%s', $area)),
+                    new Reference('nelmio_api_doc.controller_reflector'),
+                    new TaggedIteratorArgument('nelmio_api_doc.route_describer'),
+                ])
+                ->addTag(sprintf('nelmio_api_doc.describer.%s', $area), ['priority' => -400]);
 
             $container->register(sprintf('nelmio_api_doc.describers.swagger_php.%s', $area), SwaggerPhpDescriber::class)
                 ->setPublic(false)
@@ -108,6 +106,7 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
                 && 0 === count($areaConfig['host_patterns'])
                 && 0 === count($areaConfig['name_patterns'])
                 && false === $areaConfig['with_annotation']
+                && false === $areaConfig['disable_default_routes']
             ) {
                 $container->setDefinition(sprintf('nelmio_api_doc.routes.%s', $area), $routesDefinition)
                     ->setPublic(false);

--- a/Resources/doc/faq.rst
+++ b/Resources/doc/faq.rst
@@ -197,3 +197,17 @@ A: Use ``@SWG\Tag`` annotation.
     {
         //...
     }
+
+Disable Default Section
+-----------------------
+
+Q: I don't want to render the "default" section, how do I do that?
+
+A: Use ``disable_default_routes`` config in your area.
+
+.. code-block:: yaml
+
+    nelmio_api_doc:
+        areas:
+            default:
+                disable_default_routes: true

--- a/Routing/FilteredRouteCollectionBuilder.php
+++ b/Routing/FilteredRouteCollectionBuilder.php
@@ -75,7 +75,7 @@ final class FilteredRouteCollectionBuilder
                 && $this->matchHost($route)
                 && $this->matchAnnotation($route)
                 && $this->matchName($name)
-                && $this->matchDefaultRoute($route)
+                && $this->defaultRouteDisabled($route)
             ) {
                 $filteredRoutes->add($name, $route);
             }
@@ -139,7 +139,7 @@ final class FilteredRouteCollectionBuilder
         return (null !== $areas) ? $areas->has($this->area) : false;
     }
 
-    private function matchDefaultRoute(Route $route): bool
+    private function defaultRouteDisabled(Route $route): bool
     {
         if (false === $this->options['disable_default_routes']) {
             return true;

--- a/Routing/FilteredRouteCollectionBuilder.php
+++ b/Routing/FilteredRouteCollectionBuilder.php
@@ -45,11 +45,13 @@ final class FilteredRouteCollectionBuilder
                 'host_patterns' => [],
                 'name_patterns' => [],
                 'with_annotation' => false,
+                'disable_default_routes' => false,
             ])
             ->setAllowedTypes('path_patterns', 'string[]')
             ->setAllowedTypes('host_patterns', 'string[]')
             ->setAllowedTypes('name_patterns', 'string[]')
             ->setAllowedTypes('with_annotation', 'boolean')
+            ->setAllowedTypes('disable_default_routes', 'boolean')
         ;
 
         if (array_key_exists(0, $options)) {

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -29,6 +29,7 @@ class ConfigurationTest extends TestCase
                     'host_patterns' => [],
                     'name_patterns' => [],
                     'with_annotation' => false,
+                    'disable_default_routes' => false,
                     'documentation' => [],
                 ],
             ],
@@ -46,6 +47,7 @@ class ConfigurationTest extends TestCase
                 'with_annotation' => false,
                 'documentation' => [],
                 'name_patterns' => [],
+                'disable_default_routes' => false,
             ],
             'internal' => [
                 'path_patterns' => ['/internal'],
@@ -53,6 +55,7 @@ class ConfigurationTest extends TestCase
                 'with_annotation' => false,
                 'documentation' => [],
                 'name_patterns' => [],
+                'disable_default_routes' => false,
             ],
             'commercial' => [
                 'path_patterns' => ['/internal'],
@@ -60,6 +63,7 @@ class ConfigurationTest extends TestCase
                 'with_annotation' => false,
                 'documentation' => [],
                 'name_patterns' => [],
+                'disable_default_routes' => false,
             ],
         ]]]);
 
@@ -173,6 +177,7 @@ class ConfigurationTest extends TestCase
                     'host_patterns' => [],
                     'name_patterns' => [],
                     'with_annotation' => false,
+                    'disable_default_routes' => false,
                     'documentation' => [],
                 ],
             ],

--- a/Tests/Routing/FilteredRouteCollectionBuilderTest.php
+++ b/Tests/Routing/FilteredRouteCollectionBuilderTest.php
@@ -248,7 +248,7 @@ class FilteredRouteCollectionBuilderTest extends TestCase
     }
 
     /**
-     * @dataProvider getMatchingRoutesWithDisabledDefaultRoutes
+     * @dataProvider getRoutesWithDisabledDefaultRoutes
      *
      * @param array<Operation|Parameter> $annotations
      * @param array<string|boolean>      $options
@@ -288,7 +288,7 @@ class FilteredRouteCollectionBuilderTest extends TestCase
     /**
      * @return array<string,array>
      */
-    public function getMatchingRoutesWithDisabledDefaultRoutes(): array
+    public function getRoutesWithDisabledDefaultRoutes(): array
     {
         return [
             'non matching route without Annotation' => [

--- a/Tests/Routing/FilteredRouteCollectionBuilderTest.php
+++ b/Tests/Routing/FilteredRouteCollectionBuilderTest.php
@@ -250,7 +250,7 @@ class FilteredRouteCollectionBuilderTest extends TestCase
     /**
      * @dataProvider getMatchingRoutesWithDisabledDefaultRoutes
      * @param array<Operation|Parameter> $annotations
-     * @param array<string|boolean> $options
+     * @param array<string|boolean>      $options
      */
     public function testRoutesWithDisabledDefaultRoutes(
         string $name,

--- a/Tests/Routing/FilteredRouteCollectionBuilderTest.php
+++ b/Tests/Routing/FilteredRouteCollectionBuilderTest.php
@@ -14,9 +14,11 @@ namespace Nelmio\ApiDocBundle\Tests\Routing;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\Reader;
 use Nelmio\ApiDocBundle\Annotation\Areas;
+use Nelmio\ApiDocBundle\Annotation\Operation;
 use Nelmio\ApiDocBundle\Routing\FilteredRouteCollectionBuilder;
 use Nelmio\ApiDocBundle\Util\ControllerReflector;
 use PHPUnit\Framework\TestCase;
+use Swagger\Annotations\Parameter;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Routing\Route;
@@ -242,6 +244,73 @@ class FilteredRouteCollectionBuilderTest extends TestCase
             ['r4_matching_path_and_non_matching_host', new Route('/api/bar/action1', [], [], [], 'www.example.com'), ['path_patterns' => ['^/api/'], 'host_patterns' => ['^api\.']]],
             ['r5_non_matching_path_and_matching_host', new Route('/admin/bar/action1', [], [], [], 'api.example.com'), ['path_patterns' => ['^/api/'], 'host_patterns' => ['^api\.']]],
             ['r6_non_matching_path_and_non_matching_host', new Route('/admin/bar/action1', [], [], [], 'www.example.com'), ['path_patterns' => ['^/api/'], 'host_patterns' => ['^api\.ex']]],
+        ];
+    }
+
+    /**
+     * @dataProvider getMatchingRoutesWithDisabledDefaultRoutes
+     * @param array<Operation|Parameter> $annotations
+     * @param array<string|boolean> $options
+     */
+    public function testRoutesWithDisabledDefaultRoutes(
+        string $name,
+        Route $route,
+        array $annotations,
+        array $options,
+        int $expectedRoutesCount
+    ): void {
+        $routes = new RouteCollection();
+        $routes->add($name, $route);
+        $area = 'area';
+
+        $reflectionMethodStub = $this->createMock(\ReflectionMethod::class);
+        $controllerReflectorStub = $this->createMock(ControllerReflector::class);
+        $controllerReflectorStub->method('getReflectionMethod')->willReturn($reflectionMethodStub);
+
+        $annotationReader = $this->createMock(Reader::class);
+        $annotationReader
+            ->method('getMethodAnnotations')
+            ->willReturn($annotations)
+        ;
+
+        $routeBuilder = new FilteredRouteCollectionBuilder(
+            $annotationReader,
+            $controllerReflectorStub,
+            $area,
+            $options
+        );
+        $filteredRoutes = $routeBuilder->filter($routes);
+
+        $this->assertCount($expectedRoutesCount, $filteredRoutes);
+    }
+
+    /**
+     * @return array<string,array>
+     */
+    public function getMatchingRoutesWithDisabledDefaultRoutes(): array
+    {
+        return [
+            'non matching route without Annotation' => [
+                'r10',
+                new Route('/api/foo', ['_controller' => 'ApiController::fooAction']),
+                [],
+                ['disable_default_routes' => true],
+                0,
+            ],
+            'matching route with Nelmio Annotation' => [
+                'r10',
+                new Route('/api/foo', ['_controller' => 'ApiController::fooAction']),
+                [new Operation([])],
+                ['disable_default_routes' => true],
+                1,
+            ],
+            'matching route with Swagger Annotation' => [
+                'r10',
+                new Route('/api/foo', ['_controller' => 'ApiController::fooAction']),
+                [new Parameter([])],
+                ['disable_default_routes' => true],
+                1,
+            ],
         ];
     }
 

--- a/Tests/Routing/FilteredRouteCollectionBuilderTest.php
+++ b/Tests/Routing/FilteredRouteCollectionBuilderTest.php
@@ -249,6 +249,7 @@ class FilteredRouteCollectionBuilderTest extends TestCase
 
     /**
      * @dataProvider getMatchingRoutesWithDisabledDefaultRoutes
+     *
      * @param array<Operation|Parameter> $annotations
      * @param array<string|boolean>      $options
      */


### PR DESCRIPTION
By adding a  new config parameter it is possible to hide the "default" section in your config.

Approach is to not register the RouteDescriber as a tagged service per area.

Fixes: https://github.com/nelmio/NelmioApiDocBundle/issues/1458