### PR TITLE
fix: invalid nullable enums with OAS 3.1 version

### DIFF
--- a/src/PropertyDescriber/ObjectPropertyDescriber.php
+++ b/src/PropertyDescriber/ObjectPropertyDescriber.php
@@ -39,12 +39,7 @@ class ObjectPropertyDescriber implements PropertyDescriberInterface, ModelRegist
         if ($types[0]->isNullable()) {
             $weakContext = Util::createWeakContext($property->_context);
             $schemas = [new OA\Schema(['ref' => $this->modelRegistry->register(new Model($type, $groups, null, $context)), '_context' => $weakContext])];
-
-            if (function_exists('enum_exists') && enum_exists($type->getClassName())) {
-                $property->allOf = $schemas;
-            } else {
-                $property->oneOf = $schemas;
-            }
+            $property->oneOf = $schemas;
 
             return;
         }

--- a/tests/Functional/Fixtures/Controller2209.json
+++ b/tests/Functional/Fixtures/Controller2209.json
@@ -50,7 +50,7 @@
                     },
                     "nullableType": {
                         "nullable": true,
-                        "allOf": [
+                        "oneOf": [
                             {
                                 "$ref": "#/components/schemas/ArticleType81"
                             }

--- a/tests/Functional/Fixtures/MapQueryStringCleanupComponents.json
+++ b/tests/Functional/Fixtures/MapQueryStringCleanupComponents.json
@@ -47,7 +47,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -102,7 +102,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -157,7 +157,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -212,7 +212,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -267,7 +267,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -322,7 +322,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -377,7 +377,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -432,7 +432,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -489,7 +489,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -544,7 +544,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -599,7 +599,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -654,7 +654,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -709,7 +709,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -764,7 +764,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -819,7 +819,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -874,7 +874,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -1253,7 +1253,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -1308,7 +1308,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -1363,7 +1363,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -1418,7 +1418,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -1473,7 +1473,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -1528,7 +1528,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -1583,7 +1583,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -1638,7 +1638,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }

--- a/tests/Functional/Fixtures/MapQueryStringController.json
+++ b/tests/Functional/Fixtures/MapQueryStringController.json
@@ -47,7 +47,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -102,7 +102,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -157,7 +157,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -212,7 +212,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -267,7 +267,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -322,7 +322,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -377,7 +377,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -432,7 +432,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -489,7 +489,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -544,7 +544,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -599,7 +599,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -654,7 +654,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -709,7 +709,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -764,7 +764,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -819,7 +819,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -874,7 +874,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -1253,7 +1253,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -1308,7 +1308,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -1363,7 +1363,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -1418,7 +1418,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -1473,7 +1473,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -1528,7 +1528,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -1583,7 +1583,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -1638,7 +1638,7 @@
                         "required": false,
                         "schema": {
                             "nullable": true,
-                            "allOf": [
+                            "oneOf": [
                                 {
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
@@ -3090,7 +3090,7 @@
                     },
                     "nullableArticleType81": {
                         "nullable": true,
-                        "allOf": [
+                        "oneOf": [
                             {
                                 "$ref": "#/components/schemas/ArticleType81"
                             }
@@ -3121,7 +3121,7 @@
                     },
                     "nullableArticleType81": {
                         "nullable": true,
-                        "allOf": [
+                        "oneOf": [
                             {
                                 "$ref": "#/components/schemas/ArticleType81"
                             }

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -997,7 +997,7 @@ class FunctionalTest extends WebTestCase
                 ],
                 'nullableType' => [
                     'nullable' => true,
-                    'allOf' => [
+                    'oneOf' => [
                         ['$ref' => '#/components/schemas/ArticleType81'],
                     ],
                 ],

--- a/tests/Functional/SymfonyFunctionalTest.php
+++ b/tests/Functional/SymfonyFunctionalTest.php
@@ -57,7 +57,7 @@ class SymfonyFunctionalTest extends WebTestCase
                 ],
                 'nullableArticleType81' => [
                     'nullable' => true,
-                    'allOf' => [
+                    'oneOf' => [
                         ['$ref' => '#/components/schemas/ArticleType81'],
                     ],
                 ],
@@ -116,7 +116,7 @@ class SymfonyFunctionalTest extends WebTestCase
                     'required' => false,
                     'schema' => [
                         'nullable' => true,
-                        'allOf' => [
+                        'oneOf' => [
                             ['$ref' => '#/components/schemas/ArticleType81'],
                         ],
                     ],
@@ -178,7 +178,7 @@ class SymfonyFunctionalTest extends WebTestCase
                     'required' => false,
                     'schema' => [
                         'nullable' => true,
-                        'allOf' => [
+                        'oneOf' => [
                             ['$ref' => '#/components/schemas/ArticleType81'],
                         ],
                     ],
@@ -245,7 +245,7 @@ class SymfonyFunctionalTest extends WebTestCase
                     'required' => false,
                     'schema' => [
                         'nullable' => true,
-                        'allOf' => [
+                        'oneOf' => [
                             ['$ref' => '#/components/schemas/ArticleType81'],
                         ],
                     ],


### PR DESCRIPTION
Fix from https://github.com/nelmio/NelmioApiDocBundle/pull/2178 solved proper describing of nullable enums for OAS v 3.0, but it seems that broke it for OAS v 3.1.

As for version 3.0 it's correct and looks like:
```
'nullableType' => [
    'nullable' => true,
    'allOf' => [
        ['$ref' => '#/components/schemas/ArticleType81'], // enum ref
    ],
],
```

for version 3.1 it seems to be wrong. It's impossible to match these both types at the same time:
```
'nullableType' => [
    'allOf' => [
        ['$ref' => '#/components/schemas/ArticleType81'], // enum ref
        ['type' => 'null'],
    ]
],
```

I think the correct version for 3.1 should be:
```
'nullableType' => [
    'oneOf' => [
        ['$ref' => '#/components/schemas/ArticleType81'], // enum ref
        ['type' => 'null'],
    ]
],
```

In our project we're validating API data responses against API model schema using https://github.com/opis/json-schema and it reports above issue.

For now it's a dirty/draft PR to demonstrate the issue and start the discussion. It includes possible solution but I'm not sure 100% it's the correct way:
- I'm not sure about the responsibilities which lib ([nelmio](https://github.com/nelmio/NelmioApiDocBundle) or https://github.com/zircote/swagger-php) should handle OAS versions. Currently I cannot see it's happening in nelmio side and there's handling of OAS versions in https://github.com/zircote/swagger-php/blob/4.8.4/src/Annotations/AbstractAnnotation.php#L390, however there could be lack of intention context how it should be serialized at the end.

Seems to be also connected with https://github.com/zircote/swagger-php/issues/1528 and https://github.com/zircote/swagger-php/pull/1531, is that right @DjordyKoert?

I'm happy to finalize this topic, but please point me in the right direction. Any feedback is welcome :)