### PR TITLE
Update .symfony.bundle.yaml

### DIFF
--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -3,4 +3,4 @@ maintained_branches: ["3.x", "master"]
 current_branch: "master"
 dev_branch: "master"
 dev_branch_alias: "4.x"
-doc_dir: "docs/"
+doc_dir: { "3.x": "Resources/doc/", "master": "docs/" }


### PR DESCRIPTION
We saw some errors in the logs of the Symfony server related to the building of the docs of this bundle for the 3.x branch. We need to update the Symfony bundle config because the doc location is different in 3.x and master.

Thanks!