### PR TITLE
Fix OA\XmlContent class reference

### DIFF
--- a/OpenApiPhp/ModelRegister.php
+++ b/OpenApiPhp/ModelRegister.php
@@ -164,7 +164,7 @@ final class ModelRegister
 
                 break;
             case 'xml':
-                $modelAnnotation = Util::createChild($annotation, OA\XmlContent, $properties);
+                $modelAnnotation = Util::createChild($annotation, OA\XmlContent::class, $properties);
 
                 break;
             default:


### PR DESCRIPTION
Simple fix to reference class correctly, fixing XML API descriptions.