### PR TITLE
Add PHP 8.1 in CI and better test supported Symfony minors

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,16 +26,14 @@ jobs:
         include:
           - php-version: 7.2
             composer-flags: "--prefer-lowest"
-          - php-version: 7.2
-            symfony-require: "^4.0"
           - php-version: 7.3
-            symfony-require: "^5.0"
+            symfony-require: "4.4.*"
           - php-version: 7.4
-            symfony-require: "^4.0"
-          - php-version: 7.3
-            symfony-require: "^5.0"
+            symfony-require: "5.3.*"
           - php-version: 8.0
-            composer-flags: "--ignore-platform-reqs"
+            symfony-require: "5.4.*"
+          - php-version: 8.1
+            symfony-require: "5.4.*"
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
Currently, the CI runs 6 checks, some of them being unnecessary:

* PHP 7.2 / lowest deps
* PHP 7.2 / Symfony 4.0
* PHP 7.3 / Symfony 5.0
* PHP 7.4 / Symfony 4.0
* PHP 7.3 / Symfony 5.0
* PHP 8.0 / highest deps

I propose to add PHP 8.1 and simplify the matrix, while testing supported Symfony minors as well:

* PHP 7.2 / lowest deps (covers Symfony 4.0)
* PHP 7.3 / Symfony 4.4
* PHP 7.4 / Symfony 5.3 (still maintained until Jan 2022)
* PHP 8.0 / Symfony 5.4
* PHP 8.1 / Symfony 5.4 (equivalent of highest deps, the default behavior of Composer)

This decrease the amount of CI builds done while testing more dependencies cases. 