### PR TITLE
Use the same root context everywhere

### DIFF
--- a/ApiDocGenerator.php
+++ b/ApiDocGenerator.php
@@ -91,7 +91,14 @@ final class ApiDocGenerator
             return !$processor instanceof \OpenApi\Processors\OperationId;
         }));
 
-        $this->openApi = new OpenApi([]);
+        $context = Util::createContext(
+            // BC for for zircote/swagger-php < 4.2
+            method_exists($generator, 'getVersion')
+            ? ['version' => $generator->getVersion()]
+            : []
+        );
+
+        $this->openApi = new OpenApi(['_context' => $context]);
         $modelRegistry = new ModelRegistry($this->modelDescribers, $this->openApi, $this->alternativeNames);
         if (null !== $this->logger) {
             $modelRegistry->setLogger($this->logger);
@@ -103,13 +110,6 @@ final class ApiDocGenerator
 
             $describer->describe($this->openApi);
         }
-
-        $context = Util::createContext(
-            // BC for for zircote/swagger-php < 4.2
-            method_exists($generator, 'getVersion')
-            ? ['version' => $generator->getVersion()]
-            : []
-        );
         $analysis = new Analysis([], $context);
         $analysis->addAnnotation($this->openApi, $context);
 

--- a/Model/ModelRegistry.php
+++ b/Model/ModelRegistry.php
@@ -68,7 +68,7 @@ final class ModelRegistry
         }
 
         // Reserve the name
-        Util::getSchema($this->api, $this->names[$hash]);
+        $s = Util::getSchema($this->api, $this->names[$hash]);
 
         return OA\Components::SCHEMA_REF.$this->names[$hash];
     }

--- a/ModelDescriber/Annotations/OpenApiAnnotationsReader.php
+++ b/ModelDescriber/Annotations/OpenApiAnnotationsReader.php
@@ -18,7 +18,6 @@ use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 use Nelmio\ApiDocBundle\Util\SetsContextTrait;
 use OpenApi\Analysis;
 use OpenApi\Annotations as OA;
-use OpenApi\Context;
 use OpenApi\Generator;
 
 /**

--- a/ModelDescriber/Annotations/OpenApiAnnotationsReader.php
+++ b/ModelDescriber/Annotations/OpenApiAnnotationsReader.php
@@ -39,10 +39,14 @@ class OpenApiAnnotationsReader
 
     public function updateSchema(\ReflectionClass $reflectionClass, OA\Schema $schema): void
     {
+        $this->setContext(Util::createContext([], $schema->_context));
+
         /** @var OA\Schema|null $oaSchema */
         if (!$oaSchema = $this->getAnnotation($reflectionClass, OA\Schema::class)) {
             return;
         }
+
+        $this->setContext(null);
 
         // Read @Model annotations
         $this->modelRegister->__invoke(new Analysis([$oaSchema], Util::createContext()));
@@ -69,12 +73,12 @@ class OpenApiAnnotationsReader
         // In order to have nicer errors
         $declaringClass = $reflection->getDeclaringClass();
 
-        $this->setContext(new Context([
+        $this->setContext(Util::createContext([
             'namespace' => $declaringClass->getNamespaceName(),
             'class' => $declaringClass->getShortName(),
             'property' => $reflection->name,
             'filename' => $declaringClass->getFileName(),
-        ]));
+        ], $property->_context));
 
         /** @var OA\Property|null $oaProperty */
         if (!$oaProperty = $this->getAnnotation($reflection, OA\Property::class)) {

--- a/ModelDescriber/ApplyOpenApiDiscriminatorTrait.php
+++ b/ModelDescriber/ApplyOpenApiDiscriminatorTrait.php
@@ -13,6 +13,7 @@ namespace Nelmio\ApiDocBundle\ModelDescriber;
 
 use Nelmio\ApiDocBundle\Model\Model;
 use Nelmio\ApiDocBundle\Model\ModelRegistry;
+use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 use OpenApi\Annotations as OA;
 use Symfony\Component\PropertyInfo\Type;
 
@@ -43,18 +44,18 @@ trait ApplyOpenApiDiscriminatorTrait
         array $typeMap
     ): void {
         $schema->oneOf = [];
-        $schema->discriminator = new OA\Discriminator([]);
-        $schema->discriminator->propertyName = $discriminatorProperty;
-        $schema->discriminator->mapping = [];
+        $discriminator = Util::getChild($schema, OA\Discriminator::class);
+        $discriminator->propertyName = $discriminatorProperty;
+        $discriminator->mapping = [];
         foreach ($typeMap as $propertyValue => $className) {
-            $oneOfSchema = new OA\Schema([]);
+            $oneOfSchema = Util::createChild($schema, OA\Schema::class);
             $oneOfSchema->ref = $modelRegistry->register(new Model(
                 new Type(Type::BUILTIN_TYPE_OBJECT, false, $className),
                 $model->getGroups(),
                 $model->getOptions()
             ));
             $schema->oneOf[] = $oneOfSchema;
-            $schema->discriminator->mapping[$propertyValue] = $oneOfSchema->ref;
+            $discriminator->mapping[$propertyValue] = $oneOfSchema->ref;
         }
     }
 }

