### PR TITLE
Deprecations fixes for symfony 6.3

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -43,7 +43,7 @@ class DumpCommand extends Command
     /**
      * Configures the dump command.
      */
-    protected function configure()
+    protected function configure(): void
     {
         $availableFormats = $this->renderOpenApi->getAvailableFormats();
         $this

--- a/NelmioApiDocBundle.php
+++ b/NelmioApiDocBundle.php
@@ -22,7 +22,7 @@ final class NelmioApiDocBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new ConfigurationPass());
         $container->addCompilerPass(new TagDescribersPass());


### PR DESCRIPTION
Fixes next deprecations errors for new symfony 6.3.

bin/console lint:container

{"message":"User Deprecated: Method \"Symfony\\Component\\HttpKernel\\Bundle\\Bundle::build()\" might add \"void\" as a native return type declaration in the future. Do the same in child class \"Nelmio\\ApiDocBundle\\NelmioApiDocBundle\" now to avoid errors or add an explicit @return annotation to suppress this message.","context":{"exception":{"class":"ErrorException","message":"User Deprecated: Method \"Symfony\\Component\\HttpKernel\\Bundle\\Bundle::build()\" might add \"void\" as a native return type declaration in the future. Do the same in child class \"Nelmio\\ApiDocBundle\\NelmioApiDocBundle\" now to avoid errors or add an explicit @return annotation to suppress this message.","code":0,"file":"/opt/project/vendor/symfony/error-handler/DebugClassLoader.php:337"}},"level":200,"level_name":"INFO","channel":"deprecation","datetime":"2023-06-01T07:47:53.536702+00:00","extra":{"uuid":""}}

{"message":"User Deprecated: Method \"Symfony\\Component\\Console\\Command\\Command::configure()\" might add \"void\" as a native return type declaration in the future. Do the same in child class \"Nelmio\\ApiDocBundle\\Command\\DumpCommand\" now to avoid errors or add an explicit @return annotation to suppress this message.","context":{"exception":{"class":"ErrorException","message":"User Deprecated: Method \"Symfony\\Component\\Console\\Command\\Command::configure()\" might add \"void\" as a native return type declaration in the future. Do the same in child class \"Nelmio\\ApiDocBundle\\Command\\DumpCommand\" now to avoid errors or add an explicit @return annotation to suppress this message.","code":0,"file":"/opt/project/vendor/symfony/error-handler/DebugClassLoader.php:337"}},"level":200,"level_name":"INFO","channel":"deprecation","datetime":"2023-06-01T07:47:54.805944+00:00","extra":{"uuid":""}}