### PR TITLE
Add enum description to route parameter if possible.

### DIFF
--- a/RouteDescriber/RouteMetadataDescriber.php
+++ b/RouteDescriber/RouteMetadataDescriber.php
@@ -24,7 +24,7 @@ final class RouteMetadataDescriber implements RouteDescriberInterface
 {
     use RouteDescriberTrait;
 
-    private const ALPHANUM_EXPANDED_REGEX = '/^[-a-zA-Z0-9_.]*$/';
+    private const ALPHANUM_EXPANDED_REGEX = '/^[-a-zA-Z0-9_]*$/';
 
     public function describe(OA\OpenApi $api, Route $route, \ReflectionMethod $reflectionMethod)
     {

--- a/RouteDescriber/RouteMetadataDescriber.php
+++ b/RouteDescriber/RouteMetadataDescriber.php
@@ -113,8 +113,10 @@ final class RouteMetadataDescriber implements RouteDescriberInterface
 
     /**
      * returns array of separated alphanumeric (including '-', '_', '.') strings from a simple OR regex requirement pattern.
-     * (routing parameters containing enums have already been resolved to that format at this time)
+     * (routing parameters containing enums have already been resolved to that format at this time).
+     *
      * @param string $reqPattern a requirement pattern to match, e.g. 'a.html|b.html'
+     *
      * @return array<string>
      */
     private function getPossibleEnumValues(string $reqPattern): array
@@ -123,7 +125,7 @@ final class RouteMetadataDescriber implements RouteDescriberInterface
         if (str_contains($reqPattern, '|')) {
             $parts = explode('|', $reqPattern);
             foreach ($parts as $part) {
-                if ('' === $part || preg_match(self::ALPHANUM_EXPANDED_REGEX, $part) === 0) {
+                if ('' === $part || 0 === preg_match(self::ALPHANUM_EXPANDED_REGEX, $part)) {
                     // we check a complex regex expression containing | - abort in that case
                     return [];
                 } else {

--- a/RouteDescriber/RouteMetadataDescriber.php
+++ b/RouteDescriber/RouteMetadataDescriber.php
@@ -122,7 +122,7 @@ final class RouteMetadataDescriber implements RouteDescriberInterface
     private function getPossibleEnumValues(string $reqPattern): array
     {
         $requirements = [];
-        if (str_contains($reqPattern, '|')) {
+        if (false !== strpos($reqPattern, '|')) {
             $parts = explode('|', $reqPattern);
             foreach ($parts as $part) {
                 if ('' === $part || 0 === preg_match(self::ALPHANUM_EXPANDED_REGEX, $part)) {

--- a/RouteDescriber/RouteMetadataDescriber.php
+++ b/RouteDescriber/RouteMetadataDescriber.php
@@ -112,7 +112,7 @@ final class RouteMetadataDescriber implements RouteDescriberInterface
     }
 
     /**
-     * returns array of separated alphanumeric (including '-', '_', '.') strings from a simple OR regex requirement pattern.
+     * returns array of separated alphanumeric (including '-', '_') strings from a simple OR regex requirement pattern.
      * (routing parameters containing enums have already been resolved to that format at this time).
      *
      * @param string $reqPattern a requirement pattern to match, e.g. 'a.html|b.html'

--- a/Tests/RouteDescriber/RouteMetadataDescriberTest.php
+++ b/Tests/RouteDescriber/RouteMetadataDescriberTest.php
@@ -95,7 +95,6 @@ class RouteMetadataDescriberTest extends TestCase
         yield ['srf|rtr|rsi'];
         yield ['srf-1|srf-2'];
         yield ['srf-1|srf-2'];
-        yield ['a_1.html|b-2.html'];
     }
 
     public function provideInvalidEnumPattern()
@@ -106,5 +105,9 @@ class RouteMetadataDescriberTest extends TestCase
         yield ['srf||rtr'];
         yield ['1|2|'];
         yield ['/1|2/'];
+        yield ['\d|a'];
+        // dots have special meaning and should be skipped
+        yield ['a_1\.html|b-2\.html'];
+        yield ['a_1.html|b-2.html'];
     }
 }

--- a/Tests/RouteDescriber/RouteMetadataDescriberTest.php
+++ b/Tests/RouteDescriber/RouteMetadataDescriberTest.php
@@ -15,6 +15,7 @@ use Nelmio\ApiDocBundle\RouteDescriber\RouteMetadataDescriber;
 use OpenApi\Annotations\OpenApi;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\Route;
+use OpenApi\Generator;
 
 class RouteMetadataDescriberTest extends TestCase
 {
@@ -23,5 +24,89 @@ class RouteMetadataDescriberTest extends TestCase
         $routeDescriber = new RouteMetadataDescriber();
 
         $this->assertNull($routeDescriber->describe(new OpenApi([]), new Route('foo'), new \ReflectionMethod(__CLASS__, 'testUndefinedCheck')));
+    }
+
+
+    public function testRouteRequirementsWithPattern()
+    {
+        $api = new OpenApi([]);
+        $routeDescriber = new RouteMetadataDescriber();
+        $route = new Route('/index/{bar}/{foo}.html', [], ['foo' => '[0-9]|[a-z]'], [], 'localhost', 'https', ['GET']);
+        $routeDescriber->describe(
+            $api,
+            $route,
+            new \ReflectionMethod(__CLASS__, 'testRouteRequirementsWithPattern')
+        );
+
+        $this->assertEquals('/index/{bar}/{foo}.html', $api->paths[0]->path);
+        $getPathParameter = $api->paths[0]->get->parameters[1];
+        if ('foo' === $getPathParameter->name) {
+            $this->assertEquals('path', $getPathParameter->in);
+            $this->assertEquals('foo', $getPathParameter->name);
+            $this->assertEquals('string', $getPathParameter->schema->type);
+            $this->assertEquals('[0-9]|[a-z]', $getPathParameter->schema->pattern);
+        }
+    }
+
+    /**
+     * @dataProvider provideEnumPattern
+     */
+    public function testSimpleOrRequirementsAreHandledAsEnums($req)
+    {
+        $api = new OpenApi([]);
+        $routeDescriber = new RouteMetadataDescriber();
+        $route = new Route('/index/{bar}/{foo}.html', [], ['foo' => $req], [], 'localhost', 'https', ['GET']);
+        $routeDescriber->describe(
+            $api,
+            $route,
+            new \ReflectionMethod(__CLASS__, 'testSimpleOrRequirementsAreHandledAsEnums')
+        );
+
+        $this->assertEquals('/index/{bar}/{foo}.html', $api->paths[0]->path);
+        $getPathParameter = $api->paths[0]->get->parameters[1];
+        $this->assertEquals('path', $getPathParameter->in);
+        $this->assertEquals('foo', $getPathParameter->name);
+        $this->assertEquals('string', $getPathParameter->schema->type);
+        $this->assertEquals(explode('|', $req), $getPathParameter->schema->enum);
+        $this->assertEquals($req, $getPathParameter->schema->pattern);
+    }
+
+
+    /**
+     * @dataProvider provideInvalidEnumPattern
+     */
+    public function testNonEnumPatterns($pattern)
+    {
+        $api = new OpenApi([]);
+        $routeDescriber = new RouteMetadataDescriber();
+        $route = new Route('/index/{foo}.html', [], ['foo' => $pattern], [], 'localhost', 'https', ['GET']);
+        $routeDescriber->describe(
+            $api,
+            $route,
+            new \ReflectionMethod(__CLASS__, 'testNonEnumPatterns')
+        );
+
+        $getPathParameter = $api->paths[0]->get->parameters[0];
+        $this->assertEquals($pattern, $getPathParameter->schema->pattern);
+        $this->assertEquals(Generator::UNDEFINED, $getPathParameter->schema->enum);
+    }
+
+    public function provideEnumPattern()
+    {
+        yield ['1|2|3'];
+        yield ['srf|rtr|rsi'];
+        yield ['srf-1|srf-2'];
+        yield ['srf-1|srf-2'];
+        yield ['a_1.html|b-2.html'];
+    }
+
+    public function provideInvalidEnumPattern()
+    {
+        yield ['|'];
+        yield ['|a'];
+        yield ['srf|*|rtr'];
+        yield ['srf||rtr'];
+        yield ['1|2|'];
+        yield ['/1|2/'];
     }
 }

--- a/Tests/RouteDescriber/RouteMetadataDescriberTest.php
+++ b/Tests/RouteDescriber/RouteMetadataDescriberTest.php
@@ -13,9 +13,9 @@ namespace Nelmio\ApiDocBundle\Tests\RouteDescriber;
 
 use Nelmio\ApiDocBundle\RouteDescriber\RouteMetadataDescriber;
 use OpenApi\Annotations\OpenApi;
+use OpenApi\Generator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\Route;
-use OpenApi\Generator;
 
 class RouteMetadataDescriberTest extends TestCase
 {
@@ -25,7 +25,6 @@ class RouteMetadataDescriberTest extends TestCase
 
         $this->assertNull($routeDescriber->describe(new OpenApi([]), new Route('foo'), new \ReflectionMethod(__CLASS__, 'testUndefinedCheck')));
     }
-
 
     public function testRouteRequirementsWithPattern()
     {
@@ -70,7 +69,6 @@ class RouteMetadataDescriberTest extends TestCase
         $this->assertEquals(explode('|', $req), $getPathParameter->schema->enum);
         $this->assertEquals($req, $getPathParameter->schema->pattern);
     }
-
 
     /**
      * @dataProvider provideInvalidEnumPattern


### PR DESCRIPTION
Adds an "enum" schema to route parameters if the routing requirements consists only of a simple OR regex epression.
It skips complex expression.
The schema "pattern" field still contains the original regex.
This is mainly useful to display enum values in the Swagger UI gui as select boxes rather than text boxes.
