### PR TITLE
Add support for attributes in OpenApiAnnotationsReader

### DIFF
--- a/Tests/ModelDescriber/Annotations/AnnotationReaderTest.php
+++ b/Tests/ModelDescriber/Annotations/AnnotationReaderTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\ModelDescriber\Annotations;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Nelmio\ApiDocBundle\Model\ModelRegistry;
+use Nelmio\ApiDocBundle\ModelDescriber\Annotations\OpenApiAnnotationsReader;
+use OpenApi\Annotations as OA;
+use OpenApi\Generator;
+use PHPUnit\Framework\TestCase;
+
+class AnnotationReaderTest extends TestCase
+{
+    /**
+     * @param object $entity
+     * @dataProvider provideProperty
+     */
+    public function testProperty($entity)
+    {
+        $schema = new OA\Schema([]);
+        $schema->merge([new OA\Property(['property' => 'property1'])]);
+        $schema->merge([new OA\Property(['property' => 'property2'])]);
+
+        $registry = new ModelRegistry([], new OA\OpenApi([]), []);
+        $symfonyConstraintAnnotationReader = new OpenApiAnnotationsReader(new AnnotationReader(), $registry, ['json']);
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property2'), $schema->properties[1]);
+
+        $this->assertEquals($schema->properties[0]->example, 1);
+        $this->assertEquals($schema->properties[0]->description, Generator::UNDEFINED);
+
+        $this->assertEquals($schema->properties[1]->example, 'some example');
+        $this->assertEquals($schema->properties[1]->description, 'some description');
+    }
+
+    public function provideProperty(): iterable
+    {
+        yield 'Annotations' => [new class() {
+            /**
+             * @OA\Property(example=1)
+             */
+            private $property1;
+            /**
+             * @OA\Property(example="some example", description="some description")
+             */
+            private $property2;
+        }];
+
+        if (\PHP_VERSION_ID >= 80100) {
+            yield 'Attributes' => [new class() {
+                #[OA\Property(example: 1)]
+                private $property1;
+                #[OA\Property(example: 'some example', description: 'some description')]
+                private $property2;
+            }];
+        }
+    }
+}


### PR DESCRIPTION
Migrated to the OA attributes (on 8.1), and noticed that the schemas stopped showing correctly.

Note that the check for php 8.1 (80100) is because that's when the attribute is created in swagger-php https://github.com/zircote/swagger-php/blob/4.0.5/src/Annotations/Schema.php#L388

Didnt find any tests that directly tested `OpenApiAnnotationsReader`, so I wrote one which has both annotations and attributes (kind of copied the symfony constraint reader tests)