### PR TITLE
disable html render if `symfony/asset` not installed

### DIFF
--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -152,14 +152,15 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
                 ->setArgument(1, $config['media_types']);
         }
 
-        // ApiPlatform support
         $bundles = $container->getParameter('kernel.bundles');
-        if (!isset($bundles['TwigBundle'])) {
+        if (!isset($bundles['TwigBundle']) || !class_exists('Symfony\Component\Asset\Packages')) {
             $container->removeDefinition('nelmio_api_doc.controller.swagger_ui');
 
             $container->removeDefinition('nelmio_api_doc.render_docs.html');
             $container->removeDefinition('nelmio_api_doc.render_docs.html.asset');
         }
+
+        // ApiPlatform support
         if (isset($bundles['ApiPlatformBundle']) && class_exists('ApiPlatform\Core\Documentation\Documentation')) {
             $loader->load('api_platform.xml');
         }


### PR DESCRIPTION
fix #1876

it will work at least from symfony 4.4 https://github.com/symfony/twig-bundle/blob/4.4/DependencyInjection/Compiler/ExtensionPass.php#L28 to symfony 6.0 https://github.com/symfony/twig-bundle/blob/6.0/DependencyInjection/Compiler/ExtensionPass.php#L30