### PR TITLE
The ObjectModelDescriber can support interfaces

### DIFF
--- a/ModelDescriber/ObjectModelDescriber.php
+++ b/ModelDescriber/ObjectModelDescriber.php
@@ -215,6 +215,7 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
 
     public function supports(Model $model): bool
     {
-        return Type::BUILTIN_TYPE_OBJECT === $model->getType()->getBuiltinType() && class_exists($model->getType()->getClassName());
+        return Type::BUILTIN_TYPE_OBJECT === $model->getType()->getBuiltinType()
+            && (class_exists($model->getType()->getClassName()) || interface_exists($model->getType()->getClassName()));
     }
 }

--- a/Tests/Functional/Controller/ApiController80.php
+++ b/Tests/Functional/Controller/ApiController80.php
@@ -11,6 +11,7 @@
 
 namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
 
+use Functional\Entity\ArticleInterface;
 use Nelmio\ApiDocBundle\Annotation\Areas;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use Nelmio\ApiDocBundle\Annotation\Operation;
@@ -48,6 +49,23 @@ class ApiController80
      * @OA\Parameter(name="Application-Name", in="header", @OA\Schema(type="string"))
      */
     public function fetchArticleAction()
+    {
+    }
+
+    /**
+     * @OA\Get(
+     *  @OA\Response(
+     *   response="200",
+     *   description="Success",
+     *   @Model(type=ArticleInterface::class, groups={"light"}))
+     *  )
+     * )
+     * @OA\Parameter(ref="#/components/parameters/test")
+     * @Route("/article-interface/{id}", methods={"GET"})
+     * @OA\Parameter(name="Accept-Version", in="header", @OA\Schema(type="string"))
+     * @OA\Parameter(name="Application-Name", in="header", @OA\Schema(type="string"))
+     */
+    public function fetchArticleInterfaceAction()
     {
     }
 

--- a/Tests/Functional/Entity/ArticleInterface.php
+++ b/Tests/Functional/Entity/ArticleInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Functional\Entity;
+
+interface ArticleInterface
+{
+    public function getAuthor(): string;
+}


### PR DESCRIPTION
I've encountered a class hierarchy where there was an interface.

The ObjectModelDescriber already behave well with interface but the `class_exists` prevent it from being used with interface.

Not sure if I'm missing something.