### PR TITLE
refactor: PropertyDescribers

### DIFF
--- a/DependencyInjection/NelmioApiDocExtension.php
+++ b/DependencyInjection/NelmioApiDocExtension.php
@@ -228,15 +228,6 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
         if (null !== $controllerNameConverter) {
             $container->getDefinition('nelmio_api_doc.controller_reflector')->setArgument(1, $controllerNameConverter);
         }
-
-        // New parameter self-exclude has to be set to false for service nelmio_api_doc.object_model.property_describers.array
-        // BC compatibility with Symfony <6.3
-        $container->getDefinition('nelmio_api_doc.object_model.property_describers.array')
-            ->setArguments([
-                !method_exists(TaggedIteratorArgument::class, 'excludeSelf')
-                ? new TaggedIteratorArgument('nelmio_api_doc.object_model.property_describer')
-                : new TaggedIteratorArgument('nelmio_api_doc.object_model.property_describer', null, null, false, null, [], false),
-            ]);
     }
 
     private function findNameAliases(array $names, string $area): array

--- a/Model/Model.php
+++ b/Model/Model.php
@@ -11,7 +11,6 @@
 
 namespace Nelmio\ApiDocBundle\Model;
 
-use JetBrains\PhpStorm\Deprecated;
 use Symfony\Component\PropertyInfo\Type;
 
 final class Model
@@ -22,12 +21,10 @@ final class Model
     private $serializationContext;
 
     /**
-     * @param string[]|null $groups deprecated since 4.17
+     * @param string[]|null $groups
      */
