### PR TITLE
Install & run PHP-CS-Fixer

### DIFF
--- a/.github/workflows/common/composer-install/action.yaml
+++ b/.github/workflows/common/composer-install/action.yaml
@@ -1,0 +1,51 @@
+name: Composer setup
+description: Setup, install and cache Composer dependencies
+
+inputs:
+  symfony-version:
+    description: The required Symfony version that will be installed
+    required: false
+    type: string
+
+  install-doctrine-annotations:
+    description: If the doctrine/annotations package should be additionally installed as a dependency
+    required: true
+    type: boolean
+
+  composer-flags:
+    description: Additional flags that are passed to the `composer update` step
+    required: false
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Get Composer cache directory
+      id: composer-cache
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Cache Composer dependencies
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+        restore-keys: |
+          ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          ${{ runner.os }}-composer-
+
+    - name: Install doctrine/annotations
+      if: ${{ inputs.install-doctrine-annotations == 'true' }}
+      run: composer require --no-update doctrine/annotations
+      shell: bash
+
+    - name: Remove packages not compatible Symfony 7
+      if: ${{ inputs.symfony-version == '7.0.*' }}
+      run: composer remove --dev --no-update friendsofsymfony/rest-bundle sensio/framework-extra-bundle
+      shell: bash
+
+    - name: Install dependencies with Composer
+      env:
+        SYMFONY_REQUIRE: ${{ inputs.symfony-version }}
+      run: composer update --no-interaction --no-progress ${{ inputs.composer-flags }}
+      shell: bash

--- a/.github/workflows/common/composer-install/action.yaml
+++ b/.github/workflows/common/composer-install/action.yaml
@@ -4,7 +4,7 @@ description: Setup, install and cache Composer dependencies
 inputs:
   symfony-version:
     description: The required Symfony version that will be installed
-    required: false
+    required: true
     type: string
 
   install-doctrine-annotations:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -100,4 +100,4 @@ jobs:
           install-doctrine-annotations: false
 
       - name: Run PHP-CS-Fixer
-        run: composer phpcs-check
+        run: vendor/bin/php-cs-fixer check -v --diff

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,7 +1,7 @@
 # from doctrine/instantiator:
 # https://github.com/doctrine/instantiator/blob/97aa11bb71ad6259a8c5a1161b4de2d6cdcc5501/.github/workflows/continuous-integration.yml
 
-name: "CI"
+name: CI
 
 on:
   pull_request:
@@ -18,8 +18,8 @@ env:
 
 jobs:
   phpunit:
-    name: "PHPUnit"
-    runs-on: "ubuntu-22.04"
+    name: PHPUnit
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -54,43 +54,24 @@ jobs:
             doctrine-annotations: false
 
     steps:
-      - name: "Checkout"
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
-      - name: "Install PHP without coverage"
+      - name: Install PHP without coverage
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "${{ matrix.php-version }}"
+          php-version: ${{ matrix.php-version }}
           tools: composer, flex
           coverage: pcov
 
-      - name: "Get composer cache directory"
-        id: composercache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: "Cache dependencies"
-        uses: actions/cache@v3
+      - name: Setup dependencies
+        uses: ./.github/workflows/common/composer-install
         with:
-          path: ${{ steps.composercache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
+          symfony-version: ${{ matrix.symfony-require }}
+          install-doctrine-annotations: ${{ matrix.doctrine-annotations }}
+          composer-flags: ${{ matrix.composer-flags }}
 
-      - name: Install doctrine/annotations
-        if: matrix.doctrine-annotations == true
-        run: |
-          composer require doctrine/annotations --no-update
-
-      - name: Remove packages not compatible symfony 7
-        if: matrix.symfony-require == '7.0.*'
-        run: |
-          composer remove friendsofsymfony/rest-bundle sensio/framework-extra-bundle --no-update --dev
-
-      - name: "Install dependencies with composer"
-        env:
-          SYMFONY_REQUIRE: "${{ matrix.symfony-require }}"
-        run: composer update --no-interaction --no-progress ${{ matrix.composer-flags }}
-
-      - name: "PHPUnit Tests"
+      - name: PHPUnit Tests
         run: vendor/bin/phpunit --configuration phpunit.xml.dist --coverage-text

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -75,3 +75,29 @@ jobs:
 
       - name: PHPUnit Tests
         run: vendor/bin/phpunit --configuration phpunit.xml.dist --coverage-text
+
+  php-cs-fixer:
+    name: PHP-CS-Fixer
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Install PHP without coverage
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          tools: composer, flex
+          coverage: pcov
+
+      - name: Setup dependencies
+        uses: ./.github/workflows/common/composer-install
+        with:
+          symfony-version: "7.0.*"
+          install-doctrine-annotations: false
+
+      - name: Run PHP-CS-Fixer
+        run: composer phpcs-check

--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,14 @@
 /vendor/
 /composer.phar
 /composer.lock
-/.php_cs.cache
-/.php_cs
 /phpunit.xml
 /.phpunit
 /.phpunit.result.cache
 /Tests/Functional/cache
 /Tests/Functional/logs
 .idea
+
+###> friendsofphp/php-cs-fixer ###
+/.php-cs-fixer.php
+/.php-cs-fixer.cache
+###< friendsofphp/php-cs-fixer ###

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -20,6 +20,5 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 HEADER
         ],
-        'nullable_type_declaration_for_default_null_value' => false,
     ])
     ->setFinder($finder);

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,16 +1,15 @@
 <?php
 
-$finder = PhpCsFixer\Finder::create()
+declare(strict_types=1);
+
+$finder = (new PhpCsFixer\Finder())
     ->in(__DIR__)
     ->exclude('var')
-    ->exclude('Tests/Functional/cache')
-;
+    ->exclude('tests/Functional/cache');
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRules([
         '@Symfony' => true,
-        'ordered_imports' => true,
-        'phpdoc_order' => true,
         'header_comment' => [
             'header' => <<<HEADER
 This file is part of the NelmioApiDocBundle package.
@@ -21,6 +20,6 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 HEADER
         ],
+        'nullable_type_declaration_for_default_null_value' => false,
     ])
-    ->setFinder($finder)
-;
+    ->setFinder($finder);

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,7 +1,0 @@
-preset: symfony
-
-enabled:
-  - ordered_use
-
-disabled:
-  - unalign_equals

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
         "composer/package-versions-deprecated": "1.11.99.1",
 
         "phpunit/phpunit": "^8.5|^9.6",
-        "doctrine/annotations": "^2.0"
+        "doctrine/annotations": "^2.0",
+        "friendsofphp/php-cs-fixer": "^3.52"
     },
     "conflict": {
         "zircote/swagger-php": "4.8.7"
@@ -91,9 +92,13 @@
         }
     },
     "scripts-descriptions": {
+        "phpcs-check": "Run PHP-CS-Fixer in dry-run mode",
+        "phpcs-fix": "Run PHP-CS-Fixer",
         "phpunit": "Run phpunit"
     },
     "scripts": {
+        "phpcs-check": "vendor/bin/php-cs-fixer check -v --diff",
+        "phpcs-fix": "vendor/bin/php-cs-fixer fix -v",
         "phpunit": "phpunit"
     }
 }