--- a/ModelDescriber/FormModelDescriber.php
+++ b/ModelDescriber/FormModelDescriber.php
@@ -129,7 +129,7 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
             $ref = $this->modelRegistry->register($model);
             // We need to use allOf for description and title to be displayed
             if ($config->hasOption('documentation') && !empty($config->getOption('documentation'))) {
-                $property->allOf = [new OA\Schema(['ref' => $ref])];
+                $property->allOf = [Util::createChild($property, OA\Schema::class, ['ref' => $ref])];
             } else {
                 $property->ref = $ref;
             }

--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -271,7 +271,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
             if (empty($customFields)) { // no custom fields
                 $property->ref = $modelRef;
             } else {
-                $property->allOf = [new OA\Schema(['ref' => $modelRef])];
+                $property->allOf = [Util::createChild($property, OA\Schema::class, ['ref' => $modelRef])];
             }
 
             $this->contexts[$model->getHash()] = $context;

--- a/OpenApiPhp/ModelRegister.php
+++ b/OpenApiPhp/ModelRegister.php
@@ -14,6 +14,7 @@ namespace Nelmio\ApiDocBundle\OpenApiPhp;
 use Nelmio\ApiDocBundle\Annotation\Model as ModelAnnotation;
 use Nelmio\ApiDocBundle\Model\Model;
 use Nelmio\ApiDocBundle\Model\ModelRegistry;
+use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 use OpenApi\Analysis;
 use OpenApi\Annotations as OA;
 use Symfony\Component\PropertyInfo\Type;
