### PR TITLE
Ensure date time interface is described as expected

### DIFF
--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -278,7 +278,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
         } elseif (in_array($type['name'], ['double', 'float'], true)) {
             $property->type = 'number';
             $property->format = $type['name'];
-        } elseif (is_subclass_of($type['name'], \DateTimeInterface::class)) {
+        } elseif (is_a($type['name'], \DateTimeInterface::class, true)) {
             $property->type = 'string';
             $property->format = 'date-time';
         } else {


### PR DESCRIPTION
if a type is hinted as `DateTimeInterface`, the API doc wont work well as `is_subclass_of('DateTimeInterface', 'DateTimeInterface')` returns false 