### PR TITLE
Update tests remove deprecations

### DIFF
--- a/src/RouteDescriber/RouteArgumentDescriber.php
+++ b/src/RouteDescriber/RouteArgumentDescriber.php
@@ -37,7 +37,7 @@ final class RouteArgumentDescriber implements RouteDescriberInterface, ModelRegi
 
     public function describe(OA\OpenApi $api, Route $route, \ReflectionMethod $reflectionMethod): void
     {
-        $saveContext = $context = $api->_context ?? Generator::$context;
+        $saveContext = $context = Generator::$context;
         if (null === $context) {
             Generator::$context = new \OpenApi\Context(['file' => __FILE__, 'line' => __LINE__, 'class' => __CLASS__, 'method' => __METHOD__]);
         }

--- a/tests/ModelDescriber/FormModelDescriberTest.php
+++ b/tests/ModelDescriber/FormModelDescriberTest.php
@@ -17,6 +17,7 @@ use Nelmio\ApiDocBundle\Model\ModelRegistry;
 use Nelmio\ApiDocBundle\ModelDescriber\FormModelDescriber;
 use OpenApi\Annotations\Property;
 use OpenApi\Attributes\OpenApi;
+use OpenApi\Context;
 use OpenApi\Generator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -58,7 +59,7 @@ class FormModelDescriberTest extends TestCase
             ->willReturn($formMock);
 
         $annotationReader = $this->createMock(Reader::class);
-
+        Generator::$context = new Context(['openapi' => OpenApi::DEFAULT_VERSION]); // use generator context as fallback instead of generating one on the fly
         $api = new OpenApi();
         $model = new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, FormType::class));
         $schema = $this->initSchema();

--- a/tests/ModelDescriber/SelfDescribingModelDescriberTest.php
+++ b/tests/ModelDescriber/SelfDescribingModelDescriberTest.php
@@ -15,6 +15,9 @@ use Nelmio\ApiDocBundle\Model\Model;
 use Nelmio\ApiDocBundle\ModelDescriber\SelfDescribingModelDescriber;
 use Nelmio\ApiDocBundle\Tests\ModelDescriber\Fixtures\SelfDescribingModel;
 use OpenApi\Annotations\Schema;
+use OpenApi\Attributes\OpenApi;
+use OpenApi\Context;
+use OpenApi\Generator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Type;
 
