### PR TITLE
docs(#2264): adopt Conventional Commits

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -9,14 +9,14 @@ on:
       - synchronize
 
 jobs:
-  lint-pr:
-    name: Validate PR title
+  semantic-pr:
+    name: Validate semantic PR title
     runs-on: ubuntu-latest
 
     steps:
-      - name: Lint title
+      - name: Semantic PR title
         uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          subjectPattern: ^(?![A-Z]).+$
+          subjectPattern: ^(?![A-Z]).+$ # This pattern ensures the subject doesn't start with an uppercase character.

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,22 @@
+name: GitHub PR Lint
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  lint-pr:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Lint title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          subjectPattern: ^(?![A-Z]).+$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,14 @@ You SHOULD write (or update) documentation.
 You SHOULD write
 [commit messages that make sense](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 
-You MUST [rebase your branch](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) before submitting your Pull Request.
+### Pull requests
 
-While creating your Pull Request on GitHub, you MUST write a description which gives the context and/or explains why you
-are creating it.
+You MUST [rebase your branch](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) before submitting your pull request.
+
+You MUST use a pull request title compliant with the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
+
+You MUST write a meaningful description which gives the context and/or explains why you
+are creating the pull request.
+
+You SHOULD resolve review comments instead of commenting.
+<sub>Once you've done the work, resolve the conversation by selecting the Resolve conversation button in the PR overview. Avoid posting comments like "I've done the work", or "Done".</sub>


### PR DESCRIPTION
| Q             | A           |
|---------------|-------------|
| Bug fix?      | no          |
| New feature?  | no          |
| Deprecations? | no          |
| Issues        | Close #2264 |

* Adds a GitHub Actions workflow (based on [amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request)) validating PR titles for compliance with the [Conventional Commits](https://www.conventionalcommits.org/) specification.