### PR TITLE
fixed : add doc blocks to silence Symfony deprecations

### DIFF
--- a/Render/Html/GetNelmioAsset.php
+++ b/Render/Html/GetNelmioAsset.php
@@ -31,10 +31,7 @@ class GetNelmioAsset extends AbstractExtension
         $this->resourcesDir = __DIR__.'/../../Resources/public';
     }
 
-    /**
-     * @return array
-     */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('nelmioAsset', $this, ['is_safe' => ['html']]),

--- a/Render/Html/GetNelmioAsset.php
+++ b/Render/Html/GetNelmioAsset.php
@@ -31,6 +31,9 @@ class GetNelmioAsset extends AbstractExtension
         $this->resourcesDir = __DIR__.'/../../Resources/public';
     }
 
+    /**
+     * @return array
+     */
     public function getFunctions()
     {
         return [


### PR DESCRIPTION
Symfony 5.4 returning deprecations about 

```
User Deprecated: Method "Twig\Extension\ExtensionInterface::getFunctions()" might add "array" as a native return type declaration in the future.
Do the same in implementation "Nelmio\ApiDocBundle\Render\Html\GetNelmioAsset" now to avoid errors or add an explicit @return annotation to suppress this message.
```

Closes #1921 