@@ -154,11 +155,11 @@ final class ModelRegister
     ) {
         switch ($type) {
             case 'json':
-                $modelAnnotation = new OA\JsonContent($properties);
+                $modelAnnotation = Util::createChild($annotation, OA\JsonContent::class, $properties);
 
                 break;
             case 'xml':
-                $modelAnnotation = new OA\XmlContent($properties);
+                $modelAnnotation = Util::createChild($annotation, OA\XmlContent, $properties);
 
                 break;
             default:

--- a/OpenApiPhp/ModelRegister.php
+++ b/OpenApiPhp/ModelRegister.php
@@ -14,7 +14,6 @@ namespace Nelmio\ApiDocBundle\OpenApiPhp;
 use Nelmio\ApiDocBundle\Annotation\Model as ModelAnnotation;
 use Nelmio\ApiDocBundle\Model\Model;
 use Nelmio\ApiDocBundle\Model\ModelRegistry;
-use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 use OpenApi\Analysis;
 use OpenApi\Annotations as OA;
 use Symfony\Component\PropertyInfo\Type;

--- a/OpenApiPhp/Util.php
+++ b/OpenApiPhp/Util.php
@@ -84,7 +84,7 @@ final class Util
     public static function getSchema(OA\OpenApi $api, $schema): OA\Schema
     {
         if (!$api->components instanceof OA\Components) {
-            $api->components = new OA\Components([]);
+            $api->components = self::createChild($api, OA\Components::class, []);
         }
 
         return self::getIndexedCollectionItem($api->components, OA\Schema::class, $schema);

--- a/PropertyDescriber/ObjectPropertyDescriber.php
+++ b/PropertyDescriber/ObjectPropertyDescriber.php
@@ -14,6 +14,7 @@ namespace Nelmio\ApiDocBundle\PropertyDescriber;
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareTrait;
 use Nelmio\ApiDocBundle\Model\Model;
+use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 use OpenApi\Annotations as OA;
 use Symfony\Component\PropertyInfo\Type;
 
@@ -37,7 +38,7 @@ class ObjectPropertyDescriber implements PropertyDescriberInterface, ModelRegist
 
         if ($types[0]->isNullable()) {
             $property->nullable = true;
-            $property->allOf = [new OA\Schema(['ref' => $this->modelRegistry->register(new Model($type, $groups))])];
+            $property->allOf = [Util::createChild($property, OA\Schema::class, ['ref' => $this->modelRegistry->register(new Model($type, $groups))])];
 
             return;
         }

--- a/RouteDescriber/FosRestDescriber.php
+++ b/RouteDescriber/FosRestDescriber.php
@@ -145,7 +145,7 @@ final class FosRestDescriber implements RouteDescriberInterface
                 throw new \InvalidArgumentException('Unsupported media type');
         }
         if (!isset($requestBody->content[$contentType])) {
-            $requestBody->content[$contentType] = new OA\MediaType(
+            $requestBody->content[$contentType] = Util::createChild($requestBody, OA\MediaType::class,
                 [
                     'mediaType' => $contentType,
                 ]

--- a/Tests/Functional/SwaggerPHPApiComplianceTest.php
+++ b/Tests/Functional/SwaggerPHPApiComplianceTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional;
+
+use Nelmio\ApiDocBundle\OpenApiPhp\Util;
+use Nelmio\ApiDocBundle\Tests\Helper;
+use OpenApi\Annotations as OA;
+use OpenApi\Analysis;
+use Symfony\Component\Serializer\Annotation\SerializedName;
+
+class SwaggerPHPApiComplianceTest extends WebTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        static::createClient([], ['HTTP_HOST' => 'api.example.com']);
+    }
+
+    public function testAllContextsHaveSameRoot()
+    {
+        $openApi = $this->getOpenApiDefinition();
+        $root = $openApi->_context;
+
+        $counter = 0;
+        foreach ((new Analysis([$openApi], Util::createContext()))->annotations as $annotation) {
+            $this->assertSame($annotation->_context->root(), $root);
+        }
+    }
+}

--- a/Tests/Functional/SwaggerPHPApiComplianceTest.php
+++ b/Tests/Functional/SwaggerPHPApiComplianceTest.php
@@ -13,6 +13,7 @@ namespace Nelmio\ApiDocBundle\Tests\Functional;
 
 use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 use OpenApi\Analysis;
+use OpenApi\Context;
 
 class SwaggerPHPApiComplianceTest extends WebTestCase
 {
@@ -25,12 +26,21 @@ class SwaggerPHPApiComplianceTest extends WebTestCase
 
     public function testAllContextsHaveSameRoot()
     {
+        // zircote/swagger-php < 4.2 support
+        $getRootContext = \Closure::bind(function (Context $context) use (&$getRootContext) {
+            if (null !== $context->_parent) {
+                return $getRootContext($context->_parent);
+            }
+
+            return $context;
+        }, null, Context::class);
+
         $openApi = $this->getOpenApiDefinition();
         $root = $openApi->_context;
 
         $counter = 0;
         foreach ((new Analysis([$openApi], Util::createContext()))->annotations as $annotation) {
-            $this->assertSame($annotation->_context->root(), $root);
+            $this->assertSame($getRootContext($annotation->_context), $root);
         }
     }
 }

--- a/Tests/Functional/SwaggerPHPApiComplianceTest.php
+++ b/Tests/Functional/SwaggerPHPApiComplianceTest.php
@@ -12,10 +12,7 @@
 namespace Nelmio\ApiDocBundle\Tests\Functional;
 
 use Nelmio\ApiDocBundle\OpenApiPhp\Util;
-use Nelmio\ApiDocBundle\Tests\Helper;
-use OpenApi\Annotations as OA;
 use OpenApi\Analysis;
-use Symfony\Component\Serializer\Annotation\SerializedName;
 
 class SwaggerPHPApiComplianceTest extends WebTestCase
 {

--- a/Tests/SwaggerPhp/UtilTest.php
+++ b/Tests/SwaggerPhp/UtilTest.php
@@ -823,6 +823,7 @@ class UtilTest extends TestCase
 
     public function assertContextIsConnectedToRootContext(Context $context)
     {
+        // zircote/swagger-php < 4.2 support
         $getRootContext = \Closure::bind(function (Context $context) use (&$getRootContext) {
             if (null !== $context->_parent) {
                 return $getRootContext($context->_parent);


### PR DESCRIPTION
Fixes https://github.com/nelmio/NelmioApiDocBundle/issues/1984

Currently, in some places new Swagger-php annotations do not have a parent context, and thus do not inherit from the root context.
This causes issues with the new version field which uses the context extensively.

This PR fixes this and uses the same root context everywhere.