### PR TITLE
Respect assets mode config in controller

### DIFF
--- a/src/Controller/SwaggerUiController.php
+++ b/src/Controller/SwaggerUiController.php
@@ -12,7 +12,6 @@
 namespace Nelmio\ApiDocBundle\Controller;
 
 use Nelmio\ApiDocBundle\Exception\RenderInvalidArgumentException;
-use Nelmio\ApiDocBundle\Render\Html\AssetsMode;
 use Nelmio\ApiDocBundle\Render\RenderOpenApi;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -35,7 +34,6 @@ final class SwaggerUiController
         try {
             $response = new Response(
                 $this->renderOpenApi->renderFromRequest($request, RenderOpenApi::HTML, $area, [
-                    'assets_mode' => AssetsMode::BUNDLE,
                     'ui_renderer' => $this->uiRenderer,
                 ]),
                 Response::HTTP_OK,

--- a/tests/Functional/TestKernel.php
+++ b/tests/Functional/TestKernel.php
@@ -18,6 +18,7 @@ use FOS\RestBundle\FOSRestBundle;
 use Hateoas\Configuration\Embedded;
 use JMS\SerializerBundle\JMSSerializerBundle;
 use Nelmio\ApiDocBundle\NelmioApiDocBundle;
+use Nelmio\ApiDocBundle\Render\Html\AssetsMode;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\BazingaUser;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSComplex80;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSComplex81;
@@ -242,6 +243,9 @@ class TestKernel extends Kernel
 
         // Filter routes
         $c->loadFromExtension('nelmio_api_doc', [
+            'html_config' => [
+                'assets_mode' => AssetsMode::BUNDLE,
+            ],
             'use_validation_groups' => boolval(self::USE_VALIDATION_GROUPS === $this->flag),
             'documentation' => [
                 'info' => [


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -

Currently the `SwaggerUiController` doesn't respect the `assets_mode` configuration added in #2251.

```yaml
nelmio_api_doc:
  html_config:
    assets_mode: cdn
```

As far as I can tell, there's no reason for the default any more as it can be set through the configuration and overridden in the `DumpCommand` command using the `html-config` option.