### PR TITLE
Update faq.rst; wrong nesting of disable_default_routes option

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -205,8 +205,7 @@ A: Use ``disable_default_routes`` config in your area.
 
     nelmio_api_doc:
         areas:
-            default:
-                disable_default_routes: true
+            disable_default_routes: true
 
 Overriding a Form or Plain PHP Object Schema Type
 -------------------------------------------------


### PR DESCRIPTION
The option disable_default_routes located into areas (not into nested default option)
<img width="1086" alt="image" src="https://github.com/nelmio/NelmioApiDocBundle/assets/1362140/92d7ffa2-afae-4225-8017-fb83452b8757">