@@ -36,6 +39,8 @@ class SelfDescribingModelDescriberTest extends TestCase
 
     public function testDescribe(): void
     {
+        Generator::$context = new Context(['openapi' => OpenApi::DEFAULT_VERSION]); // use generator context as fallback instead of generating one on the fly
+
         $describer = new SelfDescribingModelDescriber();
 
         $model = new Model(new Type('object', false, SelfDescribingModel::class));

--- a/tests/RouteDescriber/RouteMetadataDescriberTest.php
+++ b/tests/RouteDescriber/RouteMetadataDescriberTest.php
@@ -13,7 +13,6 @@ namespace Nelmio\ApiDocBundle\Tests\RouteDescriber;
 
 use Nelmio\ApiDocBundle\RouteDescriber\RouteMetadataDescriber;
 use OpenApi\Annotations\OpenApi;
-use OpenApi\Context;
 use OpenApi\Generator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\Route;
@@ -26,12 +25,12 @@ class RouteMetadataDescriberTest extends TestCase
 
         $routeDescriber = new RouteMetadataDescriber();
 
-        $routeDescriber->describe(new OpenApi(['_context' => new Context(['method' => __METHOD__, 'class' => self::class])]), new Route('foo'), new \ReflectionMethod(__CLASS__, 'testUndefinedCheck'));
+        $routeDescriber->describe(new OpenApi([]), new Route('foo'), new \ReflectionMethod(__CLASS__, 'testUndefinedCheck'));
     }
 
     public function testRouteRequirementsWithPattern(): void
     {
-        $api = new OpenApi(['_context' => new Context(['method' => __METHOD__, 'class' => __CLASS__])]);
+        $api = new OpenApi([]);
         $routeDescriber = new RouteMetadataDescriber();
         $route = new Route('/index/{bar}/{foo}.html', [], ['foo' => '[0-9]|[a-z]'], [], 'localhost', 'https', ['GET']);
         $routeDescriber->describe(
@@ -55,7 +54,7 @@ class RouteMetadataDescriberTest extends TestCase
      */
     public function testSimpleOrRequirementsAreHandledAsEnums(string $req): void
     {
-        $api = new OpenApi(['_context' => new Context(['method' => __METHOD__, 'class' => __CLASS__])]);
+        $api = new OpenApi([]);
         $routeDescriber = new RouteMetadataDescriber();
         $route = new Route('/index/{bar}/{foo}.html', [], ['foo' => $req], [], 'localhost', 'https', ['GET']);
         $routeDescriber->describe(
@@ -78,7 +77,7 @@ class RouteMetadataDescriberTest extends TestCase
      */
     public function testNonEnumPatterns(string $pattern): void
     {
-        $api = new OpenApi(['_context' => new Context(['method' => __METHOD__, 'class' => self::class])]);
+        $api = new OpenApi([]);
         $routeDescriber = new RouteMetadataDescriber();
         $route = new Route('/index/{foo}.html', [], ['foo' => $pattern], [], 'localhost', 'https', ['GET']);
         $routeDescriber->describe(

--- a/tests/RouteDescriber/RouteMetadataDescriberTest.php
+++ b/tests/RouteDescriber/RouteMetadataDescriberTest.php
@@ -26,12 +26,12 @@ class RouteMetadataDescriberTest extends TestCase
 
         $routeDescriber = new RouteMetadataDescriber();
 
-        $routeDescriber->describe(new OpenApi(['_context' => new Context()]), new Route('foo'), new \ReflectionMethod(__CLASS__, 'testUndefinedCheck'));
+        $routeDescriber->describe(new OpenApi(['_context' => new Context(['method' => __METHOD__, 'class' => self::class])]), new Route('foo'), new \ReflectionMethod(__CLASS__, 'testUndefinedCheck'));
     }
 
     public function testRouteRequirementsWithPattern(): void
     {
-        $api = new OpenApi([]);
+        $api = new OpenApi(['_context' => new Context(['method' => __METHOD__, 'class' => __CLASS__])]);
         $routeDescriber = new RouteMetadataDescriber();
         $route = new Route('/index/{bar}/{foo}.html', [], ['foo' => '[0-9]|[a-z]'], [], 'localhost', 'https', ['GET']);
         $routeDescriber->describe(
@@ -55,7 +55,7 @@ class RouteMetadataDescriberTest extends TestCase
      */
     public function testSimpleOrRequirementsAreHandledAsEnums(string $req): void
     {
-        $api = new OpenApi([]);
+        $api = new OpenApi(['_context' => new Context(['method' => __METHOD__, 'class' => __CLASS__])]);
         $routeDescriber = new RouteMetadataDescriber();
         $route = new Route('/index/{bar}/{foo}.html', [], ['foo' => $req], [], 'localhost', 'https', ['GET']);
         $routeDescriber->describe(
@@ -78,7 +78,7 @@ class RouteMetadataDescriberTest extends TestCase
      */
     public function testNonEnumPatterns(string $pattern): void
     {
-        $api = new OpenApi([]);
+        $api = new OpenApi(['_context' => new Context(['method' => __METHOD__, 'class' => self::class])]);
         $routeDescriber = new RouteMetadataDescriber();
         $route = new Route('/index/{foo}.html', [], ['foo' => $pattern], [], 'localhost', 'https', ['GET']);
         $routeDescriber->describe(

--- a/tests/SwaggerPhp/UtilTest.php
+++ b/tests/SwaggerPhp/UtilTest.php
@@ -312,7 +312,7 @@ class UtilTest extends TestCase
                     ],
                 ]),
             ],
-            'assert' => [
+            'asserts' => [
                 // one fixed within setup and one dynamically created
                 'paths' => [
                     [
@@ -421,7 +421,7 @@ class UtilTest extends TestCase
                 'class' => OA\PathItem::class,
                 'get' => self::createObj(OA\Get::class, []),
             ],
-            'assert' => [
+            'asserts' => [
                 // fixed within setup
                 'get' => [
                     'class' => OA\Get::class,
@@ -447,7 +447,7 @@ class UtilTest extends TestCase
             'setup' => [
                 'class' => OA\Parameter::class,
             ],
-            'assert' => [
+            'asserts' => [
                 // create new with multiple props
                 'schema' => [
                     'class' => OA\Schema::class,
@@ -464,7 +464,7 @@ class UtilTest extends TestCase
             'setup' => [
                 'class' => OA\Parameter::class,
             ],
-            'assert' => [
+            'asserts' => [
                 // externalDocs triggers invalid argument exception
                 'schema' => [
                     'class' => OA\Schema::class,


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                               |
| New feature?  | no                                                                   |
| Deprecations? | no                                                  |
| Issues        | Fix #2279


Tries to fix 
- deprecation warning of swagger-php using detect()
  - add context for tests where possible
  - add a default context to RouteDescriber (set and unset generator::$context) 
     https://github.com/zircote/swagger-php/issues/1579
- phpunit deprecations (parameters must have the same name as array keys: asserts vs. assert

Because I don't know much about context handling, i am not sure if that fix is sufficient. Maybe there are some edge cases which I didnt consider.


Dependng on the outcome of te discussion at swagger-php mentioned above, this PR can be closed without merging.

