### PR TITLE
Fix path to index.html.twig in documentation

### DIFF
--- a/Resources/doc/faq.rst
+++ b/Resources/doc/faq.rst
@@ -136,7 +136,7 @@ A: We removed the google fonts in 3.3 to avoid the external request for GDPR rea
 
 .. code-block:: twig
 
-    {# templates/bundles/NelmioApiDocBundle/SwaggerUI/index.html.twig #}
+    {# templates/bundles/NelmioApiDocBundle/SwaggerUi/index.html.twig #}
 
     {#
        To avoid a "reached nested level" error an exclamation mark `!` has to be added


### PR DESCRIPTION
This fixes a minor typo in [*Re-add Google Fonts* part of the documentation](https://symfony.com/bundles/NelmioApiDocBundle/current/faq.html#re-add-google-fonts): using an uppercase `i` breaks template override:

```diff
-    {# templates/bundles/NelmioApiDocBundle/SwaggerUI/index.html.twig #}
+    {# templates/bundles/NelmioApiDocBundle/SwaggerUi/index.html.twig #}
```