### PR TITLE
Fix typo "expect" to "except" in documentation.

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -84,7 +84,7 @@ By default, only routes under ``/api`` are documented. Update the regexp at ``ne
         # config/packages/nelmio_api_doc.yaml
         nelmio_api_doc:
             areas:
-                path_patterns: # an array of regexps (document only routes under /api, expect /api/doc)
+                path_patterns: # an array of regexps (document only routes under /api, except /api/doc)
                     - ^/api(?!/doc$)
                 host_patterns: # document only routes with a host of the form api.*
                     - ^api\.


### PR DESCRIPTION
I suppose it means that routes under `/api/doc` will not be parsed for api documentation.