### PR TITLE
Fixed minor error in the default security policy documentation.

### DIFF
--- a/Resources/doc/security.rst
+++ b/Resources/doc/security.rst
@@ -17,27 +17,39 @@ A default security policy can be added in ``nelmio_api_doc.documentation.securit
                         in: header
                         name: X-API-Key
             security:
-                Bearer: []
+                - Bearer: []
 
 This will add the Bearer security policy to all registered paths.
 
 Overriding Specific Paths
 -------------------------
 
-The security policy can be overridden for a path using the ``@Security`` annotation.
+The security policy can be overridden for a path using the ``Security`` annotation/attribute.
 
-.. code-block:: php
+.. configuration-block::
 
-    /**
-     * @Security(name="ApiKeyAuth")
-     */
+    .. code-block:: php-annotations
 
-Notice at the bottom of the docblock is a ``@Security`` annotation with a name of `ApiKeyAuth`. This will override the global security policy to only accept the ``ApiKeyAuth`` policy for this path.
+        /**
+         * @Security(name="ApiKeyAuth")
+         */
 
-You can also completely remove security from a path by providing ``@Security`` with a name of ``null``.
+    .. code-block:: php-attributes
 
-.. code-block:: php
+        #[Security(name: "ApiKeyAuth")]
 
-    /**
-     * @Security(name=null)
-     */
+Notice at the bottom of the docblock is a ``Security`` annotation/attribute with a name of `ApiKeyAuth`. This will override the global security policy to only accept the ``ApiKeyAuth`` policy for this path.
+
+You can also completely remove security from a path by providing ``Security`` with a name of ``null``.
+
+.. configuration-block::
+
+    .. code-block:: php-annotations
+
+        /**
+         * @Security(name=null)
+         */
+
+    .. code-block:: php-attributes
+
+        #[Security(name: null)]


### PR DESCRIPTION
A missing ``-`` prevents the default security policy from being set.
Added attributes/annotations switcher to the configuration block.