### PR TITLE
Add previous exception to BadRequestHttpException on SwaggerUiController

### DIFF
--- a/Controller/SwaggerUiController.php
+++ b/Controller/SwaggerUiController.php
@@ -48,7 +48,7 @@ final class SwaggerUiController
                 $advice = ' Since the area provided contains `.json`, the issue is likely caused by route priorities. Try switching the Swagger UI / the json documentation routes order.';
             }
 
-            throw new BadRequestHttpException(sprintf('Area "%s" is not supported as it isn\'t defined in config.%s', $area, $advice));
+            throw new BadRequestHttpException(sprintf('Area "%s" is not supported as it isn\'t defined in config.%s', $area, $advice), $e);
         }
     }
 }


### PR DESCRIPTION
My case, while I dev, I got an error on Swagger UI without explicite details about why it bugged.

With previous exception set on line 51, it improve debug by providing the original exception.