### PR TITLE
Read discriminator mapping from file configuration

### DIFF
--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -144,7 +144,7 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
             ));
 
         $container->getDefinition('nelmio_api_doc.model_describers.object')
-            ->setArgument(3, $config['media_types']);
+            ->setArgument(4, $config['media_types']);
 
         // Add autoconfiguration for model describer
         $container->registerForAutoconfiguration(ModelDescriberInterface::class)

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -71,6 +71,7 @@
         <!-- Model Describers -->
         <service id="nelmio_api_doc.model_describers.object" class="Nelmio\ApiDocBundle\ModelDescriber\ObjectModelDescriber" public="false">
             <argument type="service" id="property_info" />
+            <argument type="service" id="serializer.mapping.class_metadata_factory" />
             <argument type="service" id="annotations.reader" />
             <argument type="tagged" tag="nelmio_api_doc.object_model.property_describer" />
             <argument />

--- a/Tests/Functional/Controller/ApiController80.php
+++ b/Tests/Functional/Controller/ApiController80.php
@@ -24,6 +24,7 @@ use Nelmio\ApiDocBundle\Tests\Functional\Entity\EntityWithRef;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\SymfonyConstraints;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\SymfonyConstraintsWithValidationGroups;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\SymfonyDiscriminator;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\SymfonyDiscriminatorFileMapping;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\User;
 use Nelmio\ApiDocBundle\Tests\Functional\Form\DummyType;
 use Nelmio\ApiDocBundle\Tests\Functional\Form\FormWithAlternateSchemaType;
@@ -274,6 +275,15 @@ class ApiController80
      * @OA\Response(response=200, description="Worked well!", @Model(type=SymfonyDiscriminator::class))
      */
     public function discriminatorMappingAction()
+    {
+    }
+
+    /**
+     * @Route("/discriminator-mapping-configured-with-file", methods={"GET", "POST"})
+     *
+     * @OA\Response(response=200, description="Worked well!", @Model(type=SymfonyDiscriminatorFileMapping::class))
+     */
+    public function discriminatorMappingConfiguredWithFileAction()
     {
     }
 

--- a/Tests/Functional/Entity/SymfonyDiscriminatorFileMapping.php
+++ b/Tests/Functional/Entity/SymfonyDiscriminatorFileMapping.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
+
+abstract class SymfonyDiscriminatorFileMapping
+{
+    /**
+     * @var string
+     */
+    public $type;
+}

--- a/Tests/Functional/Entity/SymfonyDiscriminatorFileMapping.php
+++ b/Tests/Functional/Entity/SymfonyDiscriminatorFileMapping.php
@@ -11,10 +11,6 @@
 
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
 
-abstract class SymfonyDiscriminatorFileMapping
+interface SymfonyDiscriminatorFileMapping
 {
-    /**
-     * @var string
-     */
-    public $type;
 }

--- a/Tests/Functional/Entity/SymfonyDiscriminatorOne.php
+++ b/Tests/Functional/Entity/SymfonyDiscriminatorOne.php
@@ -11,7 +11,7 @@
 
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
 
-class SymfonyDiscriminatorOne extends SymfonyDiscriminator
+class SymfonyDiscriminatorOne extends SymfonyDiscriminator implements SymfonyDiscriminatorFileMapping
 {
     /**
      * @var string

--- a/Tests/Functional/Entity/SymfonyDiscriminatorTwo.php
+++ b/Tests/Functional/Entity/SymfonyDiscriminatorTwo.php
@@ -11,7 +11,7 @@
 
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
 
-class SymfonyDiscriminatorTwo extends SymfonyDiscriminator
+class SymfonyDiscriminatorTwo extends SymfonyDiscriminator implements SymfonyDiscriminatorFileMapping
 {
     /**
      * @var string

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -622,6 +622,19 @@ class FunctionalTest extends WebTestCase
         $this->assertCount(2, $model->oneOf);
     }
 
+    public function testModelsWithDiscriminatorMapAreLoadedWithOpenApiPolymorphismWhenUsingFileConfiguration()
+    {
+        $model = $this->getModel('SymfonyDiscriminatorFileMapping');
+
+        $this->assertInstanceOf(OA\Discriminator::class, $model->discriminator);
+        $this->assertSame('type', $model->discriminator->propertyName);
+        $this->assertCount(2, $model->discriminator->mapping);
+        $this->assertArrayHasKey('one', $model->discriminator->mapping);
+        $this->assertArrayHasKey('two', $model->discriminator->mapping);
+        $this->assertNotSame(Generator::UNDEFINED, $model->oneOf);
+        $this->assertCount(2, $model->oneOf);
+    }
+
     public function testDiscriminatorMapLoadsChildrenModels()
     {
         // get model does its own assertions

--- a/Tests/Functional/Resources/serializer/discriminator.yaml
+++ b/Tests/Functional/Resources/serializer/discriminator.yaml
@@ -1,0 +1,6 @@
+Nelmio\ApiDocBundle\Tests\Functional\Entity\SymfonyDiscriminatorFileMapping:
+    discriminator_map:
+        type_property: type
+        mapping:
+            one: Nelmio\ApiDocBundle\Tests\Functional\Entity\SymfonyDiscriminatorOne
+            two: Nelmio\ApiDocBundle\Tests\Functional\Entity\SymfonyDiscriminatorTwo

--- a/Tests/Functional/TestKernel.php
+++ b/Tests/Functional/TestKernel.php
@@ -131,7 +131,12 @@ class TestKernel extends Kernel
             'test' => null,
             'validation' => null,
             'form' => null,
-            'serializer' => ['enable_annotations' => true],
+            'serializer' => [
+                'enable_annotations' => true,
+                'mapping' => [
+                    'paths' => [__DIR__.'/Resources/serializer/'],
+                ],
+            ],
             'property_access' => true,
         ];
         // Support symfony/framework-bundle < 5.4


### PR DESCRIPTION
Currently, the bundle can extract discriminator mappings only from the annotations. This MR uses Serializer's metadata factory to support all of configurations: annotations, yaml files, etc.