### PR TITLE
fix: Unknown Constraint class when not using symfony/validator

### DIFF
--- a/src/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
+++ b/src/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
@@ -213,7 +213,7 @@ class SymfonyConstraintAnnotationReader
      */
     private function locateAnnotations($reflection): \Traversable
     {
-        if (\PHP_VERSION_ID >= 80000) {
+        if (\PHP_VERSION_ID >= 80000 && class_exists(Constraint::class)) {
             foreach ($reflection->getAttributes(Constraint::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
                 yield $attribute->newInstance();
             }


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                                    |
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->                                                                   |
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->                                                  |
| Issues        | Fix #2275 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |

https://github.com/nelmio/NelmioApiDocBundle/pull/2259 accidentally removed the `class_exists` check for symfony/validator `Constraint`. This currently causes applications using this bundle to fail because of the missing symfony/validator dependency

