### PR TITLE
fix(2324): remove ProcessorInterface usage

### DIFF
--- a/src/ApiDocGenerator.php
+++ b/src/ApiDocGenerator.php
@@ -20,7 +20,6 @@ use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 use OpenApi\Analysis;
 use OpenApi\Annotations\OpenApi;
 use OpenApi\Generator;
-use OpenApi\Processors\ProcessorInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerAwareTrait;
 
@@ -146,7 +145,7 @@ final class ApiDocGenerator
      *
      * @param Generator $generator The generator instance to get the standard processors from
      *
-     * @return array<ProcessorInterface|callable> The array of processors
+     * @return array<callable> The array of processors
      */
     private function getProcessors(Generator $generator): array
     {

--- a/src/Processor/MapQueryStringProcessor.php
+++ b/src/Processor/MapQueryStringProcessor.php
@@ -18,7 +18,6 @@ use Nelmio\ApiDocBundle\RouteDescriber\RouteArgumentDescriber\SymfonyMapQueryStr
 use OpenApi\Analysis;
 use OpenApi\Annotations as OA;
 use OpenApi\Generator;
-use OpenApi\Processors\ProcessorInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
 /**
@@ -27,7 +26,7 @@ use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
  *
  * @see SymfonyMapQueryStringDescriber
  */
-final class MapQueryStringProcessor implements ProcessorInterface
+final class MapQueryStringProcessor
 {
     public function __invoke(Analysis $analysis): void
     {

--- a/src/Processor/MapRequestPayloadProcessor.php
+++ b/src/Processor/MapRequestPayloadProcessor.php
@@ -18,7 +18,6 @@ use Nelmio\ApiDocBundle\RouteDescriber\RouteArgumentDescriber\SymfonyMapRequestP
 use OpenApi\Analysis;
 use OpenApi\Annotations as OA;
 use OpenApi\Generator;
-use OpenApi\Processors\ProcessorInterface;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
@@ -28,7 +27,7 @@ use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
  *
  * @see SymfonyMapRequestPayloadDescriber
  */
-final class MapRequestPayloadProcessor implements ProcessorInterface
+final class MapRequestPayloadProcessor
 {
     public function __invoke(Analysis $analysis): void
     {

--- a/src/Processor/NullablePropertyProcessor.php
+++ b/src/Processor/NullablePropertyProcessor.php
@@ -16,12 +16,11 @@ namespace Nelmio\ApiDocBundle\Processor;
 use OpenApi\Analysis;
 use OpenApi\Annotations as OA;
 use OpenApi\Generator;
-use OpenApi\Processors\ProcessorInterface;
 
 /**
  * Processor to clean up the generated OpenAPI documentation for nullable properties.
  */
-final class NullablePropertyProcessor implements ProcessorInterface
+final class NullablePropertyProcessor
 {
     public function __invoke(Analysis $analysis): void
     {


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes/no                                                                                                                    |
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->                                                                   |
| Deprecations? | yes/no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->                                                  |
| Issues        | Fix #2324 |

Fixes deprecation message for using deprecated `OpenApi\Processors\ProcessorInterface`
