### PR TITLE
Fix  Disable Default Section exempale

### DIFF
--- a/Resources/doc/faq.rst
+++ b/Resources/doc/faq.rst
@@ -206,8 +206,7 @@ A: Use ``disable_default_routes`` config in your area.
 
     nelmio_api_doc:
         areas:
-            default:
-                disable_default_routes: true
+            disable_default_routes: true
 
 Overriding a Form or Plain PHP Object Schema Type
 -------------------------------------------------


### PR DESCRIPTION
The disable_default_routes is under areas and not under default. 
I'm using the version 4.9 of the bundle