### PR TITLE
Check nullable property has nullable set

### DIFF
--- a/PropertyDescriber/NullablePropertyTrait.php
+++ b/PropertyDescriber/NullablePropertyTrait.php
@@ -12,13 +12,19 @@
 namespace Nelmio\ApiDocBundle\PropertyDescriber;
 
 use OpenApi\Annotations as OA;
+use OpenApi\Generator;
 use Symfony\Component\PropertyInfo\Type;
 
 trait NullablePropertyTrait
 {
     protected function setNullableProperty(Type $type, OA\Schema $property): void
     {
-        if ($type->isNullable()) {
+        if (Generator::UNDEFINED !== $property->nullable) {
+            if (!$property->nullable) {
+                // if already false mark it as undefined (so it does not show up as `nullable: false`)
+                $property->nullable = Generator::UNDEFINED;
+            }
+        } elseif ($type->isNullable()) {
             $property->nullable = true;
         }
     }

--- a/Tests/Functional/Controller/ApiController80.php
+++ b/Tests/Functional/Controller/ApiController80.php
@@ -19,6 +19,7 @@ use Nelmio\ApiDocBundle\Tests\Functional\Entity\Article;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\ArticleInterface;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\CompoundEntity;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\EntityWithAlternateType;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\EntityWithNullableSchemaSet;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\EntityWithObjectType;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\EntityWithRef;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\SymfonyConstraints;
@@ -380,6 +381,18 @@ class ApiController80
      * )
      */
     public function formWithRefSchemaType()
+    {
+    }
+
+    /**
+     * @Route("/entity-with-nullable-property-set", methods={"GET"})
+     * @OA\Response(
+     *    response="201",
+     *    description="Operation automatically detected",
+     *    @Model(type=EntityWithNullableSchemaSet::class)
+     * )
+     */
+    public function entityWithNullableSchemaSet()
     {
     }
 }

--- a/Tests/Functional/Entity/EntityWithNullableSchemaSet.php
+++ b/Tests/Functional/Entity/EntityWithNullableSchemaSet.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
+
+use OpenApi\Annotations as OA;
+
+class EntityWithNullableSchemaSet
+{
+    /**
+     * @var ?string
+     *
+     * @OA\Property()
+     */
+    public $nullablePropertyNullableNotSet;
+
+    /**
+     * @var ?string
+     *
+     * @OA\Property(nullable=false)
+     */
+    public $nullablePropertyNullableFalseSet;
+
+    /**
+     * @var ?string
+     *
+     * @OA\Property(nullable=true)
+     */
+    public $nullablePropertyNullableTrueSet;
+
+    /**
+     * @var string
+     *
+     * @OA\Property()
+     */
+    public $nonNullablePropertyNullableNotSet;
+
+    /**
+     * @var string
+     *
+     * @OA\Property(nullable=false)
+     */
+    public $nonNullablePropertyNullableFalseSet;
+
+    /**
+     * @var string
+     *
+     * @OA\Property(nullable=true)
+     */
+    public $nonNullablePropertyNullableTrueSet;
+}

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -704,4 +704,29 @@ class FunctionalTest extends WebTestCase
         $this->assertSame('#/components/schemas/Test', $model->ref);
         $this->assertSame(Generator::UNDEFINED, $model->properties);
     }
+
+    public function testEntityWithNullableSchemaSet()
+    {
+        $model = $this->getModel('EntityWithNullableSchemaSet');
+
+        $this->assertCount(6, $model->properties);
+
+        // nullablePropertyNullableNotSet
+        $this->assertTrue($model->properties[0]->nullable);
+
+        // nullablePropertyNullableFalseSet
+        $this->assertSame(Generator::UNDEFINED, $model->properties[1]->nullable);
+
+        // nullablePropertyNullableTrueSet
+        $this->assertTrue($model->properties[2]->nullable);
+
+        // nonNullablePropertyNullableNotSet
+        $this->assertSame(Generator::UNDEFINED, $model->properties[3]->nullable);
+
+        // nonNullablePropertyNullableFalseSet
+        $this->assertSame(Generator::UNDEFINED, $model->properties[4]->nullable);
+
+        // nonNullablePropertyNullableTrueSet
+        $this->assertTrue($model->properties[5]->nullable);
+    }
 }


### PR DESCRIPTION
My use case is I have an entity which has a nullable string `?string` property (so the deserialization will work, since `null` can be passed) but the validation will check that it is not null, in which case I know that it will always be a `string`

Without this change, even tough I have `@OA\Property(nullable=false)` set in the entity, it gets ignored... this change fixes this and it will show up correctly as `nullable: false` in swagger docs

Made a small change after the fact, it checks if `nullable` is not undefined, and if it's false it will mark it undefined, so they don't show up as `nullable: false` for all the properties in the doc which is not necessary