### PR TITLE
Fix failing phpunit

### DIFF
--- a/Tests/ModelDescriber/ApplyOpenApiDiscriminatorTraitTest.php
+++ b/Tests/ModelDescriber/ApplyOpenApiDiscriminatorTraitTest.php
@@ -31,6 +31,11 @@ class ApplyOpenApiDiscriminatorTraitTest extends TestCase
 
     private $model;
 
+    /**
+     * @var ModelRegistry $modelRegistry
+     */
+    private $modelRegistry;
+
     public function testApplyAddsDiscriminatorProperty()
     {
         $this->applyOpenApiDiscriminator($this->model, $this->schema, $this->modelRegistry, 'type', [

--- a/Tests/ModelDescriber/ApplyOpenApiDiscriminatorTraitTest.php
+++ b/Tests/ModelDescriber/ApplyOpenApiDiscriminatorTraitTest.php
@@ -32,7 +32,7 @@ class ApplyOpenApiDiscriminatorTraitTest extends TestCase
     private $model;
 
     /**
-     * @var ModelRegistry $modelRegistry
+     * @var ModelRegistry
      */
     private $modelRegistry;
 

--- a/Tests/Render/RenderOpenApiTest.php
+++ b/Tests/Render/RenderOpenApiTest.php
@@ -35,16 +35,14 @@ class RenderOpenApiTest extends TestCase
     public function testUnknownFormat()
     {
         $availableOpenApiRenderers = [];
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectErrorMessage(sprintf('Format "%s" is not supported.', $this->format));
+        $this->expectExceptionObject(new InvalidArgumentException(sprintf('Format "%s" is not supported.', $this->format)));
         $this->renderOpenApi(...$availableOpenApiRenderers);
     }
 
     public function testUnknownArea()
     {
         $this->hasArea = false;
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectErrorMessage(sprintf('Area "%s" is not supported.', $this->area));
+        $this->expectExceptionObject(new InvalidArgumentException(sprintf('Area "%s" is not supported.', $this->area)));
         $this->renderOpenApi();
     }
 

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "symfony/twig-bundle": "^5.4|^6.0",
         "symfony/validator": "^5.4|^6.0",
 
-        "api-platform/core": "^2.7.0|^3@dev",
+        "api-platform/core": "^2.7.0|^3",
         "symfony/deprecation-contracts": "^2.1|^3",
 
         "friendsofsymfony/rest-bundle": "^2.8|^3.0",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/browser-kit": "^5.4|^6.0",
         "symfony/cache": "^5.4|^6.0",
         "symfony/form": "^5.4|^6.0",
-        "symfony/phpunit-bridge": "^5.4.23",
+        "symfony/phpunit-bridge": "6.3.2",
         "symfony/property-access": "^5.4|^6.0",
         "symfony/serializer": "^5.4|^6.0",
         "symfony/stopwatch": "^5.4|^6.0",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/browser-kit": "^5.4|^6.0",
         "symfony/cache": "^5.4|^6.0",
         "symfony/form": "^5.4|^6.0",
-        "symfony/phpunit-bridge": "6.3.2",
+        "symfony/phpunit-bridge": "^6.3.2",
         "symfony/property-access": "^5.4|^6.0",
         "symfony/serializer": "^5.4|^6.0",
         "symfony/stopwatch": "^5.4|^6.0",

--- a/phpunit-baseline.json
+++ b/phpunit-baseline.json
@@ -1,0 +1,27 @@
+[
+    {
+        "location": "Nelmio\\ApiDocBundle\\Tests\\Functional\\SwaggerUiTest::testSwaggerUi",
+        "message": "Since api-platform/core 2.7: Using \"api_platform.iri_converter.legacy\" is deprecated since API Platform 2.7. Use \"ApiPlatform\\Api\\IriConverterInterface\" instead.",
+        "count": 1
+    },
+    {
+        "location": "Nelmio\\ApiDocBundle\\Tests\\Functional\\SwaggerUiTest::testApiPlatformSwaggerUi",
+        "message": "Since api-platform/core 2.7: Using \"api_platform.iri_converter.legacy\" is deprecated since API Platform 2.7. Use \"ApiPlatform\\Api\\IriConverterInterface\" instead.",
+        "count": 1
+    },
+    {
+        "location": "Nelmio\\ApiDocBundle\\Tests\\Functional\\SwaggerUiTest::testJsonDocs",
+        "message": "Since api-platform/core 2.7: Using \"api_platform.iri_converter.legacy\" is deprecated since API Platform 2.7. Use \"ApiPlatform\\Api\\IriConverterInterface\" instead.",
+        "count": 1
+    },
+    {
+        "location": "Nelmio\\ApiDocBundle\\Tests\\Functional\\SwaggerUiTest::testInvalidJsonArea",
+        "message": "Since api-platform/core 2.7: Using \"api_platform.iri_converter.legacy\" is deprecated since API Platform 2.7. Use \"ApiPlatform\\Api\\IriConverterInterface\" instead.",
+        "count": 1
+    },
+    {
+        "location": "Nelmio\\ApiDocBundle\\Tests\\Functional\\SwaggerUiTest::testYamlDocs",
+        "message": "Since api-platform/core 2.7: Using \"api_platform.iri_converter.legacy\" is deprecated since API Platform 2.7. Use \"ApiPlatform\\Api\\IriConverterInterface\" instead.",
+        "count": 1
+    }
+]

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,7 +14,7 @@
         <env name="SHELL_VERBOSITY" value="-1" />
         <ini name="error_reporting" value="-1" />
         <ini name="memory_limit" value="512M" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="baselineFile=./phpunit-baseline.json&amp;max[self]=0" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
Changes:
- `api-platform/core` dependency now uses `"^2.7.0|^3"` instead of `"^2.7.0|^3@dev"` (Fixes all functional tests failing)
- Update `symfony/phpunit-bridge` dependency from `"^5.4.23"` to `"^6.3.2"` ([Baseline deprecations](https://symfony.com/doc/current/components/phpunit_bridge.html#baseline-deprecations))
- Generate baseline for unfixable `Nelmio\\ApiDocBundle\\Tests\\Functional\\SwaggerUiTest` api-platform self-deprecations