### PR TITLE
Adding support for Symofny Assert\Sequentially

### DIFF
--- a/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
+++ b/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
@@ -52,7 +52,7 @@ class SymfonyConstraintAnnotationReader
     public function updateProperty($reflection, OA\Property $property, ?array $validationGroups = null): void
     {
         foreach ($this->getAnnotations($reflection, $validationGroups) as $outerAnnotation) {
-            $innerAnnotations = $outerAnnotation instanceof Assert\Compound
+            $innerAnnotations = $outerAnnotation instanceof Assert\Compound || $outerAnnotation instanceof Assert\Sequentially
                 ? $outerAnnotation->constraints
                 : [$outerAnnotation];
 


### PR DESCRIPTION
Currently ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php not display constraints when use Assert\Sequentially, it should works like Assert\Compound