### PR TITLE
fix: Generate operationids properly

### DIFF
--- a/src/Describer/OpenApiPhpDescriber.php
+++ b/src/Describer/OpenApiPhpDescriber.php
@@ -93,10 +93,6 @@ final class OpenApiPhpDescriber
 
             $annotations = array_merge($annotations, $this->getAttributesAsAnnotation($method, $context));
 
-            if (0 === count($annotations) && 0 === count($classAnnotations[$declaringClass->getName()])) {
-                continue;
-            }
-
             $implicitAnnotations = [];
             $mergeProperties = new \stdClass();
 
@@ -157,14 +153,14 @@ final class OpenApiPhpDescriber
                 $implicitAnnotations[] = $annotation;
             }
 
-            if ([] === $implicitAnnotations && [] === get_object_vars($mergeProperties)) {
-                continue;
-            }
-
             foreach ($httpMethods as $httpMethod) {
                 $operation = Util::getOperation($path, $httpMethod);
-                $operation->merge($implicitAnnotations);
-                $operation->mergeProperties($mergeProperties);
+                if ([] !== $implicitAnnotations) {
+                    $operation->merge($implicitAnnotations);
+                }
+                if ([] !== get_object_vars($mergeProperties)) {
+                    $operation->mergeProperties($mergeProperties);
+                }
 
                 if (Generator::UNDEFINED === $operation->operationId) {
                     $operation->operationId = $httpMethod.'_'.$routeName;

--- a/tests/Functional/Controller/OperationIdController.php
+++ b/tests/Functional/Controller/OperationIdController.php
@@ -18,6 +18,14 @@ use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
+/*
+ * Not all operationIds were generqted properly. This test case covers the following scenarios:
+ * - routes with unnamed symfony route annotations (fall back to SF naming strategy)
+ * - routes combined with OA\Get annotations
+ * - routes with OA\Get annotations and additional ApiDoc root annotations
+ * - routes with operationId explicitly set
+
+ */
 class OperationIdController
 {
     // a route with only a symfony route annotation (generates GET Operation using available metadata as operationId)
@@ -26,6 +34,7 @@ class OperationIdController
     {
         return new JsonResponse();
     }
+
     // a route with a named symfony route annotation (generates GET Operation using route name as operationId)
     #[Route(path: '/generate/operation_id_route', name: 'named_route', methods: 'GET')]
     public function getMustGenerateOperationIdByRouteAnnotation(): JsonResponse
@@ -50,9 +59,9 @@ class OperationIdController
         return new JsonResponse();
     }
 
-   // custom operationId is uesed when set explicitly
+    // custom operationId is uesed when set explicitly
     #[Route(path: '/has/explicit/operationid', name: 'customOperationId', methods: 'GET')]
-    #[OA\Get(summary: 'Custom operation id must be taken', operationId: 'customOperationId')]
+    #[OA\Get(summary: 'Custom operation id must be used if provided', operationId: 'customOperationId')]
     public function getWithCustomOperationId(): JsonResponse
     {
         return new JsonResponse();

--- a/tests/Functional/Controller/OperationIdController.php
+++ b/tests/Functional/Controller/OperationIdController.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
+
+use Nelmio\ApiDocBundle\Annotation\Security;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class OperationIdController
+{
+    // a route with only a symfony route annotation (generate GET with
+    #[Route(path: '/generate/operation_id_route', name: 'only_route', methods: 'GET')]
+    public function getMustGenerateOperationIdByRouteAnnotation(): JsonResponse
+    {
+        return new JsonResponse();
+    }
+
+    // a route with an OA\GET annotation
+    #[Route(path: '/generate/operation_id_get', name: 'get_annotation', methods: 'GET')]
+    #[OA\Get(summary: 'OperationId must be generated automatically if not provided')]
+    public function getMustGenerateOperationIByGetAnnotation(): JsonResponse
+    {
+        return new JsonResponse();
+    }
+
+    #[Route(path: '/has/explicit/operationid', name: 'customOperationId', methods: 'GET')]
+    #[OA\Get(summary: 'Custom operation id must be taken', operationId: 'customOperationId')]
+    public function getWithCustomOperationId(): JsonResponse
+    {
+        return new JsonResponse();
+    }
+
+    #[Route(path: '/generate/operation_id_with_security/', name: 'with_security', methods: 'GET')]
+    #[OA\Get('OperationId must be generated automatically when additional OA/nelmio root annotations are present')]
+    #[Security(name: 'bearerAuth')] // additioanl root annotations
+    public function getWithAdditionalAnnotationsGeneratesOperationId(): JsonResponse
+    {
+        return new JsonResponse();
+    }
+}

--- a/tests/Functional/Controller/OperationIdController.php
+++ b/tests/Functional/Controller/OperationIdController.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
 /*
- * Not all operationIds were generqted properly. This test case covers the following scenarios:
+ * Not all operationIds were generated properly. This test case covers the following scenarios:
  * - routes with unnamed symfony route annotations (fall back to SF naming strategy)
  * - routes combined with OA\Get annotations
  * - routes with OA\Get annotations and additional ApiDoc root annotations

--- a/tests/Functional/Controller/OperationIdController.php
+++ b/tests/Functional/Controller/OperationIdController.php
@@ -20,14 +20,29 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class OperationIdController
 {
-    // a route with only a symfony route annotation (generate GET with
-    #[Route(path: '/generate/operation_id_route', name: 'only_route', methods: 'GET')]
+    // a route with only a symfony route annotation (generates GET Operation using available metadata as operationId)
+    #[Route(path: '/generate/operation_id_route_unnamed', methods: 'GET')]
+    public function getMustGenerateOperationIdByUnnamedRouteAnnotation(): JsonResponse
+    {
+        return new JsonResponse();
+    }
+    // a route with a named symfony route annotation (generates GET Operation using route name as operationId)
+    #[Route(path: '/generate/operation_id_route', name: 'named_route', methods: 'GET')]
     public function getMustGenerateOperationIdByRouteAnnotation(): JsonResponse
     {
         return new JsonResponse();
     }
 
-    // a route with an OA\GET annotation
+    // a route with an OA\Get annotation and a separate ApiDoc Annotation(extends GET operation with operationId)
+    #[Route(path: '/generate/operation_id_with_security/', name: 'with_security', methods: 'GET')]
+    #[OA\Get('OperationId must be generated automatically when additional OA/nelmio root annotations are present')]
+    #[Security(name: 'bearerAuth')] // additioanl root annotations
+    public function getWithAdditionalAnnotationsGeneratesOperationId(): JsonResponse
+    {
+        return new JsonResponse();
+    }
+
+    // a route with an OA\GET annotation (extends GET operation with operationId)
     #[Route(path: '/generate/operation_id_get', name: 'get_annotation', methods: 'GET')]
     #[OA\Get(summary: 'OperationId must be generated automatically if not provided')]
     public function getMustGenerateOperationIByGetAnnotation(): JsonResponse
@@ -35,17 +50,10 @@ class OperationIdController
         return new JsonResponse();
     }
 
+   // custom operationId is uesed when set explicitly
     #[Route(path: '/has/explicit/operationid', name: 'customOperationId', methods: 'GET')]
     #[OA\Get(summary: 'Custom operation id must be taken', operationId: 'customOperationId')]
     public function getWithCustomOperationId(): JsonResponse
-    {
-        return new JsonResponse();
-    }
-
-    #[Route(path: '/generate/operation_id_with_security/', name: 'with_security', methods: 'GET')]
-    #[OA\Get('OperationId must be generated automatically when additional OA/nelmio root annotations are present')]
-    #[Security(name: 'bearerAuth')] // additioanl root annotations
-    public function getWithAdditionalAnnotationsGeneratesOperationId(): JsonResponse
     {
         return new JsonResponse();
     }

--- a/tests/Functional/Controller/OperationIdController.php
+++ b/tests/Functional/Controller/OperationIdController.php
@@ -59,7 +59,7 @@ class OperationIdController
         return new JsonResponse();
     }
 
-    // custom operationId is uesed when set explicitly
+    // custom operationId is used when set explicitly
     #[Route(path: '/has/explicit/operationid', name: 'customOperationId', methods: 'GET')]
     #[OA\Get(summary: 'Custom operation id must be used if provided', operationId: 'customOperationId')]
     public function getWithCustomOperationId(): JsonResponse

--- a/tests/Functional/ControllerTest.php
+++ b/tests/Functional/ControllerTest.php
@@ -119,6 +119,14 @@ final class ControllerTest extends WebTestCase
                 'MapQueryStringCleanupComponents',
                 [__DIR__.'/Configs/CleanUnusedComponentsProcessor.yaml'],
             ];
+            // if ('attribute' === $type) {
+            yield 'operationId must always be generated' => [
+                [
+                    'name' => 'OperationIdController',
+                    'type' => $type,
+                ],
+            ];
+            // }
         }
     }
 

--- a/tests/Functional/ControllerTest.php
+++ b/tests/Functional/ControllerTest.php
@@ -119,14 +119,13 @@ final class ControllerTest extends WebTestCase
                 'MapQueryStringCleanupComponents',
                 [__DIR__.'/Configs/CleanUnusedComponentsProcessor.yaml'],
             ];
-            // if ('attribute' === $type) {
+
             yield 'operationId must always be generated' => [
                 [
                     'name' => 'OperationIdController',
                     'type' => $type,
                 ],
             ];
-            // }
         }
     }
 

--- a/tests/Functional/Fixtures/MapQueryStringCleanupComponents.json
+++ b/tests/Functional/Fixtures/MapQueryStringCleanupComponents.json
@@ -7,6 +7,7 @@
     "paths": {
         "/article_map_query_string": {
             "get": {
+                "operationId": "get_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystring",
                 "parameters": [
                     {
                         "name": "id",
@@ -62,6 +63,7 @@
                 }
             },
             "put": {
+                "operationId": "put_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystring",
                 "parameters": [
                     {
                         "name": "id",
@@ -117,6 +119,7 @@
                 }
             },
             "post": {
+                "operationId": "post_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystring",
                 "parameters": [
                     {
                         "name": "id",
@@ -172,6 +175,7 @@
                 }
             },
             "delete": {
+                "operationId": "delete_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystring",
                 "parameters": [
                     {
                         "name": "id",
@@ -227,6 +231,7 @@
                 }
             },
             "options": {
+                "operationId": "options_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystring",
                 "parameters": [
                     {
                         "name": "id",
@@ -282,6 +287,7 @@
                 }
             },
             "head": {
+                "operationId": "head_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystring",
                 "parameters": [
                     {
                         "name": "id",
@@ -337,6 +343,7 @@
                 }
             },
             "patch": {
+                "operationId": "patch_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystring",
                 "parameters": [
                     {
                         "name": "id",
@@ -392,6 +399,7 @@
                 }
             },
             "trace": {
+                "operationId": "trace_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystring",
                 "parameters": [
                     {
                         "name": "id",
@@ -449,6 +457,7 @@
         },
         "/article_map_query_string_nullable": {
             "get": {
+                "operationId": "get_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringnullable",
                 "parameters": [
                     {
                         "name": "id",
@@ -504,6 +513,7 @@
                 }
             },
             "put": {
+                "operationId": "put_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringnullable",
                 "parameters": [
                     {
                         "name": "id",
@@ -559,6 +569,7 @@
                 }
             },
             "post": {
+                "operationId": "post_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringnullable",
                 "parameters": [
                     {
                         "name": "id",
@@ -614,6 +625,7 @@
                 }
             },
             "delete": {
+                "operationId": "delete_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringnullable",
                 "parameters": [
                     {
                         "name": "id",
@@ -669,6 +681,7 @@
                 }
             },
             "options": {
+                "operationId": "options_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringnullable",
                 "parameters": [
                     {
                         "name": "id",
@@ -724,6 +737,7 @@
                 }
             },
             "head": {
+                "operationId": "head_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringnullable",
                 "parameters": [
                     {
                         "name": "id",
@@ -779,6 +793,7 @@
                 }
             },
             "patch": {
+                "operationId": "patch_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringnullable",
                 "parameters": [
                     {
                         "name": "id",
@@ -834,6 +849,7 @@
                 }
             },
             "trace": {
+                "operationId": "trace_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringnullable",
                 "parameters": [
                     {
                         "name": "id",
@@ -891,6 +907,7 @@
         },
         "/article_map_query_string_passes_validation_groups": {
             "get": {
+                "operationId": "get_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringhandlesvalidationgroups",
                 "parameters": [
                     {
                         "name": "property",
@@ -931,6 +948,7 @@
                 }
             },
             "put": {
+                "operationId": "put_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringhandlesvalidationgroups",
                 "parameters": [
                     {
                         "name": "property",
@@ -971,6 +989,7 @@
                 }
             },
             "post": {
+                "operationId": "post_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringhandlesvalidationgroups",
                 "parameters": [
                     {
                         "name": "property",
@@ -1011,6 +1030,7 @@
                 }
             },
             "delete": {
+                "operationId": "delete_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringhandlesvalidationgroups",
                 "parameters": [
                     {
                         "name": "property",
@@ -1051,6 +1071,7 @@
                 }
             },
             "options": {
+                "operationId": "options_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringhandlesvalidationgroups",
                 "parameters": [
                     {
                         "name": "property",
@@ -1091,6 +1112,7 @@
                 }
             },
             "head": {
+                "operationId": "head_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringhandlesvalidationgroups",
                 "parameters": [
                     {
                         "name": "property",
@@ -1131,6 +1153,7 @@
                 }
             },
             "patch": {
+                "operationId": "patch_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringhandlesvalidationgroups",
                 "parameters": [
                     {
                         "name": "property",
@@ -1171,6 +1194,7 @@
                 }
             },
             "trace": {
+                "operationId": "trace_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringhandlesvalidationgroups",
                 "parameters": [
                     {
                         "name": "property",
@@ -1213,6 +1237,7 @@
         },
         "/article_map_query_string_overwrite_parameters": {
             "get": {
+                "operationId": "get_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringoverwriteparameters",
                 "parameters": [
                     {
                         "name": "id",
@@ -1268,6 +1293,7 @@
                 }
             },
             "put": {
+                "operationId": "put_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringoverwriteparameters",
                 "parameters": [
                     {
                         "name": "id",
@@ -1323,6 +1349,7 @@
                 }
             },
             "post": {
+                "operationId": "post_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringoverwriteparameters",
                 "parameters": [
                     {
                         "name": "id",
@@ -1378,6 +1405,7 @@
                 }
             },
             "delete": {
+                "operationId": "delete_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringoverwriteparameters",
                 "parameters": [
                     {
                         "name": "id",
@@ -1433,6 +1461,7 @@
                 }
             },
             "options": {
+                "operationId": "options_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringoverwriteparameters",
                 "parameters": [
                     {
                         "name": "id",
@@ -1488,6 +1517,7 @@
                 }
             },
             "head": {
+                "operationId": "head_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringoverwriteparameters",
                 "parameters": [
                     {
                         "name": "id",
@@ -1543,6 +1573,7 @@
                 }
             },
             "patch": {
+                "operationId": "patch_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringoverwriteparameters",
                 "parameters": [
                     {
                         "name": "id",
@@ -1598,6 +1629,7 @@
                 }
             },
             "trace": {
+                "operationId": "trace_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringoverwriteparameters",
                 "parameters": [
                     {
                         "name": "id",
@@ -1655,6 +1687,7 @@
         },
         "/article_map_query_string_many_parameters": {
             "get": {
+                "operationId": "get_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -1743,6 +1776,7 @@
                 }
             },
             "put": {
+                "operationId": "put_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -1831,6 +1865,7 @@
                 }
             },
             "post": {
+                "operationId": "post_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -1919,6 +1954,7 @@
                 }
             },
             "delete": {
+                "operationId": "delete_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2007,6 +2043,7 @@
                 }
             },
             "options": {
+                "operationId": "options_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2095,6 +2132,7 @@
                 }
             },
             "head": {
+                "operationId": "head_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2183,6 +2221,7 @@
                 }
             },
             "patch": {
+                "operationId": "patch_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2271,6 +2310,7 @@
                 }
             },
             "trace": {
+                "operationId": "trace_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2361,6 +2401,7 @@
         },
         "/article_map_query_string_many_parameters_optional": {
             "get": {
+                "operationId": "get_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyoptionalparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2449,6 +2490,7 @@
                 }
             },
             "put": {
+                "operationId": "put_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyoptionalparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2537,6 +2579,7 @@
                 }
             },
             "post": {
+                "operationId": "post_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyoptionalparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2625,6 +2668,7 @@
                 }
             },
             "delete": {
+                "operationId": "delete_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyoptionalparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2713,6 +2757,7 @@
                 }
             },
             "options": {
+                "operationId": "options_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyoptionalparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2801,6 +2846,7 @@
                 }
             },
             "head": {
+                "operationId": "head_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyoptionalparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2889,6 +2935,7 @@
                 }
             },
             "patch": {
+                "operationId": "patch_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyoptionalparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2977,6 +3024,7 @@
                 }
             },
             "trace": {
+                "operationId": "trace_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyoptionalparameters",
                 "parameters": [
                     {
                         "name": "filter",

--- a/tests/Functional/Fixtures/MapQueryStringController.json
+++ b/tests/Functional/Fixtures/MapQueryStringController.json
@@ -7,6 +7,7 @@
     "paths": {
         "/article_map_query_string": {
             "get": {
+                "operationId": "get_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystring",
                 "parameters": [
                     {
                         "name": "id",
@@ -62,6 +63,7 @@
                 }
             },
             "put": {
+                "operationId": "put_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystring",
                 "parameters": [
                     {
                         "name": "id",
@@ -117,6 +119,7 @@
                 }
             },
             "post": {
+                "operationId": "post_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystring",
                 "parameters": [
                     {
                         "name": "id",
@@ -172,6 +175,7 @@
                 }
             },
             "delete": {
+                "operationId": "delete_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystring",
                 "parameters": [
                     {
                         "name": "id",
@@ -227,6 +231,7 @@
                 }
             },
             "options": {
+                "operationId": "options_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystring",
                 "parameters": [
                     {
                         "name": "id",
@@ -282,6 +287,7 @@
                 }
             },
             "head": {
+                "operationId": "head_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystring",
                 "parameters": [
                     {
                         "name": "id",
@@ -337,6 +343,7 @@
                 }
             },
             "patch": {
+                "operationId": "patch_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystring",
                 "parameters": [
                     {
                         "name": "id",
@@ -392,6 +399,7 @@
                 }
             },
             "trace": {
+                "operationId": "trace_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystring",
                 "parameters": [
                     {
                         "name": "id",
@@ -449,6 +457,7 @@
         },
         "/article_map_query_string_nullable": {
             "get": {
+                "operationId": "get_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringnullable",
                 "parameters": [
                     {
                         "name": "id",
@@ -504,6 +513,7 @@
                 }
             },
             "put": {
+                "operationId": "put_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringnullable",
                 "parameters": [
                     {
                         "name": "id",
@@ -559,6 +569,7 @@
                 }
             },
             "post": {
+                "operationId": "post_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringnullable",
                 "parameters": [
                     {
                         "name": "id",
@@ -614,6 +625,7 @@
                 }
             },
             "delete": {
+                "operationId": "delete_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringnullable",
                 "parameters": [
                     {
                         "name": "id",
@@ -669,6 +681,7 @@
                 }
             },
             "options": {
+                "operationId": "options_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringnullable",
                 "parameters": [
                     {
                         "name": "id",
@@ -724,6 +737,7 @@
                 }
             },
             "head": {
+                "operationId": "head_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringnullable",
                 "parameters": [
                     {
                         "name": "id",
@@ -779,6 +793,7 @@
                 }
             },
             "patch": {
+                "operationId": "patch_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringnullable",
                 "parameters": [
                     {
                         "name": "id",
@@ -834,6 +849,7 @@
                 }
             },
             "trace": {
+                "operationId": "trace_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringnullable",
                 "parameters": [
                     {
                         "name": "id",
@@ -891,6 +907,7 @@
         },
         "/article_map_query_string_passes_validation_groups": {
             "get": {
+                "operationId": "get_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringhandlesvalidationgroups",
                 "parameters": [
                     {
                         "name": "property",
@@ -931,6 +948,7 @@
                 }
             },
             "put": {
+                "operationId": "put_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringhandlesvalidationgroups",
                 "parameters": [
                     {
                         "name": "property",
@@ -971,6 +989,7 @@
                 }
             },
             "post": {
+                "operationId": "post_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringhandlesvalidationgroups",
                 "parameters": [
                     {
                         "name": "property",
@@ -1011,6 +1030,7 @@
                 }
             },
             "delete": {
+                "operationId": "delete_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringhandlesvalidationgroups",
                 "parameters": [
                     {
                         "name": "property",
@@ -1051,6 +1071,7 @@
                 }
             },
             "options": {
+                "operationId": "options_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringhandlesvalidationgroups",
                 "parameters": [
                     {
                         "name": "property",
@@ -1091,6 +1112,7 @@
                 }
             },
             "head": {
+                "operationId": "head_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringhandlesvalidationgroups",
                 "parameters": [
                     {
                         "name": "property",
@@ -1131,6 +1153,7 @@
                 }
             },
             "patch": {
+                "operationId": "patch_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringhandlesvalidationgroups",
                 "parameters": [
                     {
                         "name": "property",
@@ -1171,6 +1194,7 @@
                 }
             },
             "trace": {
+                "operationId": "trace_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringhandlesvalidationgroups",
                 "parameters": [
                     {
                         "name": "property",
@@ -1213,6 +1237,7 @@
         },
         "/article_map_query_string_overwrite_parameters": {
             "get": {
+                "operationId": "get_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringoverwriteparameters",
                 "parameters": [
                     {
                         "name": "id",
@@ -1268,6 +1293,7 @@
                 }
             },
             "put": {
+                "operationId": "put_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringoverwriteparameters",
                 "parameters": [
                     {
                         "name": "id",
@@ -1323,6 +1349,7 @@
                 }
             },
             "post": {
+                "operationId": "post_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringoverwriteparameters",
                 "parameters": [
                     {
                         "name": "id",
@@ -1378,6 +1405,7 @@
                 }
             },
             "delete": {
+                "operationId": "delete_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringoverwriteparameters",
                 "parameters": [
                     {
                         "name": "id",
@@ -1433,6 +1461,7 @@
                 }
             },
             "options": {
+                "operationId": "options_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringoverwriteparameters",
                 "parameters": [
                     {
                         "name": "id",
@@ -1488,6 +1517,7 @@
                 }
             },
             "head": {
+                "operationId": "head_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringoverwriteparameters",
                 "parameters": [
                     {
                         "name": "id",
@@ -1543,6 +1573,7 @@
                 }
             },
             "patch": {
+                "operationId": "patch_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringoverwriteparameters",
                 "parameters": [
                     {
                         "name": "id",
@@ -1598,6 +1629,7 @@
                 }
             },
             "trace": {
+                "operationId": "trace_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlefrommapquerystringoverwriteparameters",
                 "parameters": [
                     {
                         "name": "id",
@@ -1655,6 +1687,7 @@
         },
         "/article_map_query_string_many_parameters": {
             "get": {
+                "operationId": "get_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -1743,6 +1776,7 @@
                 }
             },
             "put": {
+                "operationId": "put_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -1831,6 +1865,7 @@
                 }
             },
             "post": {
+                "operationId": "post_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -1919,6 +1954,7 @@
                 }
             },
             "delete": {
+                "operationId": "delete_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2007,6 +2043,7 @@
                 }
             },
             "options": {
+                "operationId": "options_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2095,6 +2132,7 @@
                 }
             },
             "head": {
+                "operationId": "head_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2183,6 +2221,7 @@
                 }
             },
             "patch": {
+                "operationId": "patch_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2271,6 +2310,7 @@
                 }
             },
             "trace": {
+                "operationId": "trace_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2361,6 +2401,7 @@
         },
         "/article_map_query_string_many_parameters_optional": {
             "get": {
+                "operationId": "get_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyoptionalparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2449,6 +2490,7 @@
                 }
             },
             "put": {
+                "operationId": "put_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyoptionalparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2537,6 +2579,7 @@
                 }
             },
             "post": {
+                "operationId": "post_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyoptionalparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2625,6 +2668,7 @@
                 }
             },
             "delete": {
+                "operationId": "delete_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyoptionalparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2713,6 +2757,7 @@
                 }
             },
             "options": {
+                "operationId": "options_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyoptionalparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2801,6 +2846,7 @@
                 }
             },
             "head": {
+                "operationId": "head_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyoptionalparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2889,6 +2935,7 @@
                 }
             },
             "patch": {
+                "operationId": "patch_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyoptionalparameters",
                 "parameters": [
                     {
                         "name": "filter",
@@ -2977,6 +3024,7 @@
                 }
             },
             "trace": {
+                "operationId": "trace_nelmio_apidoc_tests_functional_mapquerystring_fetcharticlewithmanyoptionalparameters",
                 "parameters": [
                     {
                         "name": "filter",

--- a/tests/Functional/Fixtures/OperationIdController.json
+++ b/tests/Functional/Fixtures/OperationIdController.json
@@ -53,7 +53,7 @@
         },
         "/has/explicit/operationid": {
             "get": {
-                "summary": "Custom operation id must be taken",
+                "summary": "Custom operation id must be used if provided",
                 "operationId": "customOperationId",
                 "responses": {
                     "default": {

--- a/tests/Functional/Fixtures/OperationIdController.json
+++ b/tests/Functional/Fixtures/OperationIdController.json
@@ -1,0 +1,55 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "",
+        "version": "0.0.0"
+    },
+    "paths": {
+        "/generate/operation_id_route": {
+            "get": {
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/generate/operation_id_get": {
+            "get": {
+                "summary": "OperationId must be generated automatically if not provided",
+                "operationId": "get_get_annotation",
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/has/explicit/operationid": {
+            "get": {
+                "summary": "Custom operation id must be taken",
+                "operationId": "customOperationId",
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/generate/operation_id_with_security/": {
+            "get": {
+                "operationId": "get_with_security",
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/tests/Functional/Fixtures/OperationIdController.json
+++ b/tests/Functional/Fixtures/OperationIdController.json
@@ -5,14 +5,39 @@
         "version": "0.0.0"
     },
     "paths": {
-        "/generate/operation_id_route": {
+        "/generate/operation_id_route_unnamed": {
             "get": {
-                "operationId": "get_only_route",
+                "operationId": "get_nelmio_apidoc_tests_functional_operationid_getmustgenerateoperationidbyunnamedrouteannotation",
                 "responses": {
                     "default": {
                         "description": ""
                     }
                 }
+            }
+        },
+        "/generate/operation_id_route": {
+            "get": {
+                "operationId": "get_named_route",
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/generate/operation_id_with_security/": {
+            "get": {
+                "operationId": "get_with_security",
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
             }
         },
         "/generate/operation_id_get": {
@@ -35,21 +60,6 @@
                         "description": ""
                     }
                 }
-            }
-        },
-        "/generate/operation_id_with_security/": {
-            "get": {
-                "operationId": "get_with_security",
-                "responses": {
-                    "default": {
-                        "description": ""
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ]
             }
         }
     }

--- a/tests/Functional/Fixtures/OperationIdController.json
+++ b/tests/Functional/Fixtures/OperationIdController.json
@@ -7,6 +7,7 @@
     "paths": {
         "/generate/operation_id_route": {
             "get": {
+                "operationId": "get_only_route",
                 "responses": {
                     "default": {
                         "description": ""

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -89,7 +89,6 @@ class FunctionalTest extends WebTestCase
     public function testSwaggerAction(string $path)
     {
         $operation = $this->getOperation($path, 'get');
-
         $this->assertHasResponse('201', $operation);
         $response = $this->getOperationResponse($operation, '201');
         self::assertEquals('An example resource', $response->description);

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -89,6 +89,7 @@ class FunctionalTest extends WebTestCase
     public function testSwaggerAction(string $path)
     {
         $operation = $this->getOperation($path, 'get');
+
         $this->assertHasResponse('201', $operation);
         $response = $this->getOperationResponse($operation, '201');
         self::assertEquals('An example resource', $response->description);


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                                   |
| New feature?  | no                                                                  |
| Deprecations? | no                                                  |
| Issues        | --- |


*Current behaviour*
 - OperationId is not generated when only using symfony attributes, e.g. #[Route]
 - OperationId is not generated when only using one OA attributes, eg. #[Get] in combination with routes
 - However, some combination results in properly generated OperationIds, e.g. using #[Security] in combination with 
   #[Get] attributes.

*Expected behaviour*
 - In all cases an operationId gets generated from the route information (unless it is explicitly set).

*Implementation*
Test cases have been added for those scenarios. The existing OpenApiPhpDescriber has been updated to always reach the part where the operationId is generated.
 
