### PR TITLE
docs: update symfony_attributes.rst with info about required library

### DIFF
--- a/docs/symfony_attributes.rst
+++ b/docs/symfony_attributes.rst
@@ -6,6 +6,17 @@ NelmioApiDocBundle has the ability to automatically create documentation from **
 MapQueryString
 -------------------------------
 
+Install required component
+
+.. code-block:: terminal
+
+    $ composer require symfony/property-access
+
+.. include:: /components/require_autoload.rst.inc
+
+Usage
+-----
+
 Using the `Symfony MapQueryString`_ attribute allows NelmioApiDocBundle to automatically generate your query parameter documentation for your endpoint from your object.
 
 .. versionadded:: 6.3


### PR DESCRIPTION
Found out that MapQueryString Attribute doesn't work without component symfony/property-access (ObjectNormalizer::class). And there is no info in doc about that, also the problem is not obvious for regular MapQueryString users as the exception highlight only that there is no normalizer that supports this

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Updating doc?      | yes

