### PR TITLE
fix: use oneOf instead of allOf

### DIFF
--- a/ModelDescriber/FormModelDescriber.php
+++ b/ModelDescriber/FormModelDescriber.php
@@ -156,7 +156,7 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
             $ref = $this->modelRegistry->register($model);
             // We need to use allOf for description and title to be displayed
             if ($config->hasOption('documentation') && !empty($config->getOption('documentation'))) {
-                $property->allOf = [new OA\Schema(['ref' => $ref])];
+                $property->oneOf = [new OA\Schema(['ref' => $ref])];
             } else {
                 $property->ref = $ref;
             }

--- a/ModelDescriber/JMSModelDescriber.php
+++ b/ModelDescriber/JMSModelDescriber.php
@@ -293,7 +293,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
                 $property->ref = $modelRef;
             } else {
                 $weakContext = Util::createWeakContext($property->_context);
-                $property->allOf = [new OA\Schema(['ref' => $modelRef, '_context' => $weakContext])];
+                $property->oneOf = [new OA\Schema(['ref' => $modelRef, '_context' => $weakContext])];
             }
 
             $this->contexts[$model->getHash()] = $context;

--- a/PropertyDescriber/ObjectPropertyDescriber.php
+++ b/PropertyDescriber/ObjectPropertyDescriber.php
@@ -39,7 +39,7 @@ class ObjectPropertyDescriber implements PropertyDescriberInterface, ModelRegist
         if ($types[0]->isNullable()) {
             $weakContext = Util::createWeakContext($property->_context);
             $property->nullable = true;
-            $property->allOf = [new OA\Schema(['ref' => $this->modelRegistry->register(new Model($type, $groups)), '_context' => $weakContext])];
+            $property->oneOf = [new OA\Schema(['ref' => $this->modelRegistry->register(new Model($type, $groups)), '_context' => $weakContext])];
 
             return;
         }

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -218,7 +218,7 @@ class FunctionalTest extends WebTestCase
                     ],
                     'friend' => [
                         'nullable' => true,
-                        'allOf' => [
+                        'oneOf' => [
                             ['$ref' => '#/components/schemas/User'],
                         ],
                     ],

--- a/Tests/Functional/JMSFunctionalTest.php
+++ b/Tests/Functional/JMSFunctionalTest.php
@@ -148,11 +148,11 @@ class JMSFunctionalTest extends WebTestCase
                 ],
                 'virtual_type1' => [
                     'title' => 'JMS custom types handled via Custom Type Handlers.',
-                    'allOf' => [['$ref' => '#/components/schemas/VirtualTypeClassDoesNotExistsHandlerDefined']],
+                    'oneOf' => [['$ref' => '#/components/schemas/VirtualTypeClassDoesNotExistsHandlerDefined']],
                 ],
                 'virtual_type2' => [
                     'title' => 'JMS custom types handled via Custom Type Handlers.',
-                    'allOf' => [['$ref' => '#/components/schemas/VirtualTypeClassDoesNotExistsHandlerNotDefined']],
+                    'oneOf' => [['$ref' => '#/components/schemas/VirtualTypeClassDoesNotExistsHandlerNotDefined']],
                 ],
                 'last_update' => [
                     'type' => 'date',


### PR DESCRIPTION
Fix when generating a nullable property (an enum for example) in OpenApi 3.1.0.

swagger-php makes sure that the `nullable` property is unset when working with OpenApi 3.1.0 and transform it to the 3.1.0 equivelant (see: https://github.com/zircote/swagger-php/blob/595d8b63a589e6ac0835c83a45304c7397dc37d1/src/Annotations/AbstractAnnotation.php#L390-L402), but this doesn't work when using `allOf`.

This PR aims to fix that by replacing `allOf` with `oneOf`. Additionally `oneOf` is more logical to use in this context than `allOf`  since `allOf` means that every schema could be valid where `oneOf` means that only one schema can be valid https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/.