### PR TITLE
Support for JMS discriminator map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 CHANGELOG
 =========
 
+4.25.0
+-----
+* Added support for [JMS @Discriminator](https://jmsyst.com/libs/serializer/master/reference/annotations#discriminator) annotation/attribute
+  ```php
+  #[\JMS\Serializer\Annotation\Discriminator(field: 'type', map: ['car' => Car::class, 'plane' => Plane::class])]
+  abstract class Vehicle { }
+  class Car extends Vehicle { }
+  class Plane extends Vehicle { }
+  ```
+
 4.24.0
 -----
 * Added support for some integer ranges (https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges).  

--- a/tests/Functional/Controller/JMSController80.php
+++ b/tests/Functional/Controller/JMSController80.php
@@ -12,6 +12,7 @@
 namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
 
 use Nelmio\ApiDocBundle\Annotation\Model;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\DiscriminatorMap\JMSAbstractUser;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSComplex80;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSDualComplex;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSNamingStrategyConstraints;
@@ -149,6 +150,20 @@ class JMSController80
      * )
      */
     public function minUserNestedAction()
+    {
+    }
+
+    /**
+     * @Route("/api/jms_discriminator_map", methods={"GET"})
+     *
+     * @OA\Response(
+     *     response=200,
+     *     description="Success",
+     *
+     *     @Model(type=JMSAbstractUser::class)
+     * )
+     */
+    public function discriminatorMapAction()
     {
     }
 }

--- a/tests/Functional/Controller/JMSController81.php
+++ b/tests/Functional/Controller/JMSController81.php
@@ -13,6 +13,7 @@ namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
 
 use Nelmio\ApiDocBundle\Annotation\Model;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\Article81;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\DiscriminatorMap\JMSAbstractUser;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSComplex81;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSDualComplex;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSNamingStrategyConstraints;
@@ -128,6 +129,16 @@ class JMSController81
         content: new Model(type: Article81::class))
     ]
     public function enum()
+    {
+    }
+
+    #[Route('/api/jms_discriminator_map', methods: ['GET'])]
+    #[OA\Response(
+        response: 200,
+        description: 'Success',
+        content: new Model(type: JMSAbstractUser::class))
+    ]
+    public function discriminatorMapAction()
     {
     }
 }

--- a/tests/Functional/Entity/DiscriminatorMap/JMSAbstractUser.php
+++ b/tests/Functional/Entity/DiscriminatorMap/JMSAbstractUser.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Entity\DiscriminatorMap;
+
+use JMS\Serializer\Annotation as Serializer;
+use Nelmio\ApiDocBundle\Tests\Functional\TestKernel;
+
+if (TestKernel::isAnnotationsAvailable()) {
+    /**
+     * @Serializer\Discriminator(map={
+     *     "manager" = JMSManager::class,
+     *     "administrator" = JMSAdministrator::class,
+     * }, groups={"Default"})
+     */
+    abstract class JMSAbstractUser
+    {
+        /**
+         * @Serializer\Type("string")
+         *
+         * @Serializer\Groups({"Default"})
+         */
+        public $username;
+    }
+} else {
+    #[Serializer\Discriminator(map: ['manager' => JMSManager::class, 'administrator' => JMSAdministrator::class], groups: ['Default'])]
+    abstract class JMSAbstractUser
+    {
+        #[Serializer\Type('string')]
+        #[Serializer\Groups(['Default'])]
+        public $username;
+    }
+}

--- a/tests/Functional/Entity/DiscriminatorMap/JMSAdministrator.php
+++ b/tests/Functional/Entity/DiscriminatorMap/JMSAdministrator.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Entity\DiscriminatorMap;
+
+use JMS\Serializer\Annotation as Serializer;
+use Nelmio\ApiDocBundle\Tests\Functional\TestKernel;
+
+if (TestKernel::isAnnotationsAvailable()) {
+    class JMSAdministrator extends JMSAbstractUser
+    {
+        /**
+         * @Serializer\Type("string")
+         *
+         * @Serializer\Groups({"Default"})
+         */
+        public $adminTitle;
+    }
+} else {
+    class JMSAdministrator extends JMSAbstractUser
+    {
+        #[Serializer\Type('string')]
+        #[Serializer\Groups(['Default'])]
+        public $adminTitle;
+    }
+}

--- a/tests/Functional/Entity/DiscriminatorMap/JMSManager.php
+++ b/tests/Functional/Entity/DiscriminatorMap/JMSManager.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Entity\DiscriminatorMap;
+
+class JMSManager extends JMSAbstractUser
+{
+}

--- a/tests/Functional/JMSFunctionalTest.php
+++ b/tests/Functional/JMSFunctionalTest.php
@@ -372,6 +372,47 @@ class JMSFunctionalTest extends WebTestCase
         ], json_decode($this->getModel('ArticleType81')->toJson(), true));
     }
 
+    public function testModeDiscriminatorMap()
+    {
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'username' => [
+                    'type' => 'string',
+                ],
+            ],
+            'schema' => 'JMSManager',
+        ], json_decode($this->getModel('JMSManager')->toJson(), true));
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'username' => [
+                    'type' => 'string',
+                ],
+                'admin_title' => [
+                    'type' => 'string',
+                ],
+            ],
+            'schema' => 'JMSAdministrator',
+        ], json_decode($this->getModel('JMSAdministrator')->toJson(), true));
+
+        $this->assertEquals([
+            'oneOf' => [
+                ['$ref' => '#/components/schemas/JMSManager'],
+                ['$ref' => '#/components/schemas/JMSAdministrator'],
+            ],
+            'schema' => 'JMSAbstractUser',
+            'discriminator' => [
+                'propertyName' => 'type',
+                'mapping' => [
+                    'manager' => '#/components/schemas/JMSManager',
+                    'administrator' => '#/components/schemas/JMSAdministrator',
+                ],
+            ],
+        ], json_decode($this->getModel('JMSAbstractUser')->toJson(), true));
+    }
+
     protected static function createKernel(array $options = []): KernelInterface
     {
         return new TestKernel(TestKernel::USE_JMS);


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | no                                                                                                                    |
| New feature?  | yes                                                                  |
| Deprecations? | no                                               |
| Issues        |  |

This PR adds support for [JMS Discriminator](https://jmsyst.com/libs/serializer/master/reference/annotations#discriminator) to be able to implement [OpenAPI Polymorphism](https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/)

**Usage example**
models:

```php
<?php

use JMS\Serializer\Annotation\Discriminator;

#[Discriminator(field: 'type', map: ['car' => Car::class, 'bike' => Bike::class])]
abstract class Vehicle
{
    // Common properties and methods
}

class Car extends Vehicle
{
    // Car specific properties and methods
}

class Bike extends Vehicle
{
    // Bike specific properties and methods
}
```

controller

```php
<?php

use Nelmio\ApiDocBundle\Annotation\Model;
use OpenApi\Annotations as OA;

class YourController
{
    /**
     * @OA\Response(
     *     response=200,
     *     description="Returns vehicles",
     *     @OA\JsonContent(
     *        type="object",
     *        @OA\Property(property="vehicles", type="array", @OA\Items(ref=@Model(type=Vehicle::class)))
     *     )
     * )
     */
    public function getVehicles()
    {
        // Your code here
    }
}
```
