### PR TITLE
docs: update link to index.html.twig in customization.rst

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -68,4 +68,4 @@ Just create a file ``templates/bundles/NelmioApiDocBundle/SwaggerUi/index.html.t
         <script type="text/javascript" src="{{ asset('js/custom-request-signer.js') }}"></script>
     {% endblock javascripts %}
 
-You can have a look at the `original template <https://github.com/nelmio/NelmioApiDocBundle/blob/master/Resources/views/SwaggerUi/index.html.twig>`_, in ``/Resources/views/SwaggerUi/index.html.twig``, to see which blocks can be overridden.
+You can have a look at the `original template <https://github.com/nelmio/NelmioApiDocBundle/blob/master/templates/SwaggerUi/index.html.twig>`_, in ``/templates/SwaggerUi/index.html.twig``, to see which blocks can be overridden.


### PR DESCRIPTION
the link that was there no longer worked, it led to a file that hadn't existed for a while, so I updated it
![image](https://github.com/user-attachments/assets/9ce4ad6d-d037-4270-8aca-0cade6900640)

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                                    |
| New feature?  | no                                                                    |
| Deprecations? | yes                                                   |


