### PR TITLE
Fixed Areas attribute to work like the documentation specifies

### DIFF
--- a/Annotation/Areas.php
+++ b/Annotation/Areas.php
@@ -22,12 +22,12 @@ final class Areas
 
     public function __construct(array $properties)
     {
-        if (!array_key_exists('value', $properties) || !is_array($properties['value'])) {
+        if ($properties === []) {
             throw new \InvalidArgumentException('An array of areas was expected');
         }
 
         $areas = [];
-        foreach ($properties['value'] as $area) {
+        foreach ($properties as $area) {
             if (!is_string($area)) {
                 throw new \InvalidArgumentException('An area must be given as a string');
             }

--- a/Annotation/Areas.php
+++ b/Annotation/Areas.php
@@ -26,7 +26,7 @@ final class Areas
             $properties['value'] = array_values($properties);
         }
 
-        if ([] === $properties) {
+        if ([] === $properties['value']) {
             throw new \InvalidArgumentException('An array of areas was expected');
         }
 

--- a/Annotation/Areas.php
+++ b/Annotation/Areas.php
@@ -22,7 +22,7 @@ final class Areas
 
     public function __construct(array $properties)
     {
-        if ($properties === []) {
+        if ([] === $properties) {
             throw new \InvalidArgumentException('An array of areas was expected');
         }
 

--- a/Annotation/Areas.php
+++ b/Annotation/Areas.php
@@ -22,7 +22,6 @@ final class Areas
 
     public function __construct(array $properties)
     {
-
         if (!array_key_exists('value', $properties) || !is_array($properties['value'])) {
             $properties = array_values($properties);
         }

--- a/Annotation/Areas.php
+++ b/Annotation/Areas.php
@@ -22,12 +22,17 @@ final class Areas
 
     public function __construct(array $properties)
     {
+
+        if (!array_key_exists('value', $properties) || !is_array($properties['value'])) {
+            $properties = array_values($properties);
+        }
+
         if ([] === $properties) {
             throw new \InvalidArgumentException('An array of areas was expected');
         }
 
         $areas = [];
-        foreach ($properties as $area) {
+        foreach ($properties['value'] as $area) {
             if (!is_string($area)) {
                 throw new \InvalidArgumentException('An area must be given as a string');
             }

--- a/Annotation/Areas.php
+++ b/Annotation/Areas.php
@@ -23,7 +23,7 @@ final class Areas
     public function __construct(array $properties)
     {
         if (!array_key_exists('value', $properties) || !is_array($properties['value'])) {
-            $properties = array_values($properties);
+            $properties['value'] = array_values($properties);
         }
 
         if ([] === $properties) {


### PR DESCRIPTION
the documentation shows this usage:
```
#[Areas(['area1', 'area2'])]
```

but it was actually working like this:
```
#[Areas(['value' => ['area1', 'area2']])]
```

