### PR TITLE
Allow symfony/flex composer plugin in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -74,6 +74,7 @@ jobs:
         env:
           SYMFONY_REQUIRE: "${{ matrix.symfony-require }}"
         run: |
+          composer global config --no-plugins allow-plugins.symfony/flex true
           composer global require --no-progress --no-scripts --no-plugins symfony/flex
           composer update --no-interaction --no-progress ${{ matrix.composer-flags }}
 


### PR DESCRIPTION
Recent composer version requires to allow plugin before execution.
