### PR TITLE
add check for missing required dependencies

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -152,7 +152,7 @@ jobs:
           install-doctrine-annotations: false
 
       - name: Install Composer Require Checker
-        run: composer require --dev maglnet/composer-require-checker
+        run: composer require --dev --with-all-dependencies maglnet/composer-require-checker
 
       - name: Composer Require Checker
         run: vendor/bin/composer-require-checker

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -127,3 +127,29 @@ jobs:
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse --memory-limit=2G --no-progress --no-interaction
+
+  dependency-check:
+    name: Composer Require Checker
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Install PHP without coverage
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          tools: composer, flex
+          coverage: pcov
+
+      - name: Setup dependencies
+        uses: ./.github/workflows/common/composer-install
+        with:
+          symfony-version: "7.0.*"
+          install-doctrine-annotations: false
+
+      - name: Composer Require Checker
+        run: vendor/bin/composer-require-checker

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Install PHP without coverage
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.2
           tools: composer, flex
           coverage: pcov
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -151,5 +151,8 @@ jobs:
           symfony-version: "7.0.*"
           install-doctrine-annotations: false
 
+      - name: Install Composer Require Checker
+        run: composer require --dev maglnet/composer-require-checker
+
       - name: Composer Require Checker
         run: vendor/bin/composer-require-checker

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "friendsofsymfony/rest-bundle": "^2.8 || ^3.0",
         "jms/serializer": "^1.14 || ^3.0",
         "jms/serializer-bundle": "^2.3 || ^3.0 || ^4.0 || ^5.0",
+        "maglnet/composer-require-checker": "^4.11",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-strict-rules": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,6 @@
         "friendsofsymfony/rest-bundle": "^2.8 || ^3.0",
         "jms/serializer": "^1.14 || ^3.0",
         "jms/serializer-bundle": "^2.3 || ^3.0 || ^4.0 || ^5.0",
-        "maglnet/composer-require-checker": "^4.11",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-strict-rules": "^1.5",


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                                   |
| New feature?  | no                                                                   |
| Deprecations? | no                                                  |
| Issues        |  |


Within a project of mine, I updated all dependencies and after that I got an error because of a missing Class.
This happens because the `symfony/validator` package is not defined as a dependency (only as a dev-dependency) but it seems to be required not only in tests.

This PR does the following:
* [x] check if dependencies used within the `autoload` section are defined as a requirement
* [ ] add missing requirements to composer.json

```
Error: Class "Symfony\Component\Validator\Constraint" not found
/project-dir/vendor/nelmio/api-doc-bundle/src/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php:217
/project-dir/vendor/nelmio/api-doc-bundle/src/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php:196
/project-dir/vendor/nelmio/api-doc-bundle/src/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php:59
/project-dir/vendor/nelmio/api-doc-bundle/src/ModelDescriber/Annotations/AnnotationsReader.php:71
/project-dir/vendor/nelmio/api-doc-bundle/src/ModelDescriber/ObjectModelDescriber.php:174
/project-dir/vendor/nelmio/api-doc-bundle/src/Model/ModelRegistry.php:115
/project-dir/vendor/nelmio/api-doc-bundle/src/ApiDocGenerator.php:135
/project-dir/vendor/nelmio/api-doc-bundle/src/Render/RenderOpenApi.php:85
/project-dir/tests/src/ValidOpenAPISyntaxTest.php:32