### PR TITLE
Fix #2089. Accept both DocumentationInterface and OpenApi describers.

### DIFF
--- a/Describer/ApiPlatformDescriber.php
+++ b/Describer/ApiPlatformDescriber.php
@@ -13,17 +13,23 @@ namespace Nelmio\ApiDocBundle\Describer;
 
 use ApiPlatform\Core\Swagger\Serializer\DocumentationNormalizer;
 use ApiPlatform\Documentation\DocumentationInterface;
+use ApiPlatform\OpenApi\OpenApi;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 final class ApiPlatformDescriber extends ExternalDocDescriber
 {
-    public function __construct(DocumentationInterface $documentation, NormalizerInterface $normalizer)
+    public function __construct($documentation, NormalizerInterface $normalizer)
     {
+        if (false === $documentation instanceof DocumentationInterface && false === $documentation instanceof OpenApi) {
+            throw new \InvalidArgumentException(sprintf('First parameter $documentation MUST be of type "%s" or "%s".', DocumentationInterface::class, OpenApi::class));
+        }
+
         if (!$normalizer->supportsNormalization($documentation, 'json')) {
             throw new \InvalidArgumentException(sprintf('Argument 2 passed to %s() must implement %s and support normalization of %s. The normalizer provided is an instance of %s.', __METHOD__, NormalizerInterface::class, Documentation::class, get_class($normalizer)));
         }
 
         parent::__construct(function () use ($documentation, $normalizer) {
+
             $documentation = (array) $normalizer->normalize(
                 $documentation,
                 null,


### PR DESCRIPTION
Fix #2089. Accept both `DocumentationInterface` and `OpenApi` describers.