-    public function __construct(Type $type, #[Deprecated] array $groups = null, array $options = null, array $serializationContext = [])
+    public function __construct(Type $type, array $groups = null, array $options = null, array $serializationContext = [])
     {
-        if ()
-
         $this->type = $type;
         $this->options = $options;
         $this->serializationContext = $serializationContext;
@@ -46,8 +43,6 @@ final class Model
 
     /**
      * @return string[]|null
-     * @deprecated since 4.17 use getSerializationContext()['groups'] instead
-     * @see getSerializationContext()
      */
     public function getGroups()
     {

--- a/Model/Model.php
+++ b/Model/Model.php
@@ -11,6 +11,7 @@
 
 namespace Nelmio\ApiDocBundle\Model;
 
+use JetBrains\PhpStorm\Deprecated;
 use Symfony\Component\PropertyInfo\Type;
 
 final class Model
@@ -21,10 +22,12 @@ final class Model
     private $serializationContext;
 
     /**
-     * @param string[]|null $groups
+     * @param string[]|null $groups deprecated since 4.17
      */
-    public function __construct(Type $type, array $groups = null, array $options = null, array $serializationContext = [])
+    public function __construct(Type $type, #[Deprecated] array $groups = null, array $options = null, array $serializationContext = [])
     {
+        if ()
+
         $this->type = $type;
         $this->options = $options;
         $this->serializationContext = $serializationContext;
@@ -43,6 +46,8 @@ final class Model
 
     /**
      * @return string[]|null
+     * @deprecated since 4.17 use getSerializationContext()['groups'] instead
+     * @see getSerializationContext()
      */
     public function getGroups()
     {

--- a/ModelDescriber/ObjectModelDescriber.php
+++ b/ModelDescriber/ObjectModelDescriber.php
@@ -190,7 +190,7 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
             }
             if ($propertyDescriber->supports($types)) {
                 try {
-                    $propertyDescriber->describe($types, $property, $model->getGroups(), $schema);
+                    $propertyDescriber->describe($types, $property, $model->getGroups(), $schema, $model->getSerializationContext());
                 } catch (UndocumentedArrayItemsException $e) {
                     if (null !== $e->getClass()) {
                         throw $e; // This exception is already complete

--- a/Processor/NullablePropertyProcessor.php
+++ b/Processor/NullablePropertyProcessor.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nelmio\ApiDocBundle\Processor;
+
+use OpenApi\Analysis;
+use OpenApi\Annotations as OA;
+use OpenApi\Generator;
+use OpenApi\Processors\ProcessorInterface;
+
+/**
+ * Processor to clean up the generated OpenAPI documentation for nullable properties.
+ */
+final class NullablePropertyProcessor implements ProcessorInterface
+{
+    public function __invoke(Analysis $analysis): void
+    {
+        /** @var OA\Schema[] $schemas */
+        $schemas = $analysis->openapi->components->schemas;
+
+        foreach ($schemas as $schema) {
+            if (Generator::UNDEFINED === $schema->properties) {
+                continue;
+            }
+
+            foreach ($schema->properties as $property) {
+                if (Generator::UNDEFINED !== $property->nullable) {
+                    if (!$property->nullable) {
+                        // if already false mark it as undefined (so it does not show up as `nullable: false`)
+                        $property->nullable = Generator::UNDEFINED;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PropertyDescriber/ArrayPropertyDescriber.php
+++ b/PropertyDescriber/ArrayPropertyDescriber.php
@@ -20,7 +20,6 @@ use OpenApi\Annotations as OA;
 class ArrayPropertyDescriber implements PropertyDescriberInterface, ModelRegistryAwareInterface
 {
     use ModelRegistryAwareTrait;
-    use NullablePropertyTrait;
 
     /** @var PropertyDescriberInterface */
     private $propertyDescriber;
@@ -41,7 +40,6 @@ class ArrayPropertyDescriber implements PropertyDescriberInterface, ModelRegistr
         }
 
         $property->type = 'array';
-        $this->setNullableProperty($types[0], $property, $schema);
         $property = Util::getChild($property, OA\Items::class);
 
         try {
@@ -55,7 +53,7 @@ class ArrayPropertyDescriber implements PropertyDescriberInterface, ModelRegistr
         }
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
         return 1 === count($types) && $types[0]->isCollection();
     }

--- a/PropertyDescriber/ArrayPropertyDescriber.php
+++ b/PropertyDescriber/ArrayPropertyDescriber.php
@@ -30,7 +30,7 @@ class ArrayPropertyDescriber implements PropertyDescriberInterface, ModelRegistr
         $this->propertyDescribers = $propertyDescribers;
     }
 
-    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null)
+    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         // BC layer for symfony < 5.3
         $type = method_exists($types[0], 'getCollectionValueTypes') ?
@@ -50,7 +50,7 @@ class ArrayPropertyDescriber implements PropertyDescriberInterface, ModelRegistr
             }
             if ($propertyDescriber->supports([$type])) {
                 try {
-                    $propertyDescriber->describe([$type], $property, $groups, $schema);
+                    $propertyDescriber->describe([$type], $property, $groups, $schema, $context);
                 } catch (UndocumentedArrayItemsException $e) {
                     if (null !== $e->getClass()) {
                         throw $e; // This exception is already complete

--- a/PropertyDescriber/BooleanPropertyDescriber.php
+++ b/PropertyDescriber/BooleanPropertyDescriber.php
@@ -18,7 +18,7 @@ class BooleanPropertyDescriber implements PropertyDescriberInterface
 {
     use NullablePropertyTrait;
 
-    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null)
+    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $property->type = 'boolean';
         $this->setNullableProperty($types[0], $property, $schema);

--- a/PropertyDescriber/BooleanPropertyDescriber.php
+++ b/PropertyDescriber/BooleanPropertyDescriber.php
@@ -16,15 +16,12 @@ use Symfony\Component\PropertyInfo\Type;
 
 class BooleanPropertyDescriber implements PropertyDescriberInterface
 {
-    use NullablePropertyTrait;
-
     public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $property->type = 'boolean';
-        $this->setNullableProperty($types[0], $property, $schema);
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
         return 1 === count($types) && Type::BUILTIN_TYPE_BOOL === $types[0]->getBuiltinType();
     }

--- a/PropertyDescriber/CompoundPropertyDescriber.php
+++ b/PropertyDescriber/CompoundPropertyDescriber.php
@@ -29,7 +29,7 @@ class CompoundPropertyDescriber implements PropertyDescriberInterface, ModelRegi
         $this->propertyDescribers = $propertyDescribers;
     }
 
-    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null)
+    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $property->oneOf = Generator::UNDEFINED !== $property->oneOf ? $property->oneOf : [];
 
@@ -40,7 +40,7 @@ class CompoundPropertyDescriber implements PropertyDescriberInterface, ModelRegi
                     $propertyDescriber->setModelRegistry($this->modelRegistry);
                 }
                 if ($propertyDescriber->supports([$type])) {
-                    $propertyDescriber->describe([$type], $schema, $groups, $schema);
+                    $propertyDescriber->describe([$type], $schema, $groups, $schema, $context);
 
                     break;
                 }

--- a/PropertyDescriber/CompoundPropertyDescriber.php
+++ b/PropertyDescriber/CompoundPropertyDescriber.php
@@ -21,12 +21,12 @@ class CompoundPropertyDescriber implements PropertyDescriberInterface, ModelRegi
 {
     use ModelRegistryAwareTrait;
 
-    /** @var PropertyDescriberInterface[] */
-    private $propertyDescribers;
+    /** @var PropertyDescriberInterface */
+    private $propertyDescriber;
 
-    public function __construct(iterable $propertyDescribers)
+    public function __construct(PropertyDescriberInterface $propertyDescriber)
     {
-        $this->propertyDescribers = $propertyDescribers;
+        $this->propertyDescriber = $propertyDescriber;
     }
 
     public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
@@ -35,20 +35,12 @@ class CompoundPropertyDescriber implements PropertyDescriberInterface, ModelRegi
 
         foreach ($types as $type) {
             $property->oneOf[] = $schema = Util::createChild($property, OA\Schema::class, []);
-            foreach ($this->propertyDescribers as $propertyDescriber) {
-                if ($propertyDescriber instanceof ModelRegistryAwareInterface) {
-                    $propertyDescriber->setModelRegistry($this->modelRegistry);
-                }
-                if ($propertyDescriber->supports([$type])) {
-                    $propertyDescriber->describe([$type], $schema, $groups, $schema, $context);
 
-                    break;
-                }
-            }
+            $this->propertyDescriber->describe([$type], $schema, $groups, $schema, $context);
         }
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
         return count($types) >= 2;
     }

--- a/PropertyDescriber/DateTimePropertyDescriber.php
+++ b/PropertyDescriber/DateTimePropertyDescriber.php
@@ -18,7 +18,7 @@ class DateTimePropertyDescriber implements PropertyDescriberInterface
 {
     use NullablePropertyTrait;
 
-    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null)
+    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $property->type = 'string';
         $property->format = 'date-time';

--- a/PropertyDescriber/DateTimePropertyDescriber.php
+++ b/PropertyDescriber/DateTimePropertyDescriber.php
@@ -16,16 +16,13 @@ use Symfony\Component\PropertyInfo\Type;
 
 class DateTimePropertyDescriber implements PropertyDescriberInterface
 {
-    use NullablePropertyTrait;
-
     public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $property->type = 'string';
         $property->format = 'date-time';
-        $this->setNullableProperty($types[0], $property, $schema);
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
         return 1 === count($types)
             && Type::BUILTIN_TYPE_OBJECT === $types[0]->getBuiltinType()

--- a/PropertyDescriber/FloatPropertyDescriber.php
+++ b/PropertyDescriber/FloatPropertyDescriber.php
@@ -18,7 +18,7 @@ class FloatPropertyDescriber implements PropertyDescriberInterface
 {
     use NullablePropertyTrait;
 
-    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null)
+    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $property->type = 'number';
         $property->format = 'float';

--- a/PropertyDescriber/FloatPropertyDescriber.php
+++ b/PropertyDescriber/FloatPropertyDescriber.php
@@ -16,16 +16,13 @@ use Symfony\Component\PropertyInfo\Type;
 
 class FloatPropertyDescriber implements PropertyDescriberInterface
 {
-    use NullablePropertyTrait;
-
     public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $property->type = 'number';
         $property->format = 'float';
-        $this->setNullableProperty($types[0], $property, $schema);
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
         return 1 === count($types) && Type::BUILTIN_TYPE_FLOAT === $types[0]->getBuiltinType();
     }

--- a/PropertyDescriber/IntegerPropertyDescriber.php
+++ b/PropertyDescriber/IntegerPropertyDescriber.php
@@ -18,7 +18,7 @@ class IntegerPropertyDescriber implements PropertyDescriberInterface
 {
     use NullablePropertyTrait;
 
-    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null)
+    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $property->type = 'integer';
         $this->setNullableProperty($types[0], $property, $schema);

--- a/PropertyDescriber/IntegerPropertyDescriber.php
+++ b/PropertyDescriber/IntegerPropertyDescriber.php
@@ -16,15 +16,12 @@ use Symfony\Component\PropertyInfo\Type;
 
 class IntegerPropertyDescriber implements PropertyDescriberInterface
 {
-    use NullablePropertyTrait;
-
     public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $property->type = 'integer';
-        $this->setNullableProperty($types[0], $property, $schema);
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
         return 1 === count($types) && Type::BUILTIN_TYPE_INT === $types[0]->getBuiltinType();
     }

--- a/PropertyDescriber/NullablePropertyDescriber.php
+++ b/PropertyDescriber/NullablePropertyDescriber.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\PropertyDescriber;
+
+use OpenApi\Annotations as OA;
+use OpenApi\Generator;
+
+final class NullablePropertyDescriber implements PropertyDescriberInterface, PropertyDescriberAwareInterface
+{
+    use PropertyDescriberAwareTrait;
+
+    private const RECURSIVE = self::class.'::RECURSIVE';
+
+    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
+    {
+        if (Generator::UNDEFINED !== $property->nullable) {
+            return;
+        }
+
+        $property->nullable = true;
+
+        $context[self::RECURSIVE] = true;
+        $this->propertyDescriber->describe($types, $property, $groups, $schema, $context);
+    }
+
+    public function supports(array $types, array $context = []): bool
+    {
+        return 1 === count($types)
+            && $types[0]->isNullable()
+            && !array_key_exists(self::RECURSIVE, $context);
+    }
+}

--- a/PropertyDescriber/NullablePropertyTrait.php
+++ b/PropertyDescriber/NullablePropertyTrait.php
@@ -16,6 +16,9 @@ use OpenApi\Annotations as OA;
 use OpenApi\Generator;
 use Symfony\Component\PropertyInfo\Type;
 
+/**
+ * @deprecated Since 4.17, {@see NullablePropertyDescriber} instead.
+ */
 trait NullablePropertyTrait
 {
     protected function setNullableProperty(Type $type, OA\Schema $property, ?OA\Schema $schema, array $context = []): void

--- a/PropertyDescriber/NullablePropertyTrait.php
+++ b/PropertyDescriber/NullablePropertyTrait.php
@@ -18,7 +18,7 @@ use Symfony\Component\PropertyInfo\Type;
 
 trait NullablePropertyTrait
 {
-    protected function setNullableProperty(Type $type, OA\Schema $property, ?OA\Schema $schema): void
+    protected function setNullableProperty(Type $type, OA\Schema $property, ?OA\Schema $schema, array $context = []): void
     {
         if (Generator::UNDEFINED !== $property->nullable) {
             if (!$property->nullable) {

--- a/PropertyDescriber/ObjectPropertyDescriber.php
+++ b/PropertyDescriber/ObjectPropertyDescriber.php
@@ -23,7 +23,7 @@ class ObjectPropertyDescriber implements PropertyDescriberInterface, ModelRegist
 {
     use ModelRegistryAwareTrait;
 
-    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null)
+    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $type = new Type(
             $types[0]->getBuiltinType(),

--- a/PropertyDescriber/ObjectPropertyDescriber.php
+++ b/PropertyDescriber/ObjectPropertyDescriber.php
@@ -37,9 +37,7 @@ class ObjectPropertyDescriber implements PropertyDescriberInterface, ModelRegist
                 $types[0]->getCollectionValueType()
         ); // ignore nullable field
 
-        if ($types[0]->isNullable()) {
-            $property->nullable = true;
-
+        if ($types[0]->isNullable() === true) {
             $weakContext = Util::createWeakContext($property->_context);
             $schemas = [new OA\Schema(['ref' => $this->modelRegistry->register(new Model($type, $groups)), '_context' => $weakContext])];
 
@@ -53,22 +51,11 @@ class ObjectPropertyDescriber implements PropertyDescriberInterface, ModelRegist
         }
 
         $property->ref = $this->modelRegistry->register(new Model($type, $groups));
-
-        if (!$type->isNullable() && null !== $schema) {
-            $propertyName = Util::getSchemaPropertyName($schema, $property);
-            if (null === $propertyName) {
-                return;
-            }
-
-            $existingRequiredFields = Generator::UNDEFINED !== $schema->required ? $schema->required : [];
-            $existingRequiredFields[] = $propertyName;
-
-            $schema->required = array_values(array_unique($existingRequiredFields));
-        }
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
-        return 1 === count($types) && Type::BUILTIN_TYPE_OBJECT === $types[0]->getBuiltinType();
+        return 1 === count($types)
+            && Type::BUILTIN_TYPE_OBJECT === $types[0]->getBuiltinType();
     }
 }

--- a/PropertyDescriber/PropertyDescriber.php
+++ b/PropertyDescriber/PropertyDescriber.php
@@ -24,25 +24,29 @@ final class PropertyDescriber implements PropertyDescriberInterface, ModelRegist
     public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = []): void
     {
         if (!$normalizer = $this->getPropertyDescriber($types, $context)) {
-            throw new \LogicException(sprintf('No property describer supports the given type "%s".', implode(', ', $types)));
+            return;
         }
 
         $normalizer->describe($types, $property, $groups, $schema, $context);
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
-        return null !== $this->getPropertyDescriber($types);
+        return null !== $this->getPropertyDescriber($types, $context);
     }
 
-    private function getPropertyDescriber(array $types): ?PropertyDescriberInterface
+    private function getPropertyDescriber(array $types, array $context): ?PropertyDescriberInterface
     {
         foreach ($this->propertyDescribers as $propertyDescriber) {
             if ($propertyDescriber instanceof ModelRegistryAwareInterface) {
                 $propertyDescriber->setModelRegistry($this->modelRegistry);
             }
 
-            if ($propertyDescriber->supports($types)) {
+            if ($propertyDescriber instanceof PropertyDescriberAwareInterface) {
+                $propertyDescriber->setPropertyDescriber($this);
+            }
+
+            if ($propertyDescriber->supports($types, $context)) {
                 return $propertyDescriber;
             }
         }

--- a/PropertyDescriber/PropertyDescriber.php
+++ b/PropertyDescriber/PropertyDescriber.php
@@ -38,6 +38,11 @@ final class PropertyDescriber implements PropertyDescriberInterface, ModelRegist
     private function getPropertyDescriber(array $types, array $context): ?PropertyDescriberInterface
     {
         foreach ($this->propertyDescribers as $propertyDescriber) {
+            /** BC layer for Symfony < 6.3 @see https://symfony.com/doc/6.3/service_container/tags.html#reference-tagged-services */
+            if ($propertyDescriber instanceof self) {
+                continue;
+            }
+
             if ($propertyDescriber instanceof ModelRegistryAwareInterface) {
                 $propertyDescriber->setModelRegistry($this->modelRegistry);
             }

--- a/PropertyDescriber/PropertyDescriber.php
+++ b/PropertyDescriber/PropertyDescriber.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nelmio\ApiDocBundle\PropertyDescriber;
+
+use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
+use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareTrait;
+use OpenApi\Annotations as OA;
+
+final class PropertyDescriber implements PropertyDescriberInterface, ModelRegistryAwareInterface
+{
+    use ModelRegistryAwareTrait;
+
+    /** @var PropertyDescriberInterface[] */
+    private $propertyDescribers;
+
+    public function __construct(
+        iterable $propertyDescribers
+    ) {
+        $this->propertyDescribers = $propertyDescribers;
+    }
+
+    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = []): void
+    {
+        if (!$normalizer = $this->getPropertyDescriber($types, $context)) {
+            throw new \LogicException(sprintf('No property describer supports the given type "%s".', implode(', ', $types)));
+        }
+
+        $normalizer->describe($types, $property, $groups, $schema, $context);
+    }
+
+    public function supports(array $types): bool
+    {
+        return null !== $this->getPropertyDescriber($types);
+    }
+
+    private function getPropertyDescriber(array $types): ?PropertyDescriberInterface
+    {
+        foreach ($this->propertyDescribers as $propertyDescriber) {
+            if ($propertyDescriber instanceof ModelRegistryAwareInterface) {
+                $propertyDescriber->setModelRegistry($this->modelRegistry);
+            }
+
+            if ($propertyDescriber->supports($types)) {
+                return $propertyDescriber;
+            }
+        }
+
+        return null;
+    }
+}

--- a/PropertyDescriber/PropertyDescriberAwareInterface.php
+++ b/PropertyDescriber/PropertyDescriberAwareInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\PropertyDescriber;
+
+interface PropertyDescriberAwareInterface
+{
+    public function setPropertyDescriber(PropertyDescriberInterface $propertyDescriber);
+}

--- a/PropertyDescriber/PropertyDescriberAwareTrait.php
+++ b/PropertyDescriber/PropertyDescriberAwareTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\PropertyDescriber;
+
+use Nelmio\ApiDocBundle\OpenApiPhp\Util;
+use OpenApi\Annotations as OA;
+use OpenApi\Generator;
+use Symfony\Component\PropertyInfo\Type;
+
+trait PropertyDescriberAwareTrait
+{
+    /**
+     * @var PropertyDescriberInterface
+     */
+    protected $propertyDescriber;
+
+    public function setPropertyDescriber(PropertyDescriberInterface $propertyDescriber)
+    {
+        $this->propertyDescriber = $propertyDescriber;
+    }
+}

--- a/PropertyDescriber/PropertyDescriberInterface.php
+++ b/PropertyDescriber/PropertyDescriberInterface.php
@@ -18,9 +18,11 @@ interface PropertyDescriberInterface
 {
     /**
      * @param Type[] $types
+     * @param string[]|null $groups Deprecated use $context['groups'] instead
      * @param Schema $schema Allows to make changes inside of the schema (e.g. adding required fields)
+     * @param array<string, mixed> $context Context options for describing the property
      */
-    public function describe(array $types, Schema $property, array $groups = null /* , ?Schema $schema = null */);
+    public function describe(array $types, Schema $property, array $groups = null /* , ?Schema $schema = null */ /* , array $context = [] */);
 
     /**
      * @param Type[] $types

--- a/PropertyDescriber/PropertyDescriberInterface.php
+++ b/PropertyDescriber/PropertyDescriberInterface.php
@@ -26,6 +26,7 @@ interface PropertyDescriberInterface
 
     /**
      * @param Type[] $types
+     * @param array<string, mixed> $context Context options for describing the property
      */
-    public function supports(array $types): bool;
+    public function supports(array $types /* , array $context = [] */): bool;
 }

--- a/PropertyDescriber/RequiredPropertyDescriber.php
+++ b/PropertyDescriber/RequiredPropertyDescriber.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\PropertyDescriber;
+
+use OpenApi\Annotations as OA;
+use OpenApi\Generator;
+
+/**
+ * Mark a property as required if it is not nullable.
+ */
+final class RequiredPropertyDescriber implements PropertyDescriberInterface, PropertyDescriberAwareInterface
+{
+    use PropertyDescriberAwareTrait;
+
+    private const RECURSIVE = self::class.'::RECURSIVE';
+
+    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
+    {
+        $context[self::RECURSIVE] = true;
+        $this->propertyDescriber->describe($types, $property, $groups, $schema, $context);
+
+        if (!$property instanceof OA\Property) {
+            return;
+        }
+
+        if ($property->nullable !== true) {
+            $existingRequiredFields = Generator::UNDEFINED !== $schema->required ? $schema->required : [];
+            $existingRequiredFields[] = $property->property;
+
+            $schema->required = array_values(array_unique($existingRequiredFields));
+        }
+    }
+
+    public function supports(array $types, array $context = []): bool
+    {
+        return !array_key_exists(self::RECURSIVE, $context);
+    }
+}

--- a/PropertyDescriber/StringPropertyDescriber.php
+++ b/PropertyDescriber/StringPropertyDescriber.php
@@ -16,15 +16,12 @@ use Symfony\Component\PropertyInfo\Type;
 
 class StringPropertyDescriber implements PropertyDescriberInterface
 {
-    use NullablePropertyTrait;
-
     public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $property->type = 'string';
-        $this->setNullableProperty($types[0], $property, $schema);
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
         return 1 === count($types) && Type::BUILTIN_TYPE_STRING === $types[0]->getBuiltinType();
     }

--- a/PropertyDescriber/StringPropertyDescriber.php
+++ b/PropertyDescriber/StringPropertyDescriber.php
@@ -18,7 +18,7 @@ class StringPropertyDescriber implements PropertyDescriberInterface
 {
     use NullablePropertyTrait;
 
-    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null)
+    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $property->type = 'string';
         $this->setNullableProperty($types[0], $property, $schema);

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -76,7 +76,7 @@
         <service id="nelmio_api_doc.model_describers.object" class="Nelmio\ApiDocBundle\ModelDescriber\ObjectModelDescriber" public="false">
             <argument type="service" id="property_info" />
             <argument type="service" id="annotations.reader" on-invalid="null"/>
-            <argument type="tagged" tag="nelmio_api_doc.object_model.property_describer" />
+            <argument type="service" id="nelmio_api_doc.object_model.property_describer" />
             <argument />
             <argument type="service" id="serializer.name_converter.metadata_aware" on-invalid="ignore" />
             <argument>%nelmio_api_doc.use_validation_groups%</argument>
@@ -103,32 +103,40 @@
         <service id="nelmio_api_doc.object_model.property_describer" class="Nelmio\ApiDocBundle\PropertyDescriber\PropertyDescriber" public="false">
             <argument type="tagged" tag="nelmio_api_doc.object_model.property_describer" />
 
-            <tag name="nelmio_api_doc.object_model.property_describer" />
+            <tag name="nelmio_api_doc.object_model.property_describer" priority="100" />
         </service>
 
         <service id="nelmio_api_doc.object_model.property_describers.array" class="Nelmio\ApiDocBundle\PropertyDescriber\ArrayPropertyDescriber" public="false">
             <argument type="service" id="nelmio_api_doc.object_model.property_describer" />
 
-            <tag name="nelmio_api_doc.object_model.property_describer" />
+            <tag name="nelmio_api_doc.object_model.property_describer" priority="-1000" />
         </service>
 
         <service id="nelmio_api_doc.object_model.property_describers.boolean" class="Nelmio\ApiDocBundle\PropertyDescriber\BooleanPropertyDescriber" public="false">
-            <tag name="nelmio_api_doc.object_model.property_describer" />
+            <tag name="nelmio_api_doc.object_model.property_describer" priority="-1000" />
         </service>
 
         <service id="nelmio_api_doc.object_model.property_describers.float" class="Nelmio\ApiDocBundle\PropertyDescriber\FloatPropertyDescriber" public="false">
-            <tag name="nelmio_api_doc.object_model.property_describer" />
+            <tag name="nelmio_api_doc.object_model.property_describer" priority="-1000" />
         </service>
 
         <service id="nelmio_api_doc.object_model.property_describers.integer" class="Nelmio\ApiDocBundle\PropertyDescriber\IntegerPropertyDescriber" public="false">
-            <tag name="nelmio_api_doc.object_model.property_describer" />
+            <tag name="nelmio_api_doc.object_model.property_describer" priority="-1000" />
         </service>
 
         <service id="nelmio_api_doc.object_model.property_describers.string" class="Nelmio\ApiDocBundle\PropertyDescriber\StringPropertyDescriber" public="false">
-            <tag name="nelmio_api_doc.object_model.property_describer" />
+            <tag name="nelmio_api_doc.object_model.property_describer" priority="-1000" />
         </service>
 
         <service id="nelmio_api_doc.object_model.property_describers.date_time" class="Nelmio\ApiDocBundle\PropertyDescriber\DateTimePropertyDescriber" public="false">
+            <tag name="nelmio_api_doc.object_model.property_describer" priority="-1000" />
+        </service>
+
+        <service id="nelmio_api_doc.object_model.property_describers.nullable" class="Nelmio\ApiDocBundle\PropertyDescriber\NullablePropertyDescriber" public="false">
+            <tag name="nelmio_api_doc.object_model.property_describer" />
+        </service>
+
+        <service id="nelmio_api_doc.object_model.property_describers.required" class="Nelmio\ApiDocBundle\PropertyDescriber\RequiredPropertyDescriber" public="false">
             <tag name="nelmio_api_doc.object_model.property_describer" />
         </service>
 
@@ -137,15 +145,20 @@
         </service>
 
         <service id="nelmio_api_doc.object_model.property_describers.compound" class="Nelmio\ApiDocBundle\PropertyDescriber\CompoundPropertyDescriber" public="false">
-            <argument type="service" id="nelmio_api_doc.object_model.property_describer" />
+            <argument type="service" id="nelmio_api_doc.object_model.property_describer"  />
 
-            <tag name="nelmio_api_doc.object_model.property_describer" priority="-1001" />
+            <tag name="nelmio_api_doc.object_model.property_describer" priority="-1000" />
         </service>
 
         <!-- Form Type Extensions -->
 
         <service id="nelmio_api_doc.form.documentation_extension" class="Nelmio\ApiDocBundle\Form\Extension\DocumentationExtension">
             <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\FormType"/>
+        </service>
+
+        <!-- Swagger processors -->
+        <service id="nelmio_api_doc.swagger.processor.nullable_property" class="Nelmio\ApiDocBundle\Processor\NullablePropertyProcessor">
+            <tag name="nelmio_api_doc.swagger.processor" />
         </service>
     </services>
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -94,8 +94,20 @@
         </service>
 
         <!-- Property Describers -->
+        <instanceof id="Nelmio\ApiDocBundle\PropertyDescriber\PropertyDescriberInterface">
+            <tag name="nelmio_api_doc.object_model.property_describer"/>
+        </instanceof>
+
+        <service id="Nelmio\ApiDocBundle\PropertyDescriber\PropertyDescriberInterface" alias="nelmio_api_doc.object_model.property_describer"/>
+
+        <service id="nelmio_api_doc.object_model.property_describer" class="Nelmio\ApiDocBundle\PropertyDescriber\PropertyDescriber" public="false">
+            <argument type="tagged" tag="nelmio_api_doc.object_model.property_describer" />
+
+            <tag name="nelmio_api_doc.object_model.property_describer" />
+        </service>
+
         <service id="nelmio_api_doc.object_model.property_describers.array" class="Nelmio\ApiDocBundle\PropertyDescriber\ArrayPropertyDescriber" public="false">
-            <!-- <argument type="tagged" tag="nelmio_api_doc.object_model.property_describer" exclude-self="false" /> -->
+            <argument type="service" id="nelmio_api_doc.object_model.property_describer" />
 
             <tag name="nelmio_api_doc.object_model.property_describer" />
         </service>
@@ -125,7 +137,7 @@
         </service>
 
         <service id="nelmio_api_doc.object_model.property_describers.compound" class="Nelmio\ApiDocBundle\PropertyDescriber\CompoundPropertyDescriber" public="false">
-            <argument type="tagged" tag="nelmio_api_doc.object_model.property_describer" />
+            <argument type="service" id="nelmio_api_doc.object_model.property_describer" />
 
             <tag name="nelmio_api_doc.object_model.property_describer" priority="-1001" />
         </service>

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "symfony/property-info": "^5.4|^6.0|^7.0",
         "symfony/routing": "^5.4|^6.0|^7.0",
         "zircote/swagger-php": "^4.2.15",
-        "phpdocumentor/reflection-docblock": "^3.1|^4.0|^5.0"
+        "phpdocumentor/reflection-docblock": "^3.1|^4.0|^5.0",
+        "symfony/deprecation-contracts": "^2.1|^3"
     },
     "require-dev": {
         "sensio/framework-extra-bundle": "^5.4|^6.0",
@@ -49,7 +50,6 @@
         "symfony/expression-language": "^5.4|^6.0|^7.0",
 
         "api-platform/core": "^2.7.0|^3",
-        "symfony/deprecation-contracts": "^2.1|^3",
         "friendsofsymfony/rest-bundle": "^2.8|^3.0",
         "willdurand/hateoas-bundle": "^1.0|^2.0",
         "jms/serializer-bundle": "^2.3|^3.0|^4.0|^5.0",


### PR DESCRIPTION
Refactor to the behaviour of the property describers:
- [x] Automatic tagging for `PropertyDescriberInterface` with `nelmio_api_doc.swagger.processor`. This makes it easier for users of the bundle the create their own property describers.
- [x] Deprecate `NullablePropertyTrait` in favor of using a property describer service.
	- [x] Implement a nullable property describer as replacement
	- [x] Implement `PropertyDescriberAwareTrait` & `PropertyDescriberAwareInterface` to allow 'chaining' of describers
- [x] Refactor `PropertyDescriberInterface` dependency injection by no longer requiring to pass an array of describers
	- [x] Potential BC: `ArrayPropertyDesciber` & `CompoundPropertyDesciber` constructor type changed from `PropertyDescriberInterface[]`to `PropertyDescriberInterface`


`ObjectModelDescriber` changes:
- [x] Deprecate injection of `PropertyDescriberInterface[]` in favor of a single `PropertyDescriberInterface`
- [x] Require `symfony/deprecation-contracts` to ease deprecations

Additional change:
- [x] add `$context` (context from Model) parameter to methods of `PropertyDescriberInterface` 
	- Prevents potential recursion when chaining property describers
	- Allows better property generation using model context. Potential use cases:
		- https://github.com/nelmio/NelmioApiDocBundle/pull/2098 Better doc generation for uuid https://github.com/symfony/symfony/blob/7bbc9be7ea7d607fa901edb2068c2cea13d24978/src/Symfony/Component/Serializer/Normalizer/UidNormalizer.php#L53-L62