### PR TITLE
Make Doctrine annotations optional

### DIFF
--- a/DependencyInjection/Compiler/ConfigurationPass.php
+++ b/DependencyInjection/Compiler/ConfigurationPass.php
@@ -14,6 +14,7 @@ namespace Nelmio\ApiDocBundle\DependencyInjection\Compiler;
 use Nelmio\ApiDocBundle\ModelDescriber\FormModelDescriber;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -29,7 +30,7 @@ final class ConfigurationPass implements CompilerPassInterface
             $container->register('nelmio_api_doc.model_describers.form', FormModelDescriber::class)
                 ->setPublic(false)
                 ->addArgument(new Reference('form.factory'))
-                ->addArgument(new Reference('annotations.reader'))
+                ->addArgument(new Reference('annotations.reader', ContainerInterface::NULL_ON_INVALID_REFERENCE))
                 ->addArgument($container->getParameter('nelmio_api_doc.media_types'))
                 ->addArgument($container->getParameter('nelmio_api_doc.use_validation_groups'))
                 ->addTag('nelmio_api_doc.model_describer', ['priority' => 100]);

--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -25,6 +25,7 @@ use Nelmio\ApiDocBundle\Routing\FilteredRouteCollectionBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -94,7 +95,7 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
                 ->setArguments([
                     new Reference(sprintf('nelmio_api_doc.routes.%s', $area)),
                     new Reference('nelmio_api_doc.controller_reflector'),
-                    new Reference('annotations.reader'), // We cannot use the cached version of the annotation reader since the construction of the annotations is context dependant...
+                    new Reference('annotations.reader', ContainerInterface::NULL_ON_INVALID_REFERENCE), // We cannot use the cached version of the annotation reader since the construction of the annotations is context dependant...
                     new Reference('logger'),
                 ])
                 ->addTag(sprintf('nelmio_api_doc.describer.%s', $area), ['priority' => -200]);
