### PR TITLE
refactor: remove deprecation & thrown exception & constructor defaults

### DIFF
--- a/src/ModelDescriber/FormModelDescriber.php
+++ b/src/ModelDescriber/FormModelDescriber.php
@@ -38,7 +38,7 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
     use ModelRegistryAwareTrait;
     use SetsContextTrait;
 
-    private ?FormFactoryInterface $formFactory;
+    private FormFactoryInterface $formFactory;
     private ?Reader $doctrineReader;
 
     /**
@@ -49,23 +49,17 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
     private bool $isFormCsrfExtensionEnabled;
 
     /**
-     * @param string[]|null $mediaTypes
+     * @param string[] $mediaTypes
      */
     public function __construct(
-        ?FormFactoryInterface $formFactory = null,
-        ?Reader $reader = null,
-        ?array $mediaTypes = null,
-        bool $useValidationGroups = false,
-        bool $isFormCsrfExtensionEnabled = false
+        FormFactoryInterface $formFactory,
+        ?Reader $reader,
+        array $mediaTypes,
+        bool $useValidationGroups,
+        bool $isFormCsrfExtensionEnabled
     ) {
         $this->formFactory = $formFactory;
         $this->doctrineReader = $reader;
-
-        if (null === $mediaTypes) {
-            $mediaTypes = ['json'];
-
-            trigger_deprecation('nelmio/api-doc-bundle', '4.1', 'Not passing media types to the constructor of %s is deprecated and won\'t be allowed in version 5.', self::class);
-        }
         $this->mediaTypes = $mediaTypes;
         $this->useValidationGroups = $useValidationGroups;
         $this->isFormCsrfExtensionEnabled = $isFormCsrfExtensionEnabled;
@@ -73,10 +67,6 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
 
     public function describe(Model $model, OA\Schema $schema): void
     {
-        if (null === $this->formFactory) {
-            throw new \LogicException('You need to enable forms in your application to use a form as a model.');
-        }
-
         $class = $model->getType()->getClassName();
 
         $annotationsReader = new AnnotationsReader(


### PR DESCRIPTION
## Description

Refactor `FormModelDescriber`:
- Remove default values from constructor params
  - The class is marked as internal so default params are not needed as we can rely on DI
- Removed impossible deprecation `$mediaTypes` is not nullable
- Removed impossible exception `$formFactory` could never be `null`

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [x] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [x] I have made corresponding changes to the documentation (`docs/`)
- [x] I have made corresponding changes to the changelog (`CHANGELOG.md`)