### PR TITLE
fix: pass through serializationContext into models where possible

### DIFF
--- a/src/ModelDescriber/ApplyOpenApiDiscriminatorTrait.php
+++ b/src/ModelDescriber/ApplyOpenApiDiscriminatorTrait.php
@@ -54,7 +54,8 @@ trait ApplyOpenApiDiscriminatorTrait
             $oneOfSchema->ref = $modelRegistry->register(new Model(
                 new Type(Type::BUILTIN_TYPE_OBJECT, false, $className),
                 $model->getGroups(),
-                $model->getOptions()
+                $model->getOptions(),
+                $model->getSerializationContext()
             ));
             $schema->oneOf[] = $oneOfSchema;
             $schema->discriminator->mapping[$propertyValue] = $oneOfSchema->ref;

--- a/src/ModelDescriber/BazingaHateoasModelDescriber.php
+++ b/src/ModelDescriber/BazingaHateoasModelDescriber.php
@@ -71,7 +71,7 @@ class BazingaHateoasModelDescriber implements ModelDescriberInterface, ModelRegi
 
             $property = Util::getProperty($relationSchema, $relation->getName());
             if (null !== $embedded && method_exists($embedded, 'getType') && null !== $embedded->getType()) {
-                $this->JMSModelDescriber->describeItem($embedded->getType(), $property, $context);
+                $this->JMSModelDescriber->describeItem($embedded->getType(), $property, $context, $model->getSerializationContext());
             } else {
                 $property->type = 'object';
             }

--- a/src/ModelDescriber/JMSModelDescriber.php
+++ b/src/ModelDescriber/JMSModelDescriber.php
@@ -200,7 +200,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
                 continue;
             }
 
-            $this->describeItem($item->type, $property, $context);
+            $this->describeItem($item->type, $property, $context, $model->getSerializationContext());
             $context->popPropertyMetadata();
         }
         $context->popClassMetadata();
@@ -281,8 +281,9 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
      * @internal
      *
      * @param mixed[] $type
+     * @param mixed[] $serializationContext
      */
-    public function describeItem(array $type, OA\Schema $property, Context $context): void
+    public function describeItem(array $type, OA\Schema $property, Context $context, array $serializationContext): void
     {
         $nestedTypeInfo = $this->getNestedTypeInArray($type);
         if (null !== $nestedTypeInfo) {
@@ -299,14 +300,14 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
                     return;
                 }
 
-                $this->describeItem($nestedType, $property->additionalProperties, $context);
+                $this->describeItem($nestedType, $property->additionalProperties, $context, $serializationContext);
 
                 return;
             }
 
             $property->type = 'array';
             $property->items = Util::createChild($property, OA\Items::class);
-            $this->describeItem($nestedType, $property->items, $context);
+            $this->describeItem($nestedType, $property->items, $context, $serializationContext);
         } elseif ('array' === $type['name']) {
             $property->type = 'object';
             $property->additionalProperties = true;
@@ -333,8 +334,9 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
             }
 
             $groups = $this->computeGroups($context, $type);
+            unset($serializationContext['groups']);
 
-            $model = new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, $type['name']), $groups);
+            $model = new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, $type['name']), $groups, null, $serializationContext);
             $modelRef = $this->modelRegistry->register($model);
 
             $customFields = (array) $property->jsonSerialize();


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                                    |
| New feature?  | o <!-- please update src/**/CHANGELOG.md files -->                                                                   |
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->                                                  |
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->
I noticed that information I'm adding into a JMS serializer model gets lost inside it because `serializationContext` is not passed through everywhere, but it most likely should? the thing I slightly dislike though is that it _could_ include `groups` and in the scope of `JMSModelDescriber` where groups are determined in another way and overwritten I have to unset that key from the serializationContext to avoid side-effects. WDYT @DjordyKoert?