### PR TITLE
Remove model name sub-collision logging

### DIFF
--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -152,7 +152,7 @@ final class ModelRegistry
 
         if ($i > 1) {
             if (isset($this->registeredModelNames[$base])) {
-                $this->logger->info(sprintf('Can not assign a name for the model, the name "%s" is now being used %s times', $base, $i), [
+                $this->logger->info(sprintf('Can not assign a name for the model, the name "%s" has already been taken.', $base), [
                     'model' => $this->modelToArray($model),
                     'taken_by' => $this->modelToArray($this->registeredModelNames[$base]),
                 ]);

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -146,16 +146,16 @@ final class ModelRegistry
         );
         $i = 1;
         while (\in_array($name, $names, true)) {
-            if (isset($this->registeredModelNames[$name])) {
-                $this->logger->info(sprintf('Can not assign a name for the model, the name "%s" has already been taken.', $name), [
-                    'model' => $this->modelToArray($model),
-                    'taken_by' => $this->modelToArray($this->registeredModelNames[$name]),
-                ]);
-            }
-            ++$i;
+            $i++;
             $name = $base.$i;
         }
 
+        if($i > 1) {
+            $this->logger->info(sprintf('Can not assign a name for the model, the name "%s" is now being used %s times', $base, $i), [
+                'model' => $this->modelToArray($model),
+                'taken_by' => $this->modelToArray($this->registeredModelNames[$base]),
+            ]);
+        }
         return $name;
     }
 

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -158,6 +158,7 @@ final class ModelRegistry
                 ]);
             }
         }
+
         return $name;
     }
 

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -151,10 +151,12 @@ final class ModelRegistry
         }
 
         if ($i > 1) {
-            $this->logger->info(sprintf('Can not assign a name for the model, the name "%s" is now being used %s times', $base, $i), [
-                'model' => $this->modelToArray($model),
-                'taken_by' => $this->modelToArray($this->registeredModelNames[$base]),
-            ]);
+            if (isset($this->registeredModelNames[$base])) {
+                $this->logger->info(sprintf('Can not assign a name for the model, the name "%s" is now being used %s times', $base, $i), [
+                    'model' => $this->modelToArray($model),
+                    'taken_by' => $this->modelToArray($this->registeredModelNames[$base]),
+                ]);
+            }
         }
         return $name;
     }

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -146,11 +146,11 @@ final class ModelRegistry
         );
         $i = 1;
         while (\in_array($name, $names, true)) {
-            $i++;
+            ++$i;
             $name = $base.$i;
         }
 
-        if($i > 1) {
+        if ($i > 1) {
             $this->logger->info(sprintf('Can not assign a name for the model, the name "%s" is now being used %s times', $base, $i), [
                 'model' => $this->modelToArray($model),
                 'taken_by' => $this->modelToArray($this->registeredModelNames[$base]),


### PR DESCRIPTION
With all of the love this bundle has recently been getting, I got tired of manually removing the logging functionality every update to be able to actually use my local environment's OA docs.

This should alleviate a good chunk of the problems referenced in #2099
Rather than logging ~n^2/2 average times per shared name, this change cuts it down to at most once per shared name. There's still quite a bit of logging, but this cuts down the number of logs by an order of magnitude... so I'd say its a good start. If you have 1000 models named "image", and load the entire doc reference, the current package would generate ~500k logs but with the changes in this PR would only generate 999.

I'd prefer if it were an option we could opt out of logging it in its entirety via a config var but I've spent far too long trying to makeshift that to work. 