### PR TITLE
Proposal: Add ``header_block`` Twig Block

### DIFF
--- a/Resources/doc/customization.rst
+++ b/Resources/doc/customization.rst
@@ -50,4 +50,4 @@ Just create a file ``templates/bundles/NelmioApiDocBundle/SwaggerUi/index.html.t
         <script type="text/javascript" src="{{ asset('js/custom-request-signer.js') }}"></script>
     {% endblock javascripts %}
 
-You can have a look at the original template to see which blocks can be overridden.
+You can have a look at the `original template <https://github.com/nelmio/NelmioApiDocBundle/blob/master/Resources/views/SwaggerUi/index.html.twig>`_, in ``/Resources/views/SwaggerUi/index.html.twig``, to see which blocks can be overridden.

--- a/Resources/views/SwaggerUi/index.html.twig
+++ b/Resources/views/SwaggerUi/index.html.twig
@@ -51,13 +51,16 @@ file that was distributed with this source code. #}
             </defs>
         </svg>
     {% endblock svg_icons %}
-    <header>
-        {% block header %}
-            <a id="logo" href="https://github.com/nelmio/NelmioApiDocBundle">
-                <img src="{{ nelmioAsset(assets_mode, 'logo.png') }}" alt="NelmioApiDocBundle">
-            </a>
-        {% endblock header %}
-    </header>
+    
+    {% block header_block %}
+        <header>
+            {% block header %}
+                <a id="logo" href="https://github.com/nelmio/NelmioApiDocBundle">
+                    <img src="{{ nelmioAsset(assets_mode, 'logo.png') }}" alt="NelmioApiDocBundle">
+                </a>
+            {% endblock header %}
+        </header>
+    {% endblock header_block %}
 
     {% block swagger_ui %}
         <div id="swagger-ui" class="api-platform"></div>


### PR DESCRIPTION
In attempting to remove the default green header from the API docs (I am integrating the docs into a site that already has a header), I have found that the only possible way to do so is to overwrite the entire ``index.html.twig`` file.  This is because the existing ``{% header %}`` twig tags are placed *inside* the ``<header>`` HTML tags.  So, if one overrides the ``{% header %}`` block, it only adjusts the header content, as opposed to allowing control over the entire header object.

To resolve this problem I considered two methods:

- Move the existing ``{% header %}`` tags _*outside*_ of the ``<header>`` tags.  This would resolve the problem in the simplest fashion, but would be a breaking change for those currently overriding the block.

- Add a new twig block, placing its tags *_outside_* the existing ``<header>`` tags.  This would leave the existing functionality as-is, and would not break any current implementations.

I chose the latter for the reasons specified above, and suggested the name ``{% header_block %}``.  Thanks for considering this proposal.