### PR TITLE
Fix `phpdocumentor/reflection-docblock` usage for `dev`

### DIFF
--- a/DependencyInjection/Compiler/PhpDocExtractorPass.php
+++ b/DependencyInjection/Compiler/PhpDocExtractorPass.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Enables the `PhpDocExtractor` in case `nelmo/api-doc-bundle` required for dev environment only.
+ *
+ * @see https://github.com/symfony/symfony/blob/6.1/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L1889
+ *
+ * @internal
+ */
+final class PhpDocExtractorPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('property_info.php_doc_extractor')) {
+            $definition = $container->register('property_info.php_doc_extractor', 'Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor');
+            $definition->addTag('property_info.description_extractor', ['priority' => -1000]);
+            $definition->addTag('property_info.type_extractor', ['priority' => -1001]);
+        }
+    }
+}

--- a/DependencyInjection/Compiler/PhpDocExtractorPass.php
+++ b/DependencyInjection/Compiler/PhpDocExtractorPass.php
@@ -15,7 +15,8 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * Enables the `PhpDocExtractor` in case `nelmo/api-doc-bundle` required for dev environment only.
+ * Enables the `PhpDocExtractor` manually if Symfony did not. Covers the cases where the `phpdocumentor/reflection-docblock` dependency is considered
+ * dev only and not automatically enabled by Symfony because `nelmio/api-doc-bundle` (which requires it) is required for dev environment only.
  *
  * @see https://github.com/symfony/symfony/blob/6.1/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L1889
  *

--- a/NelmioApiDocBundle.php
+++ b/NelmioApiDocBundle.php
@@ -12,6 +12,7 @@
 namespace Nelmio\ApiDocBundle;
 
 use Nelmio\ApiDocBundle\DependencyInjection\Compiler\ConfigurationPass;
+use Nelmio\ApiDocBundle\DependencyInjection\Compiler\PhpDocExtractorPass;
 use Nelmio\ApiDocBundle\DependencyInjection\Compiler\TagDescribersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -25,5 +26,6 @@ final class NelmioApiDocBundle extends Bundle
     {
         $container->addCompilerPass(new ConfigurationPass());
         $container->addCompilerPass(new TagDescribersPass());
+        $container->addCompilerPass(new PhpDocExtractorPass());
     }
 }


### PR DESCRIPTION
I found that `property_info.php_doc_extractor` won't be available at Symfony ^5.0, if NelmioApiDocBundle is required for dev only.

https://github.com/symfony/symfony/blob/6.1/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L1889

That's why I added custom pass for this class. Since `reflection-docblock` is mandatory, there is no need to check for `ContainerBuilder::willBeAvailable`.