### PR TITLE
Add Location of Original Template

### DIFF
--- a/Resources/doc/customization.rst
+++ b/Resources/doc/customization.rst
@@ -50,4 +50,4 @@ Just create a file ``templates/bundles/NelmioApiDocBundle/SwaggerUi/index.html.t
         <script type="text/javascript" src="{{ asset('js/custom-request-signer.js') }}"></script>
     {% endblock javascripts %}
 
-You can have a look at the original template to see which blocks can be overridden.
+You can have a look at the `original template <https://github.com/nelmio/NelmioApiDocBundle/blob/master/Resources/views/SwaggerUi/index.html.twig>`_, in ``/Resources/views/SwaggerUi/index.html.twig``, to see which blocks can be overridden.


### PR DESCRIPTION
This doc page advises that one can `have a look at the original template to see which blocks can be overridden`, but does not say where the original template can be found.  This edit adds that information for clarity.

Note that I haven't run any tests as this is a docs-only change.