--- a/src/Annotation/Model.php
+++ b/src/Annotation/Model.php
@@ -21,7 +21,6 @@ use OpenApi\Generator;
 #[\Attribute(\Attribute::TARGET_METHOD)]
 final class Model extends Attachable
 {
-    /** {@inheritdoc} */
     public static $_types = [
         'type' => 'string',
         'groups' => '[string]',

--- a/src/Annotation/Model.php
+++ b/src/Annotation/Model.php
@@ -62,8 +62,8 @@ final class Model extends Attachable
     public function __construct(
         array $properties = [],
         string $type = Generator::UNDEFINED,
-        array $groups = null,
-        array $options = null,
+        ?array $groups = null,
+        ?array $options = null,
         array $serializationContext = []
     ) {
         parent::__construct($properties + [

--- a/src/Annotation/Security.php
+++ b/src/Annotation/Security.php
@@ -38,7 +38,7 @@ class Security extends AbstractAnnotation
 
     public function __construct(
         array $properties = [],
-        string $name = null,
+        ?string $name = null,
         array $scopes = []
     ) {
         parent::__construct($properties + [

--- a/src/Annotation/Security.php
+++ b/src/Annotation/Security.php
@@ -19,7 +19,6 @@ use OpenApi\Annotations\AbstractAnnotation;
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Security extends AbstractAnnotation
 {
-    /** {@inheritdoc} */
     public static $_types = [
         'name' => 'string',
         'scopes' => '[string]',

--- a/src/ApiDocGenerator.php
+++ b/src/ApiDocGenerator.php
@@ -51,7 +51,7 @@ final class ApiDocGenerator
     /**
      * @var ?string
      */
-    private $openApiVersion = null;
+    private $openApiVersion;
 
     /** @var Generator */
     private $generator;

--- a/src/ApiDocGenerator.php
+++ b/src/ApiDocGenerator.php
@@ -60,7 +60,7 @@ final class ApiDocGenerator
      * @param DescriberInterface[]|iterable      $describers
      * @param ModelDescriberInterface[]|iterable $modelDescribers
      */
-    public function __construct($describers, $modelDescribers, CacheItemPoolInterface $cacheItemPool = null, string $cacheItemId = null, Generator $generator = null)
+    public function __construct($describers, $modelDescribers, ?CacheItemPoolInterface $cacheItemPool = null, ?string $cacheItemId = null, ?Generator $generator = null)
     {
         $this->describers = $describers;
         $this->modelDescribers = $modelDescribers;

--- a/src/Controller/YamlDocumentationController.php
+++ b/src/Controller/YamlDocumentationController.php
@@ -11,7 +11,6 @@
 
 namespace Nelmio\ApiDocBundle\Controller;
 
-use InvalidArgumentException;
 use Nelmio\ApiDocBundle\Render\RenderOpenApi;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -39,7 +38,7 @@ final class YamlDocumentationController
             );
 
             return $response->setCharset('UTF-8');
-        } catch (InvalidArgumentException $e) {
+        } catch (\InvalidArgumentException $e) {
             throw new BadRequestHttpException(sprintf('Area "%s" is not supported as it isn\'t defined in config.', $area));
         }
     }

--- a/src/DependencyInjection/NelmioApiDocExtension.php
+++ b/src/DependencyInjection/NelmioApiDocExtension.php
@@ -47,9 +47,6 @@ use Symfony\Component\Routing\RouteCollection;
 
 final class NelmioApiDocExtension extends Extension implements PrependExtensionInterface
 {
-    /**
-     * {@inheritdoc}
-     */
     public function prepend(ContainerBuilder $container): void
     {
         $container->prependExtensionConfig('framework', ['property_info' => ['enabled' => true]]);
@@ -62,9 +59,6 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function load(array $configs, ContainerBuilder $container): void
     {
         $config = $this->processConfiguration(new Configuration(), $configs);

--- a/src/Describer/OpenApiPhpDescriber.php
+++ b/src/Describer/OpenApiPhpDescriber.php
@@ -144,10 +144,10 @@ final class OpenApiPhpDescriber
                 }
 
                 if (
-                    !$annotation instanceof OA\Response &&
-                    !$annotation instanceof OA\RequestBody &&
-                    !$annotation instanceof OA\Parameter &&
-                    !$annotation instanceof OA\ExternalDocumentation
+                    !$annotation instanceof OA\Response
+                    && !$annotation instanceof OA\RequestBody
+                    && !$annotation instanceof OA\Parameter
+                    && !$annotation instanceof OA\ExternalDocumentation
                 ) {
                     throw new \LogicException(sprintf('Using the annotation "%s" as a root annotation in "%s::%s()" is not allowed.', get_class($annotation), $method->getDeclaringClass()->name, $method->name));
                 }

--- a/src/Exception/UndocumentedArrayItemsException.php
+++ b/src/Exception/UndocumentedArrayItemsException.php
@@ -19,7 +19,7 @@ class UndocumentedArrayItemsException extends \LogicException
     private $class;
     private $path;
 
-    public function __construct(string $class = null, string $path = '')
+    public function __construct(?string $class = null, string $path = '')
     {
         $this->class = $class;
         $this->path = $path;

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -23,7 +23,7 @@ final class Model
     /**
      * @param string[]|null $groups
      */
-    public function __construct(Type $type, array $groups = null, array $options = null, array $serializationContext = [])
+    public function __construct(Type $type, ?array $groups = null, ?array $options = null, array $serializationContext = [])
     {
         $this->type = $type;
         $this->options = $options;

--- a/src/ModelDescriber/Annotations/AnnotationsReader.php
+++ b/src/ModelDescriber/Annotations/AnnotationsReader.php
@@ -54,7 +54,7 @@ class AnnotationsReader
         return $this->openApiAnnotationsReader->getPropertyName($reflection, $default);
     }
 
-    public function updateProperty($reflection, OA\Property $property, array $serializationGroups = null): void
+    public function updateProperty($reflection, OA\Property $property, ?array $serializationGroups = null): void
     {
         $this->openApiAnnotationsReader->updateProperty($reflection, $property, $serializationGroups);
         $this->phpDocReader->updateProperty($reflection, $property);

--- a/src/ModelDescriber/Annotations/OpenApiAnnotationsReader.php
+++ b/src/ModelDescriber/Annotations/OpenApiAnnotationsReader.php
@@ -67,7 +67,7 @@ class OpenApiAnnotationsReader
         return Generator::UNDEFINED !== $oaProperty->property ? $oaProperty->property : $default;
     }
 
-    public function updateProperty($reflection, OA\Property $property, array $serializationGroups = null): void
+    public function updateProperty($reflection, OA\Property $property, ?array $serializationGroups = null): void
     {
         /** @var OA\Property|null $oaProperty */
         if (!$oaProperty = $this->getAnnotation($property->_context, $reflection, OA\Property::class)) {

--- a/src/ModelDescriber/Annotations/OpenApiAnnotationsReader.php
+++ b/src/ModelDescriber/Annotations/OpenApiAnnotationsReader.php
@@ -86,8 +86,6 @@ class OpenApiAnnotationsReader
 
     /**
      * @param \ReflectionClass|\ReflectionProperty|\ReflectionMethod $reflection
-     *
-     * @return mixed
      */
     private function getAnnotation(Context $parentContext, $reflection, string $className)
     {

--- a/src/ModelDescriber/BazingaHateoasModelDescriber.php
+++ b/src/ModelDescriber/BazingaHateoasModelDescriber.php
@@ -41,9 +41,6 @@ class BazingaHateoasModelDescriber implements ModelDescriberInterface, ModelRegi
         $this->JMSModelDescriber->setModelRegistry($modelRegistry);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function describe(Model $model, OA\Schema $schema): void
     {
         $this->JMSModelDescriber->describe($model, $schema);
@@ -106,9 +103,6 @@ class BazingaHateoasModelDescriber implements ModelDescriberInterface, ModelRegi
         return null;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function supports(Model $model): bool
     {
         return $this->JMSModelDescriber->supports($model) || null !== $this->getHateoasMetadata($model);

--- a/src/ModelDescriber/EnumModelDescriber.php
+++ b/src/ModelDescriber/EnumModelDescriber.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\ModelDescriber;
 
 use Nelmio\ApiDocBundle\Model\Model;

--- a/src/ModelDescriber/FormModelDescriber.php
+++ b/src/ModelDescriber/FormModelDescriber.php
@@ -50,9 +50,9 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
     private $isFormCsrfExtensionEnabled;
 
     public function __construct(
-        FormFactoryInterface $formFactory = null,
-        Reader $reader = null,
-        array $mediaTypes = null,
+        ?FormFactoryInterface $formFactory = null,
+        ?Reader $reader = null,
+        ?array $mediaTypes = null,
         bool $useValidationGroups = false,
         bool $isFormCsrfExtensionEnabled = false
     ) {

--- a/src/ModelDescriber/JMSModelDescriber.php
+++ b/src/ModelDescriber/JMSModelDescriber.php
@@ -224,7 +224,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
         return $context;
     }
 
-    private function computeGroups(Context $context, array $type = null)
+    private function computeGroups(Context $context, ?array $type = null)
     {
         if (null === $type || true !== $this->propertyTypeUsesGroups($type)) {
             return null;

--- a/src/ModelDescriber/JMSModelDescriber.php
+++ b/src/ModelDescriber/JMSModelDescriber.php
@@ -79,9 +79,6 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
         $this->contextFactory = $contextFactory;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function describe(Model $model, OA\Schema $schema)
     {
         $className = $model->getType()->getClassName();
@@ -246,9 +243,6 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
         return $groups;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function supports(Model $model): bool
     {
         $className = $model->getType()->getClassName();

--- a/src/ModelDescriber/ObjectModelDescriber.php
+++ b/src/ModelDescriber/ObjectModelDescriber.php
@@ -53,9 +53,9 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
         ?Reader $reader,
         $propertyDescribers,
         array $mediaTypes,
-        NameConverterInterface $nameConverter = null,
+        ?NameConverterInterface $nameConverter = null,
         bool $useValidationGroups = false,
-        ClassMetadataFactoryInterface $classMetadataFactory = null
+        ?ClassMetadataFactoryInterface $classMetadataFactory = null
     ) {
         if (is_iterable($propertyDescribers)) {
             trigger_deprecation('nelmio/api-doc-bundle', '4.17', 'Passing an array of PropertyDescriberInterface to %s() is deprecated. Pass a single PropertyDescriberInterface instead.', __METHOD__);

--- a/src/NelmioApiDocBundle.php
+++ b/src/NelmioApiDocBundle.php
@@ -20,9 +20,6 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class NelmioApiDocBundle extends Bundle
 {
-    /**
-     * {@inheritdoc}
-     */
     public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new ConfigurationPass());

--- a/src/OpenApiPhp/ModelRegister.php
+++ b/src/OpenApiPhp/ModelRegister.php
@@ -38,7 +38,7 @@ final class ModelRegister
         $this->mediaTypes = $mediaTypes;
     }
 
-    public function __invoke(Analysis $analysis, array $parentGroups = null)
+    public function __invoke(Analysis $analysis, ?array $parentGroups = null)
     {
         foreach ($analysis->annotations as $annotation) {
             // @Model using the ref field
@@ -106,7 +106,7 @@ final class ModelRegister
         }
     }
 
-    private function getGroups(ModelAnnotation $model, array $parentGroups = null): ?array
+    private function getGroups(ModelAnnotation $model, ?array $parentGroups = null): ?array
     {
         if (null === $model->groups) {
             return $parentGroups;

--- a/src/OpenApiPhp/Util.php
+++ b/src/OpenApiPhp/Util.php
@@ -214,7 +214,6 @@ final class Util
      * @see OA\AbstractAnnotation::$_nested
      *
      * @param string $class
-     * @param mixed  $value
      */
     public static function getIndexedCollectionItem(OA\AbstractAnnotation $parent, $class, $value): OA\AbstractAnnotation
     {
@@ -259,7 +258,6 @@ final class Util
      * Search for an Annotation within the $collection that has its member $index set to $value.
      *
      * @param string $member
-     * @param mixed  $value
      *
      * @return false|int|string
      */

--- a/src/OpenApiPhp/Util.php
+++ b/src/OpenApiPhp/Util.php
@@ -310,7 +310,7 @@ final class Util
      *
      * @see Context
      */
-    public static function createContext(array $properties = [], Context $parent = null): Context
+    public static function createContext(array $properties = [], ?Context $parent = null): Context
     {
         return new Context($properties, $parent);
     }
@@ -320,7 +320,7 @@ final class Util
      *
      * @see Context
      */
-    public static function createWeakContext(Context $parent = null, array $additionalProperties = []): Context
+    public static function createWeakContext(?Context $parent = null, array $additionalProperties = []): Context
     {
         $propsToCopy = [
             'version',

--- a/src/Processor/MapQueryStringProcessor.php
+++ b/src/Processor/MapQueryStringProcessor.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Processor;
 
 use Nelmio\ApiDocBundle\OpenApiPhp\Util;

--- a/src/Processor/MapRequestPayloadProcessor.php
+++ b/src/Processor/MapRequestPayloadProcessor.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Processor;
 
 use Nelmio\ApiDocBundle\OpenApiPhp\Util;

--- a/src/Processor/NullablePropertyProcessor.php
+++ b/src/Processor/NullablePropertyProcessor.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Processor;
 
 use OpenApi\Analysis;

--- a/src/PropertyDescriber/ArrayPropertyDescriber.php
+++ b/src/PropertyDescriber/ArrayPropertyDescriber.php
@@ -22,7 +22,7 @@ class ArrayPropertyDescriber implements PropertyDescriberInterface, ModelRegistr
     use ModelRegistryAwareTrait;
     use PropertyDescriberAwareTrait;
 
-    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
+    public function describe(array $types, OA\Schema $property, ?array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $property->type = 'array';
         /** @var OA\Items $property */

--- a/src/PropertyDescriber/BooleanPropertyDescriber.php
+++ b/src/PropertyDescriber/BooleanPropertyDescriber.php
@@ -16,7 +16,7 @@ use Symfony\Component\PropertyInfo\Type;
 
 class BooleanPropertyDescriber implements PropertyDescriberInterface
 {
-    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
+    public function describe(array $types, OA\Schema $property, ?array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $property->type = 'boolean';
     }

--- a/src/PropertyDescriber/CompoundPropertyDescriber.php
+++ b/src/PropertyDescriber/CompoundPropertyDescriber.php
@@ -22,7 +22,7 @@ class CompoundPropertyDescriber implements PropertyDescriberInterface, ModelRegi
     use ModelRegistryAwareTrait;
     use PropertyDescriberAwareTrait;
 
-    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
+    public function describe(array $types, OA\Schema $property, ?array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $property->oneOf = Generator::UNDEFINED !== $property->oneOf ? $property->oneOf : [];
 

--- a/src/PropertyDescriber/DateTimePropertyDescriber.php
+++ b/src/PropertyDescriber/DateTimePropertyDescriber.php
@@ -16,7 +16,7 @@ use Symfony\Component\PropertyInfo\Type;
 
 class DateTimePropertyDescriber implements PropertyDescriberInterface
 {
-    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
+    public function describe(array $types, OA\Schema $property, ?array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $property->type = 'string';
         $property->format = 'date-time';

--- a/src/PropertyDescriber/DictionaryPropertyDescriber.php
+++ b/src/PropertyDescriber/DictionaryPropertyDescriber.php
@@ -31,7 +31,6 @@ final class DictionaryPropertyDescriber implements PropertyDescriberInterface, M
         $this->propertyDescriber->describe($types[0]->getCollectionValueTypes(), $additionalProperties, $groups, $schema, $context);
     }
 
-    /** {@inheritDoc} */
     public function supports(array $types): bool
     {
         return 1 === count($types)

--- a/src/PropertyDescriber/DictionaryPropertyDescriber.php
+++ b/src/PropertyDescriber/DictionaryPropertyDescriber.php
@@ -22,7 +22,7 @@ final class DictionaryPropertyDescriber implements PropertyDescriberInterface, M
     use ModelRegistryAwareTrait;
     use PropertyDescriberAwareTrait;
 
-    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
+    public function describe(array $types, OA\Schema $property, ?array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $property->type = 'object';
         /** @var OA\AdditionalProperties $additionalProperties */

--- a/src/PropertyDescriber/FloatPropertyDescriber.php
+++ b/src/PropertyDescriber/FloatPropertyDescriber.php
@@ -16,7 +16,7 @@ use Symfony\Component\PropertyInfo\Type;
 
 class FloatPropertyDescriber implements PropertyDescriberInterface
 {
-    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
+    public function describe(array $types, OA\Schema $property, ?array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $property->type = 'number';
         $property->format = 'float';

--- a/src/PropertyDescriber/IntegerPropertyDescriber.php
+++ b/src/PropertyDescriber/IntegerPropertyDescriber.php
@@ -16,7 +16,7 @@ use Symfony\Component\PropertyInfo\Type;
 
 class IntegerPropertyDescriber implements PropertyDescriberInterface
 {
-    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
+    public function describe(array $types, OA\Schema $property, ?array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $property->type = 'integer';
     }

--- a/src/PropertyDescriber/NullablePropertyDescriber.php
+++ b/src/PropertyDescriber/NullablePropertyDescriber.php
@@ -18,7 +18,7 @@ final class NullablePropertyDescriber implements PropertyDescriberInterface, Pro
 {
     use PropertyDescriberAwareTrait;
 
-    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
+    public function describe(array $types, OA\Schema $property, ?array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         if (Generator::UNDEFINED === $property->nullable) {
             $property->nullable = true;

--- a/src/PropertyDescriber/ObjectPropertyDescriber.php
+++ b/src/PropertyDescriber/ObjectPropertyDescriber.php
@@ -22,7 +22,7 @@ class ObjectPropertyDescriber implements PropertyDescriberInterface, ModelRegist
 {
     use ModelRegistryAwareTrait;
 
-    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
+    public function describe(array $types, OA\Schema $property, ?array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $type = new Type(
             $types[0]->getBuiltinType(),

--- a/src/PropertyDescriber/PropertyDescriber.php
+++ b/src/PropertyDescriber/PropertyDescriber.php
@@ -33,7 +33,7 @@ final class PropertyDescriber implements PropertyDescriberInterface, ModelRegist
         $this->propertyDescribers = $propertyDescribers;
     }
 
-    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = []): void
+    public function describe(array $types, OA\Schema $property, ?array $groups = null, ?OA\Schema $schema = null, array $context = []): void
     {
         if (!$propertyDescriber = $this->getPropertyDescriber($types)) {
             return;

--- a/src/PropertyDescriber/PropertyDescriber.php
+++ b/src/PropertyDescriber/PropertyDescriber.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\PropertyDescriber;
 
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;

--- a/src/PropertyDescriber/PropertyDescriberInterface.php
+++ b/src/PropertyDescriber/PropertyDescriberInterface.php
@@ -22,7 +22,7 @@ interface PropertyDescriberInterface
      * @param Schema               $schema  Allows to make changes inside of the schema (e.g. adding required fields)
      * @param array<string, mixed> $context Context options for describing the property
      */
-    public function describe(array $types, Schema $property, array $groups = null /* , ?Schema $schema = null */ /* , array $context = [] */);
+    public function describe(array $types, Schema $property, ?array $groups = null /* , ?Schema $schema = null */ /* , array $context = [] */);
 
     /**
      * @param Type[] $types

--- a/src/PropertyDescriber/RequiredPropertyDescriber.php
+++ b/src/PropertyDescriber/RequiredPropertyDescriber.php
@@ -21,7 +21,7 @@ final class RequiredPropertyDescriber implements PropertyDescriberInterface, Pro
 {
     use PropertyDescriberAwareTrait;
 
-    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
+    public function describe(array $types, OA\Schema $property, ?array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $this->propertyDescriber->describe($types, $property, $groups, $schema, $context);
 

--- a/src/PropertyDescriber/StringPropertyDescriber.php
+++ b/src/PropertyDescriber/StringPropertyDescriber.php
@@ -16,7 +16,7 @@ use Symfony\Component\PropertyInfo\Type;
 
 class StringPropertyDescriber implements PropertyDescriberInterface
 {
-    public function describe(array $types, OA\Schema $property, array $groups = null, ?OA\Schema $schema = null, array $context = [])
+    public function describe(array $types, OA\Schema $property, ?array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $property->type = 'string';
     }

--- a/src/Render/Html/HtmlOpenApiRenderer.php
+++ b/src/Render/Html/HtmlOpenApiRenderer.php
@@ -11,7 +11,6 @@
 
 namespace Nelmio\ApiDocBundle\Render\Html;
 
-use InvalidArgumentException;
 use Nelmio\ApiDocBundle\Render\OpenApiRenderer;
 use Nelmio\ApiDocBundle\Render\RenderOpenApi;
 use OpenApi\Annotations\OpenApi;
@@ -28,7 +27,7 @@ class HtmlOpenApiRenderer implements OpenApiRenderer
     public function __construct($twig)
     {
         if (!$twig instanceof \Twig_Environment && !$twig instanceof Environment) {
-            throw new InvalidArgumentException(sprintf('Providing an instance of "%s" as twig is not supported.', get_class($twig)));
+            throw new \InvalidArgumentException(sprintf('Providing an instance of "%s" as twig is not supported.', get_class($twig)));
         }
         $this->twig = $twig;
     }

--- a/src/Render/Html/Renderer.php
+++ b/src/Render/Html/Renderer.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Render\Html;
 
 class Renderer

--- a/src/RouteDescriber/PhpDocDescriber.php
+++ b/src/RouteDescriber/PhpDocDescriber.php
@@ -23,7 +23,7 @@ final class PhpDocDescriber implements RouteDescriberInterface
 
     private $docBlockFactory;
 
-    public function __construct(DocBlockFactoryInterface $docBlockFactory = null)
+    public function __construct(?DocBlockFactoryInterface $docBlockFactory = null)
     {
         if (null === $docBlockFactory) {
             $docBlockFactory = DocBlockFactory::createInstance();

--- a/src/RouteDescriber/RouteArgumentDescriber.php
+++ b/src/RouteDescriber/RouteArgumentDescriber.php
@@ -2,13 +2,21 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\RouteDescriber;
 
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareTrait;
 use Nelmio\ApiDocBundle\RouteDescriber\RouteArgumentDescriber\RouteArgumentDescriberInterface;
 use OpenApi\Annotations as OA;
-use ReflectionMethod;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactoryInterface;
 use Symfony\Component\Routing\Route;
 
@@ -26,7 +34,7 @@ final class RouteArgumentDescriber implements RouteDescriberInterface, ModelRegi
     ) {
     }
 
-    public function describe(OA\OpenApi $api, Route $route, ReflectionMethod $reflectionMethod): void
+    public function describe(OA\OpenApi $api, Route $route, \ReflectionMethod $reflectionMethod): void
     {
         $controller = $route->getDefault('_controller');
 

--- a/src/RouteDescriber/RouteArgumentDescriber/RouteArgumentDescriberInterface.php
+++ b/src/RouteDescriber/RouteArgumentDescriber/RouteArgumentDescriberInterface.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\RouteDescriber\RouteArgumentDescriber;
 
 use OpenApi\Annotations as OA;

--- a/src/RouteDescriber/RouteArgumentDescriber/SymfonyMapQueryParameterDescriber.php
+++ b/src/RouteDescriber/RouteArgumentDescriber/SymfonyMapQueryParameterDescriber.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\RouteDescriber\RouteArgumentDescriber;
 
 use Nelmio\ApiDocBundle\OpenApiPhp\Util;

--- a/src/RouteDescriber/RouteArgumentDescriber/SymfonyMapQueryStringDescriber.php
+++ b/src/RouteDescriber/RouteArgumentDescriber/SymfonyMapQueryStringDescriber.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\RouteDescriber\RouteArgumentDescriber;
 
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
@@ -15,11 +24,11 @@ use Symfony\Component\Validator\Constraints\GroupSequence;
 
 final class SymfonyMapQueryStringDescriber implements RouteArgumentDescriberInterface, ModelRegistryAwareInterface
 {
+    use ModelRegistryAwareTrait;
+
     public const CONTEXT_KEY = 'nelmio_api_doc_bundle.map_query_string.'.self::class;
     public const CONTEXT_ARGUMENT_METADATA = 'nelmio_api_doc_bundle.argument_metadata.'.self::class;
     public const CONTEXT_MODEL_REF = 'nelmio_api_doc_bundle.model_ref.'.self::class;
-
-    use ModelRegistryAwareTrait;
 
     public function describe(ArgumentMetadata $argumentMetadata, OA\Operation $operation): void
     {

--- a/src/RouteDescriber/RouteArgumentDescriber/SymfonyMapRequestPayloadDescriber.php
+++ b/src/RouteDescriber/RouteArgumentDescriber/SymfonyMapRequestPayloadDescriber.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\RouteDescriber\RouteArgumentDescriber;
 
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
@@ -15,10 +24,10 @@ use Symfony\Component\Validator\Constraints\GroupSequence;
 
 final class SymfonyMapRequestPayloadDescriber implements RouteArgumentDescriberInterface, ModelRegistryAwareInterface
 {
+    use ModelRegistryAwareTrait;
+
     public const CONTEXT_ARGUMENT_METADATA = 'nelmio_api_doc_bundle.argument_metadata.'.self::class;
     public const CONTEXT_MODEL_REF = 'nelmio_api_doc_bundle.model_ref.'.self::class;
-
-    use ModelRegistryAwareTrait;
 
     public function describe(ArgumentMetadata $argumentMetadata, OA\Operation $operation): void
     {

--- a/src/RouteDescriber/RouteMetadataDescriber.php
+++ b/src/RouteDescriber/RouteMetadataDescriber.php
@@ -11,7 +11,6 @@
 
 namespace Nelmio\ApiDocBundle\RouteDescriber;
 
-use LogicException;
 use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 use OpenApi\Annotations as OA;
 use OpenApi\Generator;
@@ -44,7 +43,7 @@ final class RouteMetadataDescriber implements RouteDescriberInterface
                 $parameter = $existingParams[$paramId] ?? null;
                 if (null !== $parameter) {
                     if (!$parameter->required || Generator::UNDEFINED === $parameter->required) {
-                        throw new LogicException(\sprintf('Global parameter "%s" is used as part of route "%s" and must be set as "required"', $pathVariable, $route->getPath()));
+                        throw new \LogicException(\sprintf('Global parameter "%s" is used as part of route "%s" and must be set as "required"', $pathVariable, $route->getPath()));
                     }
 
                     continue;

--- a/src/Util/SetsContextTrait.php
+++ b/src/Util/SetsContextTrait.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Util;
 
 use Nelmio\ApiDocBundle\OpenApiPhp\Util;

--- a/tests/Functional/BazingaFunctionalTest.php
+++ b/tests/Functional/BazingaFunctionalTest.php
@@ -14,8 +14,6 @@ namespace Nelmio\ApiDocBundle\Tests\Functional;
 use Hateoas\Configuration\Embedded;
 use Metadata\Cache\PsrCacheAdapter;
 use Metadata\MetadataFactory;
-use ReflectionException;
-use ReflectionMethod;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -117,8 +115,8 @@ class BazingaFunctionalTest extends WebTestCase
     public function testWithType()
     {
         try {
-            new ReflectionMethod(Embedded::class, 'getType');
-        } catch (ReflectionException $e) {
+            new \ReflectionMethod(Embedded::class, 'getType');
+        } catch (\ReflectionException $e) {
             $this->markTestSkipped('Typed embedded properties require at least willdurand/hateoas 3.0');
         }
         $this->assertEquals([

--- a/tests/Functional/ConfigurableContainerFactory.php
+++ b/tests/Functional/ConfigurableContainerFactory.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/tests/Functional/Controller/Controller2209.php
+++ b/tests/Functional/Controller/Controller2209.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
 
 use Nelmio\ApiDocBundle\Annotation\Model;

--- a/tests/Functional/Controller/MapQueryStringController.php
+++ b/tests/Functional/Controller/MapQueryStringController.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
 
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\QueryModel\ArrayQueryModel;

--- a/tests/Functional/Controller/PromotedPropertiesController80.php
+++ b/tests/Functional/Controller/PromotedPropertiesController80.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the NelmioApiDocBundle package.
  *
@@ -8,8 +10,6 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
-declare(strict_types=1);
 
 namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
 

--- a/tests/Functional/Controller/PromotedPropertiesController81.php
+++ b/tests/Functional/Controller/PromotedPropertiesController81.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the NelmioApiDocBundle package.
  *
@@ -8,8 +10,6 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
-declare(strict_types=1);
 
 namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
 

--- a/tests/Functional/CsrfProtectionFunctionalTest.php
+++ b/tests/Functional/CsrfProtectionFunctionalTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional;
 
 use Symfony\Component\HttpKernel\KernelInterface;

--- a/tests/Functional/Entity/ArrayItems/Dictionary.php
+++ b/tests/Functional/Entity/ArrayItems/Dictionary.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity\ArrayItems;
 
 class Dictionary
@@ -12,12 +21,12 @@ class Dictionary
     public $options;
 
     /**
-     * @var array<string, string|integer>
+     * @var array<string, string|int>
      */
     public $compoundOptions;
 
     /**
-     * @var array<array<string, string|integer>>
+     * @var array<array<string, string|int>>
      */
     public $nestedCompoundOptions;
 
@@ -37,7 +46,7 @@ class Dictionary
     public $arrayOrDictOptions;
 
     /**
-     * @var array<string, integer>
+     * @var array<string, int>
      */
     public $integerOptions;
 }

--- a/tests/Functional/Entity/Article81.php
+++ b/tests/Functional/Entity/Article81.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
 
 class Article81

--- a/tests/Functional/Entity/ArticleInterface.php
+++ b/tests/Functional/Entity/ArticleInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
 
 interface ArticleInterface

--- a/tests/Functional/Entity/ArticleType81.php
+++ b/tests/Functional/Entity/ArticleType81.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
 
 enum ArticleType81: string

--- a/tests/Functional/Entity/ArticleType81IntBacked.php
+++ b/tests/Functional/Entity/ArticleType81IntBacked.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
 
 enum ArticleType81IntBacked: int

--- a/tests/Functional/Entity/ArticleType81NotBacked.php
+++ b/tests/Functional/Entity/ArticleType81NotBacked.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
 
 enum ArticleType81NotBacked

--- a/tests/Functional/Entity/CustomDateTime.php
+++ b/tests/Functional/Entity/CustomDateTime.php
@@ -11,13 +11,12 @@
 
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
 
-use DateTime;
 use JMS\Serializer\Annotation as Serializer;
 
 /**
  * @author Javier Spagnoletti <phansys@gmail.com>
  */
-class CustomDateTime extends DateTime
+class CustomDateTime extends \DateTime
 {
     /**
      * @Serializer\Type("string")

--- a/tests/Functional/Entity/EntityThroughNameConverter.php
+++ b/tests/Functional/Entity/EntityThroughNameConverter.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
 
 class EntityThroughNameConverter

--- a/tests/Functional/Entity/EntityThroughNameConverterNested.php
+++ b/tests/Functional/Entity/EntityThroughNameConverterNested.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
 
 class EntityThroughNameConverterNested

--- a/tests/Functional/Entity/EntityWithAlternateType80.php
+++ b/tests/Functional/Entity/EntityWithAlternateType80.php
@@ -11,23 +11,21 @@
 
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
 
-use ArrayIterator;
-use IteratorAggregate;
 use OpenApi\Annotations as OA;
 
 /**
  * @OA\Schema(type="array", @OA\Items(type="string"))
  */
-class EntityWithAlternateType80 implements IteratorAggregate
+class EntityWithAlternateType80 implements \IteratorAggregate
 {
     /**
      * @var string
      */
     public $ignored = 'this property should be ignored because of the annotation above';
 
-    public function getIterator(): ArrayIterator
+    public function getIterator(): \ArrayIterator
     {
-        return new ArrayIterator([
+        return new \ArrayIterator([
             'abc',
             'def',
         ]);

--- a/tests/Functional/Entity/EntityWithAlternateType81.php
+++ b/tests/Functional/Entity/EntityWithAlternateType81.php
@@ -11,21 +11,19 @@
 
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
 
-use ArrayIterator;
-use IteratorAggregate;
 use OpenApi\Attributes as OA;
 
 #[OA\Schema(type: 'array', items: new OA\Items(type: 'string'))]
-class EntityWithAlternateType81 implements IteratorAggregate
+class EntityWithAlternateType81 implements \IteratorAggregate
 {
     /**
      * @var string
      */
     public $ignored = 'this property should be ignored because of the annotation above';
 
-    public function getIterator(): ArrayIterator
+    public function getIterator(): \ArrayIterator
     {
-        return new ArrayIterator([
+        return new \ArrayIterator([
             'abc',
             'def',
         ]);

--- a/tests/Functional/Entity/EntityWithFalsyDefaults.php
+++ b/tests/Functional/Entity/EntityWithFalsyDefaults.php
@@ -26,7 +26,7 @@ class EntityWithFalsyDefaults
     public $false = false;
 
     /** @var string|null */
-    public $nullString = null;
+    public $nullString;
 
     /** @var string[] */
     public $array = [];

--- a/tests/Functional/Entity/QueryModel/ArrayQueryModel.php
+++ b/tests/Functional/Entity/QueryModel/ArrayQueryModel.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity\QueryModel;
 
 use OpenApi\Attributes as OA;

--- a/tests/Functional/Entity/QueryModel/FilterQueryModel.php
+++ b/tests/Functional/Entity/QueryModel/FilterQueryModel.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity\QueryModel;
 
 final class FilterQueryModel

--- a/tests/Functional/Entity/QueryModel/PaginationQueryModel.php
+++ b/tests/Functional/Entity/QueryModel/PaginationQueryModel.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity\QueryModel;
 
 final class PaginationQueryModel

--- a/tests/Functional/Entity/QueryModel/SortEnum.php
+++ b/tests/Functional/Entity/QueryModel/SortEnum.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity\QueryModel;
 
 enum SortEnum: string

--- a/tests/Functional/Entity/QueryModel/SortQueryModel.php
+++ b/tests/Functional/Entity/QueryModel/SortQueryModel.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity\QueryModel;
 
 class SortQueryModel

--- a/tests/Functional/Entity/RangeInteger.php
+++ b/tests/Functional/Entity/RangeInteger.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
 
 use Symfony\Component\HttpKernel\Kernel;

--- a/tests/Functional/Entity/SymfonyMapQueryString.php
+++ b/tests/Functional/Entity/SymfonyMapQueryString.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
 
 class SymfonyMapQueryString

--- a/tests/Functional/Entity/User.php
+++ b/tests/Functional/Entity/User.php
@@ -144,7 +144,7 @@ if (TestKernel::isAnnotationsAvailable()) {
         {
         }
 
-        public function setFriend(self $friend = null)
+        public function setFriend(?self $friend = null)
         {
         }
 
@@ -284,7 +284,7 @@ if (TestKernel::isAnnotationsAvailable()) {
         {
         }
 
-        public function setFriend(self $friend = null)
+        public function setFriend(?self $friend = null)
         {
         }
 

--- a/tests/Functional/Entity/VirtualProperty80.php
+++ b/tests/Functional/Entity/VirtualProperty80.php
@@ -12,7 +12,6 @@
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
 
 use JMS\Serializer\Annotation as Serializer;
-use LogicException;
 
 /**
  * Class VirtualProperty.
@@ -64,6 +63,6 @@ class VirtualProperty80
             return 'Success';
         }
 
-        throw new LogicException(sprintf('%s::__call does not implement this function.', __CLASS__));
+        throw new \LogicException(sprintf('%s::__call does not implement this function.', __CLASS__));
     }
 }

--- a/tests/Functional/Entity/VirtualProperty81.php
+++ b/tests/Functional/Entity/VirtualProperty81.php
@@ -12,7 +12,6 @@
 namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
 
 use JMS\Serializer\Annotation as Serializer;
-use LogicException;
 
 /**
  * Class VirtualProperty.
@@ -54,6 +53,6 @@ class VirtualProperty81
             return 'Success';
         }
 
-        throw new LogicException(sprintf('%s::__call does not implement this function.', __CLASS__));
+        throw new \LogicException(sprintf('%s::__call does not implement this function.', __CLASS__));
     }
 }

--- a/tests/Functional/Form/FormWithCsrfProtectionDisabledType.php
+++ b/tests/Functional/Form/FormWithCsrfProtectionDisabledType.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional\Form;
 
 use Symfony\Component\Form\AbstractType;

--- a/tests/Functional/Form/FormWithCsrfProtectionEnabledType.php
+++ b/tests/Functional/Form/FormWithCsrfProtectionEnabledType.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional\Form;
 
 use Symfony\Component\Form\AbstractType;

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -19,7 +19,6 @@ use OpenApi\Attributes as OAAttributes;
 use OpenApi\Generator;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Serializer\Annotation\SerializedName;
-use const PHP_VERSION_ID;
 
 class FunctionalTest extends WebTestCase
 {
@@ -70,7 +69,7 @@ class FunctionalTest extends WebTestCase
             yield 'Annotations' => ['/api/article/{id}'];
         }
 
-        if (PHP_VERSION_ID >= 80100) {
+        if (\PHP_VERSION_ID >= 80100) {
             yield 'Attributes' => ['/api/article_attributes/{id}'];
         }
     }
@@ -389,7 +388,7 @@ class FunctionalTest extends WebTestCase
     {
         yield 'Annotations' => ['/api/security'];
 
-        if (PHP_VERSION_ID >= 80100) {
+        if (\PHP_VERSION_ID >= 80100) {
             yield 'Attributes' => ['/api/security_attributes'];
         }
     }
@@ -407,14 +406,14 @@ class FunctionalTest extends WebTestCase
     {
         yield 'Annotations' => ['/api/securityOverride'];
 
-        if (PHP_VERSION_ID >= 80100) {
+        if (\PHP_VERSION_ID >= 80100) {
             yield 'Attributes' => ['/api/security_override_attributes'];
         }
     }
 
     public function testInlinePHP81Parameters()
     {
-        if (PHP_VERSION_ID < 80100) {
+        if (\PHP_VERSION_ID < 80100) {
             $this->markTestSkipped('Attributes require PHP 8.1');
         }
 

--- a/tests/Functional/ModelDescriber/NameConverter.php
+++ b/tests/Functional/ModelDescriber/NameConverter.php
@@ -28,7 +28,7 @@ class NameConverter implements AdvancedNameConverterInterface
         $this->inner = $inner;
     }
 
-    public function normalize(string $propertyName, string $class = null, string $format = null, array $context = []): string
+    public function normalize(string $propertyName, ?string $class = null, ?string $format = null, array $context = []): string
     {
         if (!isset($context['secret_name_converter_value'])) {
             return $this->inner->normalize($propertyName, $class, $format, $context);
@@ -37,7 +37,7 @@ class NameConverter implements AdvancedNameConverterInterface
         return 'name_converter_context_'.$propertyName;
     }
 
-    public function denormalize(string $propertyName, string $class = null, string $format = null, array $context = []): string
+    public function denormalize(string $propertyName, ?string $class = null, ?string $format = null, array $context = []): string
     {
         throw new \RuntimeException('Was not expected to be called');
     }

--- a/tests/Functional/ModelDescriber/NameConverter.php
+++ b/tests/Functional/ModelDescriber/NameConverter.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Functional\ModelDescriber;
 
 use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;

--- a/tests/Functional/TestKernel.php
+++ b/tests/Functional/TestKernel.php
@@ -26,8 +26,6 @@ use Nelmio\ApiDocBundle\Tests\Functional\Entity\PrivateProtectedExposure;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\SymfonyConstraintsWithValidationGroups;
 use Nelmio\ApiDocBundle\Tests\Functional\ModelDescriber\NameConverter;
 use Nelmio\ApiDocBundle\Tests\Functional\ModelDescriber\VirtualTypeClassDoesNotExistsHandlerDefinedDescriber;
-use ReflectionException;
-use ReflectionMethod;
 use Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle;
 use Symfony\Bundle\FrameworkBundle\Command\CachePoolClearCommand;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
@@ -43,11 +41,12 @@ use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 class TestKernel extends Kernel
 {
     use MicroKernelTrait;
-    const USE_JMS = 1;
-    const USE_BAZINGA = 2;
-    const USE_FOSREST = 3;
-    const USE_VALIDATION_GROUPS = 8;
-    const USE_FORM_CSRF = 16;
+
+    public const USE_JMS = 1;
+    public const USE_BAZINGA = 2;
+    public const USE_FOSREST = 3;
+    public const USE_VALIDATION_GROUPS = 8;
+    public const USE_FORM_CSRF = 16;
 
     private $flags;
 
@@ -103,9 +102,9 @@ class TestKernel extends Kernel
             $routes->withPath('/')->import(__DIR__.'/Controller/BazingaTypedController.php', self::isAnnotationsAvailable() ? 'annotation' : 'attribute');
 
             try {
-                new ReflectionMethod(Embedded::class, 'getType');
+                new \ReflectionMethod(Embedded::class, 'getType');
                 $routes->withPath('/')->import(__DIR__.'/Controller/BazingaTypedController.php', self::isAnnotationsAvailable() ? 'annotation' : 'attribute');
-            } catch (ReflectionException $e) {
+            } catch (\ReflectionException $e) {
             }
         }
 
@@ -246,13 +245,13 @@ class TestKernel extends Kernel
         } elseif (self::isAttributesAvailable()) {
             $models = array_merge($models, [
                 [
-                'alias' => 'JMSComplex',
-                'type' => JMSComplex81::class,
-                'groups' => [
-                    'list',
-                    'details',
-                    'User' => ['list'],
-                ],
+                    'alias' => 'JMSComplex',
+                    'type' => JMSComplex81::class,
+                    'groups' => [
+                        'list',
+                        'details',
+                        'User' => ['list'],
+                    ],
                 ],
                 [
                     'alias' => 'JMSComplexDefault',
@@ -319,20 +318,20 @@ class TestKernel extends Kernel
                     ],
                 ],
             ],
-           'areas' => [
-               'default' => [
-                   'path_patterns' => ['^/api(?!/admin)'],
-                   'host_patterns' => ['^api\.'],
-               ],
-               'test' => [
-                   'path_patterns' => ['^/test'],
-                   'host_patterns' => ['^api-test\.'],
-                   'documentation' => [
-                       'info' => [
-                           'title' => 'My Test App',
-                       ],
-                   ],
-               ],
+            'areas' => [
+                'default' => [
+                    'path_patterns' => ['^/api(?!/admin)'],
+                    'host_patterns' => ['^api\.'],
+                ],
+                'test' => [
+                    'path_patterns' => ['^/test'],
+                    'host_patterns' => ['^api-test\.'],
+                    'documentation' => [
+                        'info' => [
+                            'title' => 'My Test App',
+                        ],
+                    ],
+                ],
             ],
             'models' => [
                 'names' => $models,

--- a/tests/Helper.php
+++ b/tests/Helper.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests;
 
 use PackageVersions\Versions;

--- a/tests/Model/ModelRegistryTest.php
+++ b/tests/Model/ModelRegistryTest.php
@@ -17,7 +17,6 @@ use OpenApi\Annotations as OA;
 use OpenApi\Context;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use ReflectionClass;
 use Symfony\Component\PropertyInfo\Type;
 
 class ModelRegistryTest extends TestCase
@@ -47,24 +46,24 @@ class ModelRegistryTest extends TestCase
             ->method('info')
             ->with(
                 'Can not assign a name for the model, the name "ModelRegistryTest" has already been taken.', [
-                'model' => [
-                    'type' => $arrayType,
-                    'options' => null,
-                    'groups' => ['group2'],
-                    'serialization_context' => [
+                    'model' => [
+                        'type' => $arrayType,
+                        'options' => null,
                         'groups' => ['group2'],
+                        'serialization_context' => [
+                            'groups' => ['group2'],
+                        ],
                     ],
-                ],
-                'taken_by' => [
-                    'type' => $arrayType,
-                    'options' => null,
-                    'groups' => ['group1'],
-                    'serialization_context' => [
+                    'taken_by' => [
+                        'type' => $arrayType,
+                        'options' => null,
                         'groups' => ['group1'],
-                        'extra_context' => true,
+                        'serialization_context' => [
+                            'groups' => ['group1'],
+                            'extra_context' => true,
+                        ],
                     ],
-                ],
-            ]);
+                ]);
 
         $registry = new ModelRegistry([], $this->createOpenApi(), []);
         $registry->setLogger($logger);
@@ -111,7 +110,7 @@ class ModelRegistryTest extends TestCase
 
     public function testNameCollisionsAreLoggedWithAlternativeNames()
     {
-        $ref = new ReflectionClass(self::class);
+        $ref = new \ReflectionClass(self::class);
         $alternativeNames = [
             $ref->getShortName() => [
                 'type' => $ref->getName(),
@@ -124,33 +123,33 @@ class ModelRegistryTest extends TestCase
             ->method('info')
             ->with(
                 'Can not assign a name for the model, the name "ModelRegistryTest" has already been taken.', [
-                'model' => [
-                    'type' => [
-                        'class' => 'Nelmio\\ApiDocBundle\\Tests\\Model\\ModelRegistryTest',
-                        'built_in_type' => 'object',
-                        'nullable' => false,
-                        'collection' => false,
-                        'collection_key_types' => null,
-                        'collection_value_types' => null,
+                    'model' => [
+                        'type' => [
+                            'class' => 'Nelmio\\ApiDocBundle\\Tests\\Model\\ModelRegistryTest',
+                            'built_in_type' => 'object',
+                            'nullable' => false,
+                            'collection' => false,
+                            'collection_key_types' => null,
+                            'collection_value_types' => null,
+                        ],
+                        'options' => null,
+                        'groups' => ['group2'],
+                        'serialization_context' => ['groups' => ['group2']],
                     ],
-                    'options' => null,
-                    'groups' => ['group2'],
-                    'serialization_context' => ['groups' => ['group2']],
-                ],
-                'taken_by' => [
-                    'type' => [
-                        'class' => 'Nelmio\\ApiDocBundle\\Tests\\Model\\ModelRegistryTest',
-                        'built_in_type' => 'object',
-                        'nullable' => false,
-                        'collection' => false,
-                        'collection_key_types' => null,
-                        'collection_value_types' => null,
+                    'taken_by' => [
+                        'type' => [
+                            'class' => 'Nelmio\\ApiDocBundle\\Tests\\Model\\ModelRegistryTest',
+                            'built_in_type' => 'object',
+                            'nullable' => false,
+                            'collection' => false,
+                            'collection_key_types' => null,
+                            'collection_value_types' => null,
+                        ],
+                        'options' => null,
+                        'groups' => ['group1'],
+                        'serialization_context' => ['groups' => ['group1']],
                     ],
-                    'options' => null,
-                    'groups' => ['group1'],
-                    'serialization_context' => ['groups' => ['group1']],
-                ],
-            ]);
+                ]);
 
         $registry = new ModelRegistry([], $this->createOpenApi(), $alternativeNames);
         $registry->setLogger($logger);

--- a/tests/ModelDescriber/Annotations/AnnotationReaderTest.php
+++ b/tests/ModelDescriber/Annotations/AnnotationReaderTest.php
@@ -20,8 +20,6 @@ use OpenApi\Attributes as OAattr;
 use OpenApi\Context;
 use OpenApi\Generator;
 use PHPUnit\Framework\TestCase;
-use ReflectionProperty;
-use const PHP_VERSION_ID;
 
 class AnnotationReaderTest extends TestCase
 {
@@ -46,8 +44,8 @@ class AnnotationReaderTest extends TestCase
             $registry,
             ['json']
         );
-        $symfonyConstraintAnnotationReader->updateProperty(new ReflectionProperty($entity, 'property1'), $schema->properties[0]);
-        $symfonyConstraintAnnotationReader->updateProperty(new ReflectionProperty($entity, 'property2'), $schema->properties[1]);
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property2'), $schema->properties[1]);
 
         $this->assertEquals($schema->properties[0]->example, 1);
         $this->assertEquals($schema->properties[0]->description, Generator::UNDEFINED);
@@ -69,7 +67,7 @@ class AnnotationReaderTest extends TestCase
             private $property2;
         }];
 
-        if (PHP_VERSION_ID >= 80100) {
+        if (\PHP_VERSION_ID >= 80100) {
             yield 'Attributes' => [new class() {
                 #[OAattr\Property(example: 1)]
                 private $property1;

--- a/tests/ModelDescriber/Annotations/Fixture/CompoundStub.php
+++ b/tests/ModelDescriber/Annotations/Fixture/CompoundStub.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\ModelDescriber\Annotations\Fixture;
 
 class CompoundStub

--- a/tests/ModelDescriber/Annotations/Fixture/CompoundValidationRule.php
+++ b/tests/ModelDescriber/Annotations/Fixture/CompoundValidationRule.php
@@ -2,9 +2,17 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\ModelDescriber\Annotations\Fixture;
 
-use Attribute;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Constraints\Compound;
 
@@ -15,7 +23,7 @@ if (!class_exists(Compound::class)) {
 /**
  * @Annotation
  */
-#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class CompoundValidationRule extends Compound
 {
     protected function getConstraints(array $options): array

--- a/tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
+++ b/tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
@@ -20,12 +20,9 @@ use OpenApi\Annotations as OA;
 use OpenApi\Context;
 use OpenApi\Generator;
 use PHPUnit\Framework\TestCase;
-use ReflectionProperty;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints as Assert;
-use function property_exists;
-use const PHP_VERSION_ID;
 
 class SymfonyConstraintAnnotationReaderTest extends TestCase
 {
@@ -73,8 +70,8 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader($this->doctrineAnnotations);
         $symfonyConstraintAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new ReflectionProperty($entity, 'property1'), $schema->properties[0]);
-        $symfonyConstraintAnnotationReader->updateProperty(new ReflectionProperty($entity, 'property2'), $schema->properties[1]);
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property2'), $schema->properties[1]);
 
         // expect required to be numeric array with sequential keys (not [0 => ..., 2 => ...])
         $this->assertEquals($schema->required, ['property1', 'property2']);
@@ -87,7 +84,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
      */
     public function testOptionalProperty($entity)
     {
-        if (!property_exists(Assert\NotBlank::class, 'allowNull')) {
+        if (!\property_exists(Assert\NotBlank::class, 'allowNull')) {
             $this->markTestSkipped('NotBlank::allowNull was added in symfony/validator 4.3.');
         }
 
@@ -98,8 +95,8 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader($this->doctrineAnnotations);
         $symfonyConstraintAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new ReflectionProperty($entity, 'property1'), $schema->properties[0]);
-        $symfonyConstraintAnnotationReader->updateProperty(new ReflectionProperty($entity, 'property2'), $schema->properties[1]);
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property2'), $schema->properties[1]);
 
         // expect required to be numeric array with sequential keys (not [0 => ..., 2 => ...])
         $this->assertEquals($schema->required, ['property2']);
@@ -125,7 +122,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
             ];
         }
 
-        if (PHP_VERSION_ID >= 80000) {
+        if (\PHP_VERSION_ID >= 80000) {
             yield 'Attributes' => [new class() {
                 #[Assert\NotBlank(allowNull: true)]
                 #[Assert\Length(min: 1)]
@@ -149,7 +146,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader($this->doctrineAnnotations);
         $symfonyConstraintAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
 
         // expect enum to be numeric array with sequential keys (not [1 => "active", 2 => "active"])
         $this->assertEquals($schema->properties[0]->enum, ['active', 'blocked']);
@@ -175,7 +172,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
             ];
         }
 
-        if (PHP_VERSION_ID >= 80000) {
+        if (\PHP_VERSION_ID >= 80000) {
             yield 'Attributes' => [new class() {
                 #[Assert\Length(min: 1)]
                 #[Assert\Choice(choices: TEST_ASSERT_CHOICE_STATUSES)]
@@ -197,7 +194,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader($this->doctrineAnnotations);
         $symfonyConstraintAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
 
         $this->assertInstanceOf(OA\Items::class, $schema->properties[0]->items);
         $this->assertEquals($schema->properties[0]->items->enum, ['one', 'two']);
@@ -214,7 +211,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
             }];
         }
 
-        if (PHP_VERSION_ID >= 80000) {
+        if (\PHP_VERSION_ID >= 80000) {
             yield 'Attributes' => [new class() {
                 #[Assert\Choice(choices: ['one', 'two'], multiple: true)]
                 private $property1;
@@ -237,7 +234,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader($this->doctrineAnnotations);
         $symfonyConstraintAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
 
         $this->assertSame(Generator::UNDEFINED, $schema->properties[0]->maxLength);
         $this->assertSame(1, $schema->properties[0]->minLength);
@@ -256,7 +253,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
             ];
         }
 
-        if (PHP_VERSION_ID >= 80000) {
+        if (\PHP_VERSION_ID >= 80000) {
             yield 'Attributes' => [new class() {
                 #[Assert\Length(min: 1)]
                 private $property1;
@@ -279,7 +276,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader($this->doctrineAnnotations);
         $symfonyConstraintAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
 
         $this->assertSame(Generator::UNDEFINED, $schema->properties[0]->minLength);
         $this->assertSame(100, $schema->properties[0]->maxLength);
@@ -298,7 +295,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
             ];
         }
 
-        if (PHP_VERSION_ID >= 80000) {
+        if (\PHP_VERSION_ID >= 80000) {
             yield 'Attributes' => [new class() {
                 #[Assert\Length(max: 100)]
                 private $property1;
@@ -329,7 +326,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader($this->doctrineAnnotations);
         $symfonyConstraintAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new ReflectionProperty($entity, $propertyName), $schema->properties[0]);
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, $propertyName), $schema->properties[0]);
 
         if (Helper::isCompoundValidatorConstraintSupported()) {
             $this->assertSame([$propertyName], $schema->required);
@@ -361,7 +358,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader($this->doctrineAnnotations);
         $symfonyConstraintAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
 
         $this->assertSame(Generator::UNDEFINED, $schema->properties[0]->minItems);
         $this->assertSame(10, $schema->properties[0]->maxItems);
@@ -380,7 +377,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
             ];
         }
 
-        if (PHP_VERSION_ID >= 80000) {
+        if (\PHP_VERSION_ID >= 80000) {
             yield 'Attributes' => [new class() {
                 #[Assert\Count(max: 10)]
                 private $property1;
@@ -403,7 +400,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader($this->doctrineAnnotations);
         $symfonyConstraintAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
 
         $this->assertSame(Generator::UNDEFINED, $schema->properties[0]->maxItems);
         $this->assertSame(10, $schema->properties[0]->minItems);
@@ -422,7 +419,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
             ];
         }
 
-        if (PHP_VERSION_ID >= 80000) {
+        if (\PHP_VERSION_ID >= 80000) {
             yield 'Attributes' => [new class() {
                 #[Assert\Count(min: 10)]
                 private $property1;
@@ -445,7 +442,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader($this->doctrineAnnotations);
         $symfonyConstraintAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
 
         $this->assertSame(Generator::UNDEFINED, $schema->properties[0]->maximum);
         $this->assertSame(10, $schema->properties[0]->minimum);
@@ -464,7 +461,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
             ];
         }
 
-        if (PHP_VERSION_ID >= 80000) {
+        if (\PHP_VERSION_ID >= 80000) {
             yield 'Attributes' => [new class() {
                 #[Assert\Range(min: 10)]
                 private $property1;
@@ -487,7 +484,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader($this->doctrineAnnotations);
         $symfonyConstraintAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
 
         $this->assertSame(Generator::UNDEFINED, $schema->properties[0]->minimum);
         $this->assertSame(10, $schema->properties[0]->maximum);
@@ -506,7 +503,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
             ];
         }
 
-        if (PHP_VERSION_ID >= 80000) {
+        if (\PHP_VERSION_ID >= 80000) {
             yield 'Attributes' => [new class() {
                 #[Assert\Range(max: 10)]
                 private $property1;
@@ -531,7 +528,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
 
         // no serialization groups passed here
         $reader->updateProperty(
-            new ReflectionProperty($entity, 'property1'),
+            new \ReflectionProperty($entity, 'property1'),
             $schema->properties[0]
         );
 
@@ -554,7 +551,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
 
         // no serialization groups passed here
         $reader->updateProperty(
-            new ReflectionProperty($entity, 'property1'),
+            new \ReflectionProperty($entity, 'property1'),
             $schema->properties[0]
         );
 
@@ -578,7 +575,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
 
         // no serialization groups passed here
         $reader->updateProperty(
-            new ReflectionProperty($entity, 'property1'),
+            new \ReflectionProperty($entity, 'property1'),
             $schema->properties[0],
             ['other']
         );
@@ -603,7 +600,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
 
         // no serialization groups passed here
         $reader->updateProperty(
-            new ReflectionProperty($entity, 'property1'),
+            new \ReflectionProperty($entity, 'property1'),
             $schema->properties[0],
             ['other', Constraint::DEFAULT_GROUP]
         );
@@ -625,7 +622,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
             }];
         }
 
-        if (PHP_VERSION_ID >= 80000) {
+        if (\PHP_VERSION_ID >= 80000) {
             yield 'Attributes' => [new class() {
                 #[Assert\NotBlank()]
                 #[Assert\Range(min: 1, groups: ['other'])]

--- a/tests/ModelDescriber/FormModelDescriberTest.php
+++ b/tests/ModelDescriber/FormModelDescriberTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\ModelDescriber;
 
 use Doctrine\Common\Annotations\Reader;

--- a/tests/ModelDescriber/SelfDescribingModelDescriberTest.php
+++ b/tests/ModelDescriber/SelfDescribingModelDescriberTest.php
@@ -16,7 +16,6 @@ use Nelmio\ApiDocBundle\ModelDescriber\SelfDescribingModelDescriber;
 use Nelmio\ApiDocBundle\Tests\ModelDescriber\Fixtures\SelfDescribingModel;
 use OpenApi\Annotations\Schema;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 use Symfony\Component\PropertyInfo\Type;
 
 class SelfDescribingModelDescriberTest extends TestCase
@@ -32,7 +31,7 @@ class SelfDescribingModelDescriberTest extends TestCase
     {
         $describer = new SelfDescribingModelDescriber();
 
-        $this->assertFalse($describer->supports(new Model(new Type('object', false, stdClass::class))));
+        $this->assertFalse($describer->supports(new Model(new Type('object', false, \stdClass::class))));
     }
 
     public function testDescribe()

--- a/tests/Render/RenderOpenApiTest.php
+++ b/tests/Render/RenderOpenApiTest.php
@@ -11,7 +11,6 @@
 
 namespace Nelmio\ApiDocBundle\Tests\Render;
 
-use InvalidArgumentException;
 use Nelmio\ApiDocBundle\Render\OpenApiRenderer;
 use Nelmio\ApiDocBundle\Render\RenderOpenApi;
 use OpenApi\Annotations\OpenApi;
@@ -35,14 +34,14 @@ class RenderOpenApiTest extends TestCase
     public function testUnknownFormat()
     {
         $availableOpenApiRenderers = [];
-        $this->expectExceptionObject(new InvalidArgumentException(sprintf('Format "%s" is not supported.', $this->format)));
+        $this->expectExceptionObject(new \InvalidArgumentException(sprintf('Format "%s" is not supported.', $this->format)));
         $this->renderOpenApi(...$availableOpenApiRenderers);
     }
 
     public function testUnknownArea()
     {
         $this->hasArea = false;
-        $this->expectExceptionObject(new InvalidArgumentException(sprintf('Area "%s" is not supported.', $this->area)));
+        $this->expectExceptionObject(new \InvalidArgumentException(sprintf('Area "%s" is not supported.', $this->area)));
         $this->renderOpenApi();
     }
 

--- a/tests/RouteDescriber/FosRestDescriberTest.php
+++ b/tests/RouteDescriber/FosRestDescriberTest.php
@@ -16,7 +16,6 @@ use FOS\RestBundle\Controller\Annotations\QueryParam;
 use Nelmio\ApiDocBundle\RouteDescriber\FosRestDescriber;
 use OpenApi\Annotations\OpenApi;
 use PHPUnit\Framework\TestCase;
-use ReflectionMethod;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Validator\Constraints\Choice;
@@ -48,7 +47,7 @@ class FosRestDescriberTest extends TestCase
         $fosRestDescriber->describe(
             $api,
             new Route('/'),
-            $this->createMock(ReflectionMethod::class)
+            $this->createMock(\ReflectionMethod::class)
         );
 
         $this->assertSame($choices, $api->paths[0]->get->parameters[0]->schema->enum);

--- a/tests/RouteDescriber/RouteMetadataDescriberTest.php
+++ b/tests/RouteDescriber/RouteMetadataDescriberTest.php
@@ -16,7 +16,6 @@ use OpenApi\Annotations\OpenApi;
 use OpenApi\Context;
 use OpenApi\Generator;
 use PHPUnit\Framework\TestCase;
-use ReflectionMethod;
 use Symfony\Component\Routing\Route;
 
 class RouteMetadataDescriberTest extends TestCase
@@ -25,7 +24,7 @@ class RouteMetadataDescriberTest extends TestCase
     {
         $routeDescriber = new RouteMetadataDescriber();
 
-        $this->assertNull($routeDescriber->describe(new OpenApi(['_context' => new Context()]), new Route('foo'), new ReflectionMethod(__CLASS__, 'testUndefinedCheck')));
+        $this->assertNull($routeDescriber->describe(new OpenApi(['_context' => new Context()]), new Route('foo'), new \ReflectionMethod(__CLASS__, 'testUndefinedCheck')));
     }
 
     public function testRouteRequirementsWithPattern()
@@ -36,7 +35,7 @@ class RouteMetadataDescriberTest extends TestCase
         $routeDescriber->describe(
             $api,
             $route,
-            new ReflectionMethod(__CLASS__, 'testRouteRequirementsWithPattern')
+            new \ReflectionMethod(__CLASS__, 'testRouteRequirementsWithPattern')
         );
 
         $this->assertEquals('/index/{bar}/{foo}.html', $api->paths[0]->path);
@@ -60,7 +59,7 @@ class RouteMetadataDescriberTest extends TestCase
         $routeDescriber->describe(
             $api,
             $route,
-            new ReflectionMethod(__CLASS__, 'testSimpleOrRequirementsAreHandledAsEnums')
+            new \ReflectionMethod(__CLASS__, 'testSimpleOrRequirementsAreHandledAsEnums')
         );
 
         $this->assertEquals('/index/{bar}/{foo}.html', $api->paths[0]->path);
@@ -83,7 +82,7 @@ class RouteMetadataDescriberTest extends TestCase
         $routeDescriber->describe(
             $api,
             $route,
-            new ReflectionMethod(__CLASS__, 'testNonEnumPatterns')
+            new \ReflectionMethod(__CLASS__, 'testNonEnumPatterns')
         );
 
         $getPathParameter = $api->paths[0]->get->parameters[0];

--- a/tests/Routing/FilteredRouteCollectionBuilderTest.php
+++ b/tests/Routing/FilteredRouteCollectionBuilderTest.php
@@ -20,14 +20,11 @@ use Nelmio\ApiDocBundle\Util\ControllerReflector;
 use OpenApi\Annotations\Parameter;
 use OpenApi\Context;
 use PHPUnit\Framework\TestCase;
-use ReflectionMethod;
-use stdClass;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\OptionsResolver\Exception\InvalidArgumentException;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
-use const PHP_VERSION_ID;
 
 /**
  * Tests for FilteredRouteCollectionBuilder class.
@@ -124,7 +121,7 @@ class FilteredRouteCollectionBuilderTest extends TestCase
             [['invalid_option' => []]],
             [['path_patterns' => [22]]],
             [['path_patterns' => [null]]],
-            [['path_patterns' => [new stdClass()]]],
+            [['path_patterns' => [new \stdClass()]]],
             [['path_patterns' => ['^/foo$', 1]]],
             [['with_annotation' => ['an array']]],
             [['path_patterns' => 'a string']],
@@ -133,7 +130,7 @@ class FilteredRouteCollectionBuilderTest extends TestCase
             [['name_patterns' => 'a string']],
             [['name_patterns' => [22]]],
             [['name_patterns' => [null]]],
-            [['name_patterns' => [new stdClass()]]],
+            [['name_patterns' => [new \stdClass()]]],
         ];
     }
 
@@ -183,7 +180,7 @@ class FilteredRouteCollectionBuilderTest extends TestCase
             ['r10', new Route('/api/areas/new'), ['path_patterns' => ['^/api']]],
         ];
 
-        if (PHP_VERSION_ID < 80000) {
+        if (\PHP_VERSION_ID < 80000) {
             yield ['r10', new Route('/api/areas_attributes/new'), ['path_patterns' => ['^/api']]];
         }
     }
@@ -199,7 +196,7 @@ class FilteredRouteCollectionBuilderTest extends TestCase
         $routes->add($name, $route);
         $area = 'area';
 
-        $reflectionMethodStub = $this->createMock(ReflectionMethod::class);
+        $reflectionMethodStub = $this->createMock(\ReflectionMethod::class);
         $controllerReflectorStub = $this->createMock(ControllerReflector::class);
         $controllerReflectorStub->method('getReflectionMethod')->willReturn($reflectionMethodStub);
 
@@ -239,7 +236,7 @@ class FilteredRouteCollectionBuilderTest extends TestCase
             ],
         ];
 
-        if (PHP_VERSION_ID < 80000) {
+        if (\PHP_VERSION_ID < 80000) {
             yield from [
                 'with attribute only' => [
                     'r10',
@@ -290,7 +287,7 @@ class FilteredRouteCollectionBuilderTest extends TestCase
      * @dataProvider getRoutesWithDisabledDefaultRoutes
      *
      * @param array<Operation|Parameter> $annotations
-     * @param array<string|boolean>      $options
+     * @param array<string|bool>         $options
      */
     public function testRoutesWithDisabledDefaultRoutes(
         string $name,
@@ -303,7 +300,7 @@ class FilteredRouteCollectionBuilderTest extends TestCase
         $routes->add($name, $route);
         $area = 'area';
 
-        $reflectionMethodStub = $this->createMock(ReflectionMethod::class);
+        $reflectionMethodStub = $this->createMock(\ReflectionMethod::class);
         $controllerReflectorStub = $this->createMock(ControllerReflector::class);
         $controllerReflectorStub->method('getReflectionMethod')->willReturn($reflectionMethodStub);
 

--- a/tests/SwaggerPhp/UtilTest.php
+++ b/tests/SwaggerPhp/UtilTest.php
@@ -11,22 +11,12 @@
 
 namespace Nelmio\ApiDocBundle\Tests\SwaggerPhp;
 
-use ArrayObject;
 use Exception;
 use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 use OpenApi\Annotations as OA;
 use OpenApi\Context;
 use OpenApi\Generator;
 use PHPUnit\Framework\TestCase;
-use stdClass;
-use function array_key_exists;
-use function array_slice;
-use function count;
-use function get_class;
-use function get_class_vars;
-use function get_object_vars;
-use function in_array;
-use function strpos;
 
 /**
  * Class UtilTest.
@@ -113,8 +103,8 @@ class UtilTest extends TestCase
         /** @var OA\Info $info */
         $info = Util::createChild($this->rootAnnotation, OA\Info::class, $properties);
 
-        $properties = array_filter(get_object_vars($info), function ($key) {
-            return 0 !== strpos($key, '_');
+        $properties = array_filter(\get_object_vars($info), function ($key) {
+            return 0 !== \strpos($key, '_');
         }, ARRAY_FILTER_USE_KEY);
 
         $this->assertEquals([Generator::UNDEFINED], array_unique(array_values($properties)));
@@ -125,7 +115,7 @@ class UtilTest extends TestCase
 
     public function testCreateChildWithProperties()
     {
-        $properties = ['title' => 'testing', 'version' => '999', 'x' => new stdClass()];
+        $properties = ['title' => 'testing', 'version' => '999', 'x' => new \stdClass()];
         /** @var OA\Info $info */
         $info = Util::createChild($this->rootAnnotation, OA\Info::class, $properties);
 
@@ -185,12 +175,12 @@ class UtilTest extends TestCase
 
     public function testSearchCollectionItem()
     {
-        $item1 = new stdClass();
+        $item1 = new \stdClass();
         $item1->prop1 = 'item 1 prop 1';
         $item1->prop2 = 'item 1 prop 2';
         $item1->prop3 = 'item 1 prop 3';
 
-        $item2 = new stdClass();
+        $item2 = new \stdClass();
         $item2->prop1 = 'item 2 prop 1';
         $item2->prop2 = 'item 2 prop 2';
         $item2->prop3 = 'item 2 prop 3';
@@ -200,25 +190,25 @@ class UtilTest extends TestCase
             $item2,
         ];
 
-        $this->assertSame(0, Util::searchCollectionItem($collection, get_object_vars($item1)));
-        $this->assertSame(1, Util::searchCollectionItem($collection, get_object_vars($item2)));
+        $this->assertSame(0, Util::searchCollectionItem($collection, \get_object_vars($item1)));
+        $this->assertSame(1, Util::searchCollectionItem($collection, \get_object_vars($item2)));
 
         $this->assertNull(Util::searchCollectionItem(
             $collection,
-            array_merge(get_object_vars($item2), ['prop3' => 'foobar'])
+            array_merge(\get_object_vars($item2), ['prop3' => 'foobar'])
         ));
 
         $search = ['baz' => 'foobar'];
         $this->expectOutputString('Undefined property: stdClass::$baz');
 
         try {
-            Util::searchCollectionItem($collection, array_merge(get_object_vars($item2), $search));
-        } catch (Exception $e) {
+            Util::searchCollectionItem($collection, array_merge(\get_object_vars($item2), $search));
+        } catch (\Exception $e) {
             echo $e->getMessage();
         }
 
         // no exception on empty collection
-        $this->assertNull(Util::searchCollectionItem([], get_object_vars($item2)));
+        $this->assertNull(Util::searchCollectionItem([], \get_object_vars($item2)));
     }
 
     /**
@@ -233,7 +223,7 @@ class UtilTest extends TestCase
                     (Generator::UNDEFINED !== $setup['components']->{$collection} ? $setup['components']->{$collection} : []);
 
                 // get the indexing correct within haystack preparation
-                $properties = array_fill(0, count($setupCollection), null);
+                $properties = array_fill(0, \count($setupCollection), null);
 
                 // prepare the haystack array
                 foreach ($items as $assertItem) {
@@ -284,7 +274,7 @@ class UtilTest extends TestCase
                     $setup['components']->{$collection} ?? [];
 
                 // the children created within provider are not connected
-                if (!in_array($child, $setupHaystack, true)) {
+                if (!\in_array($child, $setupHaystack, true)) {
                     $this->assertIsNested($itemParent, $child);
                     $this->assertIsConnectedToRootContext($child);
                 }
@@ -389,7 +379,7 @@ class UtilTest extends TestCase
         ));
 
         foreach ($asserts as $key => $assert) {
-            if (array_key_exists('exceptionMessage', $assert)) {
+            if (\array_key_exists('exceptionMessage', $assert)) {
                 $this->expectExceptionMessage($assert['exceptionMessage']);
             }
             $child = Util::getChild($parent, $assert['class'], $assert['props']);
@@ -397,7 +387,7 @@ class UtilTest extends TestCase
             $this->assertInstanceOf($assert['class'], $child);
             $this->assertSame($child, $parent->{$key});
 
-            if (array_key_exists($key, $setup)) {
+            if (\array_key_exists($key, $setup)) {
                 $this->assertSame($setup[$key], $parent->{$key});
             }
 
@@ -577,8 +567,8 @@ class UtilTest extends TestCase
                 'info' => ['title' => $yes, 'version' => $yes],
             ],
             'assert' => [
-                    'info' => ['title' => $yes, 'version' => $no],
-                ] + $assertDefaults,
+                'info' => ['title' => $yes, 'version' => $no],
+            ] + $assertDefaults,
         ], [
             // Parse server url with variables, see https://github.com/nelmio/NelmioApiDocBundle/issues/1691
             'setup' => $setupDefaults,
@@ -601,12 +591,12 @@ class UtilTest extends TestCase
         ], [
             // indexed collection merge
             'setup' => [
-                    'components' => $this->createObj(OA\Components::class, [
-                        'schemas' => [
-                            $this->createObj(OA\Schema::class, ['schema' => $no, 'title' => $no]),
-                        ],
-                    ]),
-                ] + $setupDefaults,
+                'components' => $this->createObj(OA\Components::class, [
+                    'schemas' => [
+                        $this->createObj(OA\Schema::class, ['schema' => $no, 'title' => $no]),
+                    ],
+                ]),
+            ] + $setupDefaults,
             'merge' => [
                 'components' => [
                     'schemas' => [
@@ -615,17 +605,17 @@ class UtilTest extends TestCase
                 ],
             ],
             'assert' => [
-                    'components' => [
-                        'schemas' => [
-                            $no => ['title' => $no, 'description' => $yes],
-                        ],
+                'components' => [
+                    'schemas' => [
+                        $no => ['title' => $no, 'description' => $yes],
                     ],
-                ] + $assertDefaults,
+                ],
+            ] + $assertDefaults,
         ], [
             // collection merge
             'setup' => [
-                    'tags' => [$this->createObj(OA\Tag::class, ['name' => $no])],
-                ] + $setupDefaults,
+                'tags' => [$this->createObj(OA\Tag::class, ['name' => $no])],
+            ] + $setupDefaults,
             'merge' => [
                 'tags' => [
                     // this is actually appending right now, no clue if this is wanted,
@@ -641,12 +631,12 @@ class UtilTest extends TestCase
                 ],
             ],
             'assert' => [
-                    'tags' => [
-                        ['name' => $no],
-                        ['name' => $yes],
-                        ['name' => $no, 'description' => $yes],
-                    ],
-                ] + $assertDefaults,
+                'tags' => [
+                    ['name' => $no],
+                    ['name' => $yes],
+                    ['name' => $no, 'description' => $yes],
+                ],
+            ] + $assertDefaults,
         ],
             [
                 // heavy nested merge array
@@ -707,25 +697,25 @@ class UtilTest extends TestCase
                 'assert' => array_merge(
                     $assertDefaults,
                     $merge,
-                    ['tags' => array_slice($merge['tags'], 0, 2, true)]
+                    ['tags' => \array_slice($merge['tags'], 0, 2, true)]
                 ),
             ], [
                 // heavy nested merge array object
                 'setup' => $setupDefaults,
-                'merge' => new ArrayObject([
+                'merge' => new \ArrayObject([
                     'servers' => [
                         ['url' => 'http'],
                         ['url' => 'https'],
                     ],
                     'paths' => [
                         '/path/to/resource' => [
-                            'get' => new ArrayObject([
+                            'get' => new \ArrayObject([
                                 'responses' => [
                                     '200' => [
                                         '$ref' => '#/components/responses/default',
                                     ],
                                 ],
-                                'requestBody' => new ArrayObject([
+                                'requestBody' => new \ArrayObject([
                                     'description' => 'request foo',
                                     'content' => [
                                         'foo-request' => [
@@ -739,22 +729,22 @@ class UtilTest extends TestCase
                             ]),
                         ],
                     ],
-                    'tags' => new ArrayObject([
+                    'tags' => new \ArrayObject([
                         ['name' => 'baz'],
                         ['name' => 'foo'],
-                        new ArrayObject(['name' => 'baz']),
+                        new \ArrayObject(['name' => 'baz']),
                         ['name' => 'foo'],
                         ['name' => 'foo'],
                     ]),
-                    'components' => new ArrayObject([
+                    'components' => new \ArrayObject([
                         'responses' => [
                             'default' => [
                                 'description' => 'default response',
-                                'headers' => new ArrayObject([
-                                    'foo-header' => new ArrayObject([
-                                        'schema' => new ArrayObject([
+                                'headers' => new \ArrayObject([
+                                    'foo-header' => new \ArrayObject([
+                                        'schema' => new \ArrayObject([
                                             'type' => 'array',
-                                            'items' => new ArrayObject([
+                                            'items' => new \ArrayObject([
                                                 'type' => 'string',
                                                 'enum' => ['foo', 'bar', 'baz'],
                                             ]),
@@ -768,7 +758,7 @@ class UtilTest extends TestCase
                 'assert' => array_merge(
                     $assertDefaults,
                     $merge,
-                    ['tags' => array_slice($merge['tags'], 0, 2, true)]
+                    ['tags' => \array_slice($merge['tags'], 0, 2, true)]
                 ),
             ], [
                 // heavy nested merge swagger instance
@@ -834,7 +824,7 @@ class UtilTest extends TestCase
                 'assert' => array_merge(
                     $assertDefaults,
                     $merge,
-                    ['tags' => array_slice($merge['tags'], 0, 2, true)]
+                    ['tags' => \array_slice($merge['tags'], 0, 2, true)]
                 ),
             ], ];
     }
@@ -862,11 +852,11 @@ class UtilTest extends TestCase
 
     private function getNonDefaultProperties($object)
     {
-        $objectVars = get_object_vars($object);
-        $classVars = get_class_vars(get_class($object));
+        $objectVars = \get_object_vars($object);
+        $classVars = \get_class_vars(\get_class($object));
         $props = [];
         foreach ($objectVars as $key => $value) {
-            if ($value !== $classVars[$key] && 0 !== strpos($key, '_')) {
+            if ($value !== $classVars[$key] && 0 !== \strpos($key, '_')) {
                 $props[$key] = $value;
             }
         }

--- a/tests/Util/ControllerReflectorTest.php
+++ b/tests/Util/ControllerReflectorTest.php
@@ -1,11 +1,19 @@
 <?php
 
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Nelmio\ApiDocBundle\Tests\Util;
 
 use Nelmio\ApiDocBundle\Tests\Functional\Controller\BazingaController;
 use Nelmio\ApiDocBundle\Util\ControllerReflector;
 use PHPUnit\Framework\TestCase;
-use ReflectionMethod;
 use Symfony\Component\DependencyInjection\Container;
 
 class ControllerReflectorTest extends TestCase
@@ -14,11 +22,11 @@ class ControllerReflectorTest extends TestCase
     {
         $controllerReflector = new ControllerReflector(new Container());
         $this->assertEquals(
-            ReflectionMethod::class,
+            \ReflectionMethod::class,
             get_class($controllerReflector->getReflectionMethod([BazingaController::class, 'userAction']))
         );
         $this->assertEquals(
-            ReflectionMethod::class,
+            \ReflectionMethod::class,
             get_class($controllerReflector->getReflectionMethod(BazingaController::class.'::userAction'))
         );
         $this->assertNull(


### PR DESCRIPTION
| Q             | A  |
|---------------|----|
| Bug fix?      | no |
| New feature?  | no |
| Deprecations? | no |
| Issues        | /  |

As there are currently efforts to introduce PHPStan (see #2249), I thought of also introducing PHP-CS-Fixer as a dev dependency (to additionally improve the code quality) and using/upgrading the existing config file. 

**Already done:**
- Introduce [`PHP-CS-Fixer`](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer) as a dev dependency
- Upgrade the existing config
- Run PHP-CS-Fixer on the project files

**Possible further steps as part of this PR that need to be discussed:**
- Replace StyleCI with a PHP-CS-Fixer job as part of the GitHub Actions `CI`/`continuous-integration` workflow (to have a single source of truth regarding code style)?
  - Run PHP-CS-Fixer on same test matrix as PHPUnit[^1] or just on latest supported PHP version (e.g. 8.3)?

[^1]: This approach will not work on PHP 7.4 and PHP 8.0 as some files already use newer syntax leading to failures in these jobs.