### PR TITLE
Add support Pure Enum and remove IntBackedEnum interface

### DIFF
--- a/Tests/ModelDescriber/EnumModelDescriberTest.php
+++ b/Tests/ModelDescriber/EnumModelDescriberTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\ModelDescriber;
+
+use Nelmio\ApiDocBundle\Model\Model;
+use Nelmio\ApiDocBundle\ModelDescriber\EnumModelDescriber;
+use Nelmio\ApiDocBundle\Tests\ModelDescriber\Fixtures\EnumModelBackedInt;
+use Nelmio\ApiDocBundle\Tests\ModelDescriber\Fixtures\EnumModelBackedString;
+use Nelmio\ApiDocBundle\Tests\ModelDescriber\Fixtures\EnumModelPure;
+use Nelmio\ApiDocBundle\Tests\ModelDescriber\Fixtures\SelfDescribingModel;
+use OpenApi\Annotations\Schema;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
+use function var_dump;
+
+class EnumModelDescriberTest extends TestCase
+{
+    public function testSupports()
+    {
+        $describer = new EnumModelDescriber();
+
+        $this->assertTrue($describer->supports(new Model(new Type('object', false, EnumModelPure::class))));
+    }
+
+    public function testDoesNotSupport()
+    {
+        $describer = new EnumModelDescriber();
+
+        $this->assertFalse($describer->supports(new Model(new Type('object', false, \stdClass::class))));
+    }
+
+    public function testDescribeModelPure()
+    {
+        $describer = new EnumModelDescriber();
+
+        $model = new Model(new Type('object', false, EnumModelPure::class));
+        $schema = new Schema([]);
+
+        $describer->describe($model, $schema);
+
+        $this->assertSame('string', $schema->type);
+        $this->assertSame(['VALUE'], $schema->enum);
+    }
+
+    public function testDescribeModelBackedInt()
+    {
+        $describer = new EnumModelDescriber();
+
+        $model = new Model(new Type('object', false, EnumModelBackedInt::class));
+        $schema = new Schema([]);
+
+        $describer->describe($model, $schema);
+
+        $this->assertSame('integer', $schema->type);
+        $this->assertSame([1], $schema->enum);
+    }
+
+    public function testDescribeModelBackedString()
+    {
+        $describer = new EnumModelDescriber();
+
+        $model = new Model(new Type('object', false, EnumModelBackedString::class));
+        $schema = new Schema([]);
+
+        $describer->describe($model, $schema);
+
+        $this->assertSame('string', $schema->type);
+        $this->assertSame(['value'], $schema->enum);
+    }
+}

--- a/Tests/ModelDescriber/EnumModelDescriberTest.php
+++ b/Tests/ModelDescriber/EnumModelDescriberTest.php
@@ -16,14 +16,19 @@ use Nelmio\ApiDocBundle\ModelDescriber\EnumModelDescriber;
 use Nelmio\ApiDocBundle\Tests\ModelDescriber\Fixtures\EnumModelBackedInt;
 use Nelmio\ApiDocBundle\Tests\ModelDescriber\Fixtures\EnumModelBackedString;
 use Nelmio\ApiDocBundle\Tests\ModelDescriber\Fixtures\EnumModelPure;
-use Nelmio\ApiDocBundle\Tests\ModelDescriber\Fixtures\SelfDescribingModel;
 use OpenApi\Annotations\Schema;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Type;
-use function var_dump;
 
 class EnumModelDescriberTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        if (\PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Enum require PHP 8.1');
+        }
+    }
+
     public function testSupports()
     {
         $describer = new EnumModelDescriber();

--- a/Tests/ModelDescriber/Fixtures/EnumModelBackedInt.php
+++ b/Tests/ModelDescriber/Fixtures/EnumModelBackedInt.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Nelmio\ApiDocBundle\Tests\ModelDescriber\Fixtures;
+
+enum EnumModelBackedInt: int
+{
+    case VALUE = 1;
+}

--- a/Tests/ModelDescriber/Fixtures/EnumModelBackedString.php
+++ b/Tests/ModelDescriber/Fixtures/EnumModelBackedString.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Nelmio\ApiDocBundle\Tests\ModelDescriber\Fixtures;
+
+enum EnumModelBackedString: string
+{
+    case VALUE = 'value';
+}

--- a/Tests/ModelDescriber/Fixtures/EnumModelPure.php
+++ b/Tests/ModelDescriber/Fixtures/EnumModelPure.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Nelmio\ApiDocBundle\Tests\ModelDescriber\Fixtures;
+
+enum EnumModelPure
+{
+    case VALUE;
+}


### PR DESCRIPTION
Removed the IntBackedEnum interface, since it's missing from PHP, the check doesn't make sense.

Added support for Pure Enum.

Added tests for EnumModelDescriber.