### PR TITLE
fix: validation of requirements in route description

### DIFF
--- a/RouteDescriber/RouteMetadataDescriber.php
+++ b/RouteDescriber/RouteMetadataDescriber.php
@@ -68,7 +68,7 @@ final class RouteMetadataDescriber implements RouteDescriberInterface
                     }
                     // add the pattern anyway
                     if (Generator::UNDEFINED === $parameter->schema->pattern) {
-                        $parameter->schema->pattern = $requirements[$pathVariable];
+                        $parameter->schema->pattern = sprintf('^(?:%s)$', $requirements[$pathVariable]);
                     }
                 }
             }

--- a/Tests/Functional/Controller/ApiController80.php
+++ b/Tests/Functional/Controller/ApiController80.php
@@ -113,7 +113,7 @@ class ApiController80
     }
 
     /**
-     * @Route("/test/users/{user}", methods={"POST"}, schemes={"https"}, requirements={"user"="/foo/"})
+     * @Route("/test/users/{user}", methods={"POST"}, schemes={"https"}, requirements={"user"="foo"})
      * @OA\Response(
      *    response="201",
      *    description="Operation automatically detected",
@@ -129,7 +129,7 @@ class ApiController80
     }
 
     /**
-     * @Route("/test/{user}", methods={"GET"}, schemes={"https"}, requirements={"user"="/foo/"})
+     * @Route("/test/{user}", methods={"GET"}, schemes={"https"}, requirements={"user"="foo"})
      * @OA\Response(response=200, description="sucessful")
      */
     public function userAction()

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -147,7 +147,7 @@ class FunctionalTest extends WebTestCase
         $parameter = Util::getOperationParameter($operation, 'user', 'path');
         $this->assertTrue($parameter->required);
         $this->assertEquals('string', $parameter->schema->type);
-        $this->assertEquals('/foo/', $parameter->schema->pattern);
+        $this->assertEquals('^(?:foo)$', $parameter->schema->pattern);
         $this->assertEquals(Generator::UNDEFINED, $parameter->schema->format);
     }
 

--- a/Tests/RouteDescriber/RouteMetadataDescriberTest.php
+++ b/Tests/RouteDescriber/RouteMetadataDescriberTest.php
@@ -44,7 +44,7 @@ class RouteMetadataDescriberTest extends TestCase
             $this->assertEquals('path', $getPathParameter->in);
             $this->assertEquals('foo', $getPathParameter->name);
             $this->assertEquals('string', $getPathParameter->schema->type);
-            $this->assertEquals('[0-9]|[a-z]', $getPathParameter->schema->pattern);
+            $this->assertEquals('^(?:[0-9]|[a-z])$', $getPathParameter->schema->pattern);
         }
     }
 
@@ -68,7 +68,7 @@ class RouteMetadataDescriberTest extends TestCase
         $this->assertEquals('foo', $getPathParameter->name);
         $this->assertEquals('string', $getPathParameter->schema->type);
         $this->assertEquals(explode('|', $req), $getPathParameter->schema->enum);
-        $this->assertEquals($req, $getPathParameter->schema->pattern);
+        $this->assertEquals('^(?:' . $req . ')$', $getPathParameter->schema->pattern);
     }
 
     /**
@@ -86,7 +86,7 @@ class RouteMetadataDescriberTest extends TestCase
         );
 
         $getPathParameter = $api->paths[0]->get->parameters[0];
-        $this->assertEquals($pattern, $getPathParameter->schema->pattern);
+        $this->assertEquals('^(?:' . $pattern . ')$', $getPathParameter->schema->pattern);
         $this->assertEquals(Generator::UNDEFINED, $getPathParameter->schema->enum);
     }
 


### PR DESCRIPTION
See https://github.com/nelmio/NelmioApiDocBundle/issues/1873

Example
```php
#[Route('route/{id}', requirements: ['id' =>  '\d+'])]
```
Now Swagger UI allows any {id} that contains at least one digit (eg. `x1` or `"1"`). Whereas in Symfony Routing allows {id} that consists only of digits. To be sure, run
```
bin/console route:match /route/x1
# Error: almost matches but requirement for "id" does not match (\d+)

bin/console route:match /route/11
# Success: Path Regex   | {^/route/(?P<id>\d+)$}sDu  
```
See also https://github.com/symfony/routing/blob/6.2/RouteCompiler.php#L301

Therefore, a wrapper has been added to fully comply with the requirements.