### PR TITLE
Add self-describing model describer

### DIFF
--- a/ModelDescriber/SelfDescribingModelDescriber.php
+++ b/ModelDescriber/SelfDescribingModelDescriber.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\ModelDescriber;
+
+use Nelmio\ApiDocBundle\Model\Model;
+use OpenApi\Annotations as OA;
+
+class SelfDescribingModelDescriber implements ModelDescriberInterface
+{
+    public function describe(Model $model, OA\Schema $schema): void
+    {
+        call_user_func([$model->getType()->getClassName(), 'describe'], $schema, $model);
+    }
+
+    public function supports(Model $model): bool
+    {
+        return $model->getType()->getClassName()
+            && class_exists($model->getType()->getClassName())
+            && in_array(SelfDescribingModelInterface::class, class_implements($model->getType()->getClassName()), true);
+    }
+}

--- a/ModelDescriber/SelfDescribingModelDescriber.php
+++ b/ModelDescriber/SelfDescribingModelDescriber.php
@@ -25,6 +25,6 @@ class SelfDescribingModelDescriber implements ModelDescriberInterface
     {
         return $model->getType()->getClassName()
             && class_exists($model->getType()->getClassName())
-            && in_array(SelfDescribingModelInterface::class, class_implements($model->getType()->getClassName()), true);
+            && is_a($model->getType()->getClassName(), SelfDescribingModelInterface::class, true);
     }
 }

--- a/ModelDescriber/SelfDescribingModelInterface.php
+++ b/ModelDescriber/SelfDescribingModelInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\ModelDescriber;
+
+use Nelmio\ApiDocBundle\Model\Model;
+use OpenApi\Annotations\Schema;
+
+/**
+ * A self-describing model is a model able to describe its own schema through a static method call.
+ *
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+interface SelfDescribingModelInterface
+{
+    public static function describe(Schema $schema, Model $model): void;
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -69,6 +69,10 @@
         </service>
 
         <!-- Model Describers -->
+        <service id="nelmio_api_doc.model_describers.self_describing" class="Nelmio\ApiDocBundle\ModelDescriber\SelfDescribingModelDescriber" public="false">
+            <tag name="nelmio_api_doc.model_describer" priority="1000" />
+        </service>
+
         <service id="nelmio_api_doc.model_describers.object" class="Nelmio\ApiDocBundle\ModelDescriber\ObjectModelDescriber" public="false">
             <argument type="service" id="property_info" />
             <argument type="service" id="annotations.reader" />

--- a/Tests/ModelDescriber/Fixtures/SelfDescribingModel.php
+++ b/Tests/ModelDescriber/Fixtures/SelfDescribingModel.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\ModelDescriber\Fixtures;
+
+use Nelmio\ApiDocBundle\Model\Model;
+use Nelmio\ApiDocBundle\ModelDescriber\SelfDescribingModelInterface;
+use OpenApi\Annotations\Schema;
+
+class SelfDescribingModel implements SelfDescribingModelInterface
+{
+    public static function describe(Schema $schema, Model $model): void
+    {
+        $schema->title = 'SelfDescribingTitle';
+        $schema->description = $model->getType()->getClassName();
+    }
+}

--- a/Tests/ModelDescriber/SelfDescribingModelDescriberTest.php
+++ b/Tests/ModelDescriber/SelfDescribingModelDescriberTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\ModelDescriber;
+
+use Nelmio\ApiDocBundle\Model\Model;
+use Nelmio\ApiDocBundle\ModelDescriber\SelfDescribingModelDescriber;
+use Nelmio\ApiDocBundle\Tests\ModelDescriber\Fixtures\SelfDescribingModel;
+use OpenApi\Annotations\Schema;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
+
+class SelfDescribingModelDescriberTest extends TestCase
+{
+    public function testSupports()
+    {
+        $describer = new SelfDescribingModelDescriber();
+
+        $this->assertTrue($describer->supports(new Model(new Type('object', false, SelfDescribingModel::class))));
+    }
+
+    public function testDoesNotSupport()
+    {
+        $describer = new SelfDescribingModelDescriber();
+
+        $this->assertFalse($describer->supports(new Model(new Type('object', false, \stdClass::class))));
+    }
+
+    public function testDescribe()
+    {
+        $describer = new SelfDescribingModelDescriber();
+
+        $model = new Model(new Type('object', false, SelfDescribingModel::class));
+        $schema = new Schema([]);
+
+        $describer->describe($model, $schema);
+        $this->assertSame('SelfDescribingTitle', $schema->title);
+        $this->assertSame(SelfDescribingModel::class, $schema->description);
+    }
+}


### PR DESCRIPTION
This PR implements self-describing models: models that are able to describe their structure through a static method call.

I already use this technique in one of my projects with league/fractal (https://fractal.thephpleague.com): in Fractal, there is a concept of Transformers, classes that are able to transform a given object into an array. These transformers can be nested and used in collections.

Such transformers carry the output structure of my API: they are dedicated classes that I wish I could use as "models". They do not however match the currently available models describers. Thus I'd like to propose self-describing models: the ability for model classes to implement an interface and describe their structure in a static method:

```php
class SelfDescribingModel implements SelfDescribingModelInterface
{
    public static function describe(Schema $schema)
    {
        $schema->title = 'SelfDescribingTitle';
        $schema->properties = [/* ... */];
        // ...
    }
}
```