@@ -123,7 +124,7 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
                         (new Definition(FilteredRouteCollectionBuilder::class))
                             ->setArguments(
                                 [
-                                    new Reference('annotation_reader'), // Here we use the cached version as we don't deal with @OA annotations in this service
+                                    new Reference('annotation_reader', ContainerInterface::NULL_ON_INVALID_REFERENCE), // Here we use the cached version as we don't deal with @OA annotations in this service
                                     new Reference('nelmio_api_doc.controller_reflector'),
                                     $area,
                                     $areaConfig,
@@ -181,7 +182,7 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
                 ->setPublic(false)
                 ->setArguments([
                     new Reference('jms_serializer.metadata_factory'),
-                    new Reference('annotations.reader'),
+                    new Reference('annotations.reader', ContainerInterface::NULL_ON_INVALID_REFERENCE),
                     $config['media_types'],
                     $jmsNamingStrategy,
                     $container->getParameter('nelmio_api_doc.use_validation_groups'),

--- a/Describer/OpenApiPhpDescriber.php
+++ b/Describer/OpenApiPhpDescriber.php
@@ -37,7 +37,7 @@ final class OpenApiPhpDescriber
     private $logger;
     private $overwrite;
 
-    public function __construct(RouteCollection $routeCollection, ControllerReflector $controllerReflector, Reader $annotationReader, LoggerInterface $logger, bool $overwrite = false)
+    public function __construct(RouteCollection $routeCollection, ControllerReflector $controllerReflector, ?Reader $annotationReader, LoggerInterface $logger, bool $overwrite = false)
     {
         $this->routeCollection = $routeCollection;
         $this->controllerReflector = $controllerReflector;
@@ -65,16 +65,20 @@ final class OpenApiPhpDescriber
             $this->setContext($context);
 
             if (!array_key_exists($declaringClass->getName(), $classAnnotations)) {
-                $classAnnotations = array_filter($this->annotationReader->getClassAnnotations($declaringClass), function ($v) {
-                    return $v instanceof OA\AbstractAnnotation;
-                });
+                $classAnnotations = null !== $this->annotationReader ?
+                    array_filter($this->annotationReader->getClassAnnotations($declaringClass), function ($v) {
+                        return $v instanceof OA\AbstractAnnotation;
+                    }) :
+                    [];
                 $classAnnotations = array_merge($classAnnotations, $this->getAttributesAsAnnotation($declaringClass, $context));
                 $classAnnotations[$declaringClass->getName()] = $classAnnotations;
             }
 
-            $annotations = array_filter($this->annotationReader->getMethodAnnotations($method), function ($v) {
-                return $v instanceof OA\AbstractAnnotation;
-            });
+            $annotations = null !== $this->annotationReader ?
+                array_filter($this->annotationReader->getMethodAnnotations($method), function ($v) {
+                    return $v instanceof OA\AbstractAnnotation;
+                }) :
+                [];
             $annotations = array_merge($annotations, $this->getAttributesAsAnnotation($method, $context));
 
             if (0 === count($annotations) && 0 === count($classAnnotations[$declaringClass->getName()])) {

--- a/ModelDescriber/Annotations/AnnotationsReader.php
+++ b/ModelDescriber/Annotations/AnnotationsReader.php
@@ -21,22 +21,16 @@ use OpenApi\Generator;
  */
 class AnnotationsReader
 {
-    private $annotationsReader;
-    private $modelRegistry;
-
     private $phpDocReader;
     private $openApiAnnotationsReader;
     private $symfonyConstraintAnnotationReader;
 
     public function __construct(
-        Reader $annotationsReader,
+        ?Reader $annotationsReader,
         ModelRegistry $modelRegistry,
         array $mediaTypes,
         bool $useValidationGroups = false
     ) {
-        $this->annotationsReader = $annotationsReader;
-        $this->modelRegistry = $modelRegistry;
-
         $this->phpDocReader = new PropertyPhpDocReader();
         $this->openApiAnnotationsReader = new OpenApiAnnotationsReader($annotationsReader, $modelRegistry, $mediaTypes);
         $this->symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader(

--- a/ModelDescriber/Annotations/OpenApiAnnotationsReader.php
+++ b/ModelDescriber/Annotations/OpenApiAnnotationsReader.php
@@ -31,7 +31,7 @@ class OpenApiAnnotationsReader
     private $annotationsReader;
     private $modelRegister;
 
-    public function __construct(Reader $annotationsReader, ModelRegistry $modelRegistry, array $mediaTypes)
+    public function __construct(?Reader $annotationsReader, ModelRegistry $modelRegistry, array $mediaTypes)
     {
         $this->annotationsReader = $annotationsReader;
         $this->modelRegister = new ModelRegister($modelRegistry, $mediaTypes);
@@ -95,6 +95,10 @@ class OpenApiAnnotationsReader
                 if (null !== $attribute = $reflection->getAttributes($className, \ReflectionAttribute::IS_INSTANCEOF)[0] ?? null) {
                     return $attribute->newInstance();
                 }
+            }
+
+            if (null === $this->annotationsReader) {
+                return null;
             }
 
             if ($reflection instanceof \ReflectionClass) {

--- a/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
+++ b/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
@@ -28,7 +28,7 @@ class SymfonyConstraintAnnotationReader
     use SetsContextTrait;
 
     /**
-     * @var Reader
+     * @var Reader|null
      */
     private $annotationsReader;
 
@@ -42,7 +42,7 @@ class SymfonyConstraintAnnotationReader
      */
     private $useValidationGroups;
 
-    public function __construct(Reader $annotationsReader, bool $useValidationGroups=false)
+    public function __construct(?Reader $annotationsReader, bool $useValidationGroups=false)
     {
         $this->annotationsReader = $annotationsReader;
         $this->useValidationGroups = $useValidationGroups;
@@ -215,10 +215,12 @@ class SymfonyConstraintAnnotationReader
             }
         }
 
-        if ($reflection instanceof \ReflectionProperty) {
-            yield from $this->annotationsReader->getPropertyAnnotations($reflection);
-        } elseif ($reflection instanceof \ReflectionMethod) {
-            yield from $this->annotationsReader->getMethodAnnotations($reflection);
+        if (null !== $this->annotationsReader) {
+            if ($reflection instanceof \ReflectionProperty) {
+                yield from $this->annotationsReader->getPropertyAnnotations($reflection);
+            } elseif ($reflection instanceof \ReflectionMethod) {
+                yield from $this->annotationsReader->getMethodAnnotations($reflection);
+            }
         }
     }
 

--- a/ModelDescriber/FormModelDescriber.php
+++ b/ModelDescriber/FormModelDescriber.php
@@ -46,7 +46,7 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
 
     public function __construct(
         FormFactoryInterface $formFactory = null,
-        Reader $reader = null,
+        ?Reader $reader = null,
         array $mediaTypes = null,
         bool $useValidationGroups = false
     ) {

--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -60,7 +60,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
 
     public function __construct(
         MetadataFactoryInterface $factory,
-        Reader $reader,
+        ?Reader $reader,
         array $mediaTypes,
         ?PropertyNamingStrategyInterface $namingStrategy = null,
         bool $useValidationGroups = false,

--- a/ModelDescriber/ObjectModelDescriber.php
+++ b/ModelDescriber/ObjectModelDescriber.php
@@ -48,7 +48,7 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
 
     public function __construct(
         PropertyInfoExtractorInterface $propertyInfo,
-        Reader $reader,
+        ?Reader $reader,
         iterable $propertyDescribers,
         array $mediaTypes,
         NameConverterInterface $nameConverter = null,

--- a/Resources/config/fos_rest.xml
+++ b/Resources/config/fos_rest.xml
@@ -5,7 +5,7 @@
 
     <services>
         <service id="nelmio_api_doc.route_describers.fos_rest" class="Nelmio\ApiDocBundle\RouteDescriber\FosRestDescriber" public="false">
-            <argument type="service" id="annotation_reader" /> <!-- we don't deal with @OA annotations in this describer so we can use the cached reader -->
+            <argument type="service" id="annotation_reader" on-invalid="null" /> <!-- we don't deal with @OA annotations in this describer so we can use the cached reader -->
             <argument />
 
             <tag name="nelmio_api_doc.route_describer" priority="-250" />

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -75,7 +75,7 @@
 
         <service id="nelmio_api_doc.model_describers.object" class="Nelmio\ApiDocBundle\ModelDescriber\ObjectModelDescriber" public="false">
             <argument type="service" id="property_info" />
-            <argument type="service" id="annotations.reader" />
+            <argument type="service" id="annotations.reader" on-invalid="null" />
             <argument type="tagged" tag="nelmio_api_doc.object_model.property_describer" />
             <argument />
             <argument type="service" id="serializer.name_converter.metadata_aware" on-invalid="ignore" />

--- a/RouteDescriber/FosRestDescriber.php
+++ b/RouteDescriber/FosRestDescriber.php
@@ -27,13 +27,13 @@ final class FosRestDescriber implements RouteDescriberInterface
 {
     use RouteDescriberTrait;
 
-    /** @var Reader */
+    /** @var Reader|null */
     private $annotationReader;
 
     /** @var string[] */
     private $mediaTypes;
 
-    public function __construct(Reader $annotationReader, array $mediaTypes)
+    public function __construct(?Reader $annotationReader, array $mediaTypes)
     {
         $this->annotationReader = $annotationReader;
         $this->mediaTypes = $mediaTypes;
@@ -41,7 +41,9 @@ final class FosRestDescriber implements RouteDescriberInterface
 
     public function describe(OA\OpenApi $api, Route $route, \ReflectionMethod $reflectionMethod)
     {
-        $annotations = $this->annotationReader->getMethodAnnotations($reflectionMethod);
+        $annotations = null !== $this->annotationReader ?
+            $this->annotationReader->getMethodAnnotations($reflectionMethod) :
+            [];
         $annotations = array_filter($annotations, static function ($value) {
             return $value instanceof RequestParam || $value instanceof QueryParam;
         });

--- a/Routing/FilteredRouteCollectionBuilder.php
+++ b/Routing/FilteredRouteCollectionBuilder.php
@@ -21,7 +21,7 @@ use Symfony\Component\Routing\RouteCollection;
 
 final class FilteredRouteCollectionBuilder
 {
-    /** @var Reader */
+    /** @var Reader|null */
     private $annotationReader;
 
     /** @var ControllerReflector */
@@ -34,7 +34,7 @@ final class FilteredRouteCollectionBuilder
     private $options;
 
     public function __construct(
-        Reader $annotationReader,
+        ?Reader $annotationReader,
         ControllerReflector $controllerReflector,
         string $area,
         array $options = []
@@ -137,7 +137,7 @@ final class FilteredRouteCollectionBuilder
             /** @var Areas|null $areas */
             $areas = $this->getAttributesAsAnnotation($reflectionMethod->getDeclaringClass(), Areas::class)[0] ?? null;
 
-            if (null === $areas) {
+            if (null === $areas && null !== $this->annotationReader) {
                 /** @var Areas|null $areas */
                 $areas = $this->annotationReader->getMethodAnnotation(
                     $reflectionMethod,
@@ -167,7 +167,7 @@ final class FilteredRouteCollectionBuilder
             return false;
         }
 
-        $annotations = $this->annotationReader->getMethodAnnotations($method);
+        $annotations = null !== $this->annotationReader ? $this->annotationReader->getMethodAnnotations($method) : [];
         if (method_exists(\ReflectionMethod::class, 'getAttributes')) {
             $annotations = array_merge($annotations, array_map(function (\ReflectionAttribute $attribute) {
                 return $attribute->newInstance();

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     "require": {
         "php": ">=7.2",
         "ext-json": "*",
-        "doctrine/annotations": "^2.0",
         "psr/cache": "^1.0|^2.0|^3.0",
         "psr/container": "^1.0|^2.0",
         "psr/log": "^1.0|^2.0|^3.0",
@@ -34,6 +33,7 @@
         "phpdocumentor/reflection-docblock": "^3.1|^4.0|^5.0"
     },
     "require-dev": {
+        "doctrine/annotations": "^2.0",
         "sensio/framework-extra-bundle": "^5.4|^6.0",
         "symfony/asset": "^5.4|^6.0",
         "symfony/dom-crawler": "^5.4|^6.0",
@@ -59,6 +59,7 @@
     },
     "suggest": {
         "api-platform/core": "For using an API oriented framework.",
+        "doctrine/annotations": "For using Doctrine Annotations",
         "friendsofsymfony/rest-bundle": "For using the parameters annotations.",
         "jms/serializer-bundle": "For describing your models.",
         "symfony/asset": "For using the Swagger UI.",


### PR DESCRIPTION
Fixes #2143

This converts all usages of the Doctrine Annotations reader into optional dependencies, which may be `null`, and checks their availability before usage. I also moved the `doctrine/annotations` dependency to `require-dev` and `suggests` so it really is optional and one doesn't require it anymore (sidenote is that `zircote/swagger-php` still requires `doctrine/annotations`)