### PR TITLE
fix(#2300): fix missing context param UuidPropertyDescriber::describe()

### DIFF
--- a/src/PropertyDescriber/UuidPropertyDescriber.php
+++ b/src/PropertyDescriber/UuidPropertyDescriber.php
@@ -17,7 +17,10 @@ use Symfony\Component\Uid\AbstractUid;
 
 final class UuidPropertyDescriber implements PropertyDescriberInterface
 {
-    public function describe(array $types, OA\Schema $property, ?array $groups = null, ?OA\Schema $schema = null)
+    /**
+     * @param array<string, mixed> $context Context options for describing the property
+     */
+    public function describe(array $types, OA\Schema $property, ?array $groups = null, ?OA\Schema $schema = null, array $context = [])
     {
         $property->type = 'string';
         $property->format = 'uuid';


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                                    |
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->                                                                   |
| Deprecations? | yes/no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->                                                  |
| Issues        | Fix #2300 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |

Fixes deprecation warning from missing `context` parameter on `UuidPropertyDescriber::describe()`