### PR TITLE
Add jms/serializer enum support

### DIFF
--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -285,6 +285,15 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
             $property->type = 'string';
             $property->format = 'date-time';
         } else {
+            // See https://github.com/schmittjoh/serializer/blob/5a5a03a/src/Metadata/Driver/EnumPropertiesDriver.php#L51
+            if ('enum' === $type['name']
+                && isset($type['params'][0])
+                && function_exists('enum_exists')
+                && enum_exists($type['params'][0])
+            ) {
+                $type = ['name' => $type['params'][0]];
+            }
+
             $groups = $this->computeGroups($context, $type);
 
             $model = new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, $type['name']), $groups);

--- a/Tests/Functional/Controller/JMSController81.php
+++ b/Tests/Functional/Controller/JMSController81.php
@@ -12,6 +12,7 @@
 namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
 
 use Nelmio\ApiDocBundle\Annotation\Model;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\Article81;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSComplex81;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSDualComplex;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSNamingStrategyConstraints;
@@ -117,6 +118,16 @@ class JMSController81
         content: new Model(type: JMSChatRoomUser::class, groups: ['mini', 'friend' => ['living' => ['Default']]])
     )]
     public function minUserNestedAction()
+    {
+    }
+
+    #[Route('/api/jms_enum', methods: ['GET'])]
+    #[OA\Response(
+        response: 200,
+        description: 'Success',
+        content: new Model(type: Article81::class))
+    ]
+    public function enum()
     {
     }
 }

--- a/Tests/Functional/JMSFunctionalTest.php
+++ b/Tests/Functional/JMSFunctionalTest.php
@@ -335,6 +335,40 @@ class JMSFunctionalTest extends WebTestCase
         ], json_decode($this->getModel('JMSNamingStrategyConstraints')->toJson(), true));
     }
 
+    /**
+     * @requires PHP >= 8.1
+     */
+    public function testEnumSupport()
+    {
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'id' => [
+                    'type' => 'integer',
+                ],
+                'type' => [
+                    '$ref' => '#/components/schemas/ArticleType81',
+                ],
+                'int_backed_type' => [
+                    '$ref' => '#/components/schemas/ArticleType81IntBacked',
+                ],
+                'not_backed_type' => [
+                    '$ref' => '#/components/schemas/ArticleType81NotBacked',
+                ],
+            ],
+            'schema' => 'Article81',
+        ], json_decode($this->getModel('Article81')->toJson(), true));
+
+        $this->assertEquals([
+            'schema' => 'ArticleType81',
+            'type' => 'string',
+            'enum' => [
+                'draft',
+                'final',
+            ],
+        ], json_decode($this->getModel('ArticleType81')->toJson(), true));
+    }
+
     protected static function createKernel(array $options = []): KernelInterface
     {
         return new TestKernel(TestKernel::USE_JMS);

--- a/Tests/Functional/TestKernel.php
+++ b/Tests/Functional/TestKernel.php
@@ -348,6 +348,12 @@ class TestKernel extends Kernel
             ],
         ]);
 
+        if ($this->flags & self::USE_JMS && \PHP_VERSION_ID >= 80100) {
+            $c->loadFromExtension('jms_serializer', [
+                'enum_support' => true,
+            ]);
+        }
+
         $def = new Definition(VirtualTypeClassDoesNotExistsHandlerDefinedDescriber::class);
         $def->addTag('nelmio_api_doc.model_describer');
         $c->setDefinition('nelmio.test.jms.virtual_type.describer', $def);

--- a/phpunit-baseline.json
+++ b/phpunit-baseline.json
@@ -6800,6 +6800,21 @@
         "count": 1
     },
     {
+        "location": "Nelmio\\ApiDocBundle\\Tests\\Functional\\JMSFunctionalTest::testEnumSupport",
+        "message": "Since sensio/framework-extra-bundle 5.2: The \"sensio_framework_extra.routing.loader.annot_class\" service is deprecated since version 5.2",
+        "count": 1
+    },
+    {
+        "location": "Nelmio\\ApiDocBundle\\Tests\\Functional\\JMSFunctionalTest::testEnumSupport",
+        "message": "Since sensio/framework-extra-bundle 5.2: The \"sensio_framework_extra.routing.loader.annot_dir\" service is deprecated since version 5.2",
+        "count": 1
+    },
+    {
+        "location": "Nelmio\\ApiDocBundle\\Tests\\Functional\\JMSFunctionalTest::testEnumSupport",
+        "message": "Since sensio/framework-extra-bundle 5.2: The \"sensio_framework_extra.routing.loader.annot_file\" service is deprecated since version 5.2",
+        "count": 1
+    },
+    {
         "location": "Nelmio\\ApiDocBundle\\Tests\\Functional\\SwaggerPHPApiComplianceTest::testAllContextsCopyRoot",
         "message": "Since sensio/framework-extra-bundle 5.2: The \"sensio_framework_extra.routing.loader.annot_class\" service is deprecated since version 5.2",
         "count": 1


### PR DESCRIPTION
`jms/serializer` introduced enum support since [v3.20](https://github.com/schmittjoh/serializer/releases/tag/3.20.0) and added a new type: https://github.com/schmittjoh/serializer/blob/402a12629e3ad6d6897273769808a28c32745309/src/Metadata/Driver/EnumPropertiesDriver.php#L50

And since `jms/serializer-bundle` [v5.2.1](https://github.com/schmittjoh/JMSSerializerBundle/releases/tag/5.2.1) and https://github.com/schmittjoh/JMSSerializerBundle/pull/919 with `jms_serializer.enum_support: true` all existing models with enums got broken, because now enum properties are referenced to the fixed string `#/components/schemas/enum` instead of the correct `#/components/schemas/EnumClassName`:
```json
{
    "openapi": "3.0.0",
    "info": {},
    "paths": {
        "/api/card/random": {
            "get": {
                "operationId": "get_app_randomcardaction__invoke",
                "responses": {
                    "200": {
                        "description": "OK",
                        "content": {
                            "application/json": {
                                "schema": {
                                    "$ref": "#/components/schemas/Card"
                                }
                            }
                        }
                    }
                }
            }
        }
    },
    "components": {
        "schemas": {
            "Card": {
                "properties": {
                    "rank": {
                        "type": "integer"
                    },
                    "suit": {
                        "$ref": "#/components/schemas/enum"
                    }
                },
                "type": "object"
            },
            "enum": {}
        }
    }
}
```

Before it was:
```json
{
    "openapi": "3.0.0",
    "info": {},
    "paths": {
        "/api/card/random": {
            "get": {
                "operationId": "get_app_randomcardaction__invoke",
                "responses": {
                    "200": {
                        "description": "OK",
                        "content": {
                            "application/json": {
                                "schema": {
                                    "$ref": "#/components/schemas/Card"
                                }
                            }
                        }
                    }
                }
            }
        }
    },
    "components": {
        "schemas": {
            "Card": {
                "properties": {
                    "rank": {
                        "type": "integer"
                    },
                    "suit": {
                        "$ref": "#/components/schemas/Suit"
                    }
                },
                "type": "object"
            },
            "Suit": {
                "type": "string",
                "enum": [
                    "hearts",
                    "diamonds",
                    "clubs",
                    "spades"
                ]
            }
        }
    }
}
```

This PR adds support for enum type going from `jms/serializer` and returns the correct behavior.