### PR TITLE
Fix type error in SymfonyConstraintAnnotationReader

### DIFF
--- a/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
+++ b/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
@@ -225,7 +225,7 @@ class SymfonyConstraintAnnotationReader
     {
         return count(array_intersect(
             $validationGroups ?: [Constraint::DEFAULT_GROUP],
-            $annotation->groups
+            (array) $annotation->groups
         )) > 0;
     }
 }

--- a/Tests/Functional/Entity/SymfonyConstraintsWithValidationGroups.php
+++ b/Tests/Functional/Entity/SymfonyConstraintsWithValidationGroups.php
@@ -11,6 +11,7 @@
 
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
 
+use OpenApi\Annotations as OA;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -31,4 +32,12 @@ class SymfonyConstraintsWithValidationGroups
      * @Assert\Range(min=1, max=100)
      */
     public $propertyInDefaultGroup;
+
+    /**
+     * @var array
+     *
+     * @OA\Property(type="array", @OA\Items(type="string"))
+     * @Assert\Valid
+     */
+    public $propertyArray;
 }

--- a/Tests/Functional/ValidationGroupsFunctionalTest.php
+++ b/Tests/Functional/ValidationGroupsFunctionalTest.php
@@ -66,6 +66,12 @@ class ValidationGroupsFunctionalTest extends WebTestCase
                     'maximum' => 100,
                     'minimum' => 1,
                 ],
+                'propertyArray' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'string',
+                    ],
+                ],
             ],
             'type' => 'object',
             'schema' => 'SymfonyConstraintsDefaultGroup',


### PR DESCRIPTION
Steps to reproduce:
- enable `use_validation_groups: true` in configuration
- add model property with type `array` and `Assert\Valid` constraint on it
- try to build Api Doc

Got `array_intersect(): Argument #2 must be of type array, null given` in the `ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php:228`