### PR TITLE
fix(#2336): keep original index key

### DIFF
--- a/src/OpenApiPhp/Util.php
+++ b/src/OpenApiPhp/Util.php
@@ -273,14 +273,20 @@ final class Util
     /**
      * Search for an Annotation within the $collection that has its member $index set to $value.
      *
-     * @param mixed[] $collection
-     * @param mixed   $value      The value to search for
+     * @param OA\AbstractAnnotation[] $collection
+     * @param mixed                   $value      The value to search for
      *
      * @return false|int|string
      */
     public static function searchIndexedCollectionItem(array $collection, string $member, $value)
     {
-        return array_search($value, array_column($collection, $member), true);
+        foreach ($collection as $i => $child) {
+            if ($child->{$member} === $value) {
+                return $i;
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                                   |
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->                                                                   |
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->                                                  |
| Issues        | Fix #2336 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |

The original implementation lost the original key index because it created a new array (with `array_column`).
https://3v4l.org/kWPt7#v8.3.10