### PR TITLE
fix: override code based defaults with explicit ones

### DIFF
--- a/src/ModelDescriber/Annotations/AnnotationsReader.php
+++ b/src/ModelDescriber/Annotations/AnnotationsReader.php
@@ -24,6 +24,7 @@ class AnnotationsReader
     private PropertyPhpDocReader $phpDocReader;
     private OpenApiAnnotationsReader $openApiAnnotationsReader;
     private SymfonyConstraintAnnotationReader $symfonyConstraintAnnotationReader;
+    private ReflectionReader $reflectionReader;
 
     /**
      * @param string[] $mediaTypes
@@ -40,12 +41,14 @@ class AnnotationsReader
             $annotationsReader,
             $useValidationGroups
         );
+        $this->reflectionReader = new ReflectionReader();
     }
 
     public function updateDefinition(\ReflectionClass $reflectionClass, OA\Schema $schema): bool
     {
         $this->openApiAnnotationsReader->updateSchema($reflectionClass, $schema);
         $this->symfonyConstraintAnnotationReader->setSchema($schema);
+        $this->reflectionReader->setSchema($schema);
 
         return $this->shouldDescribeModelProperties($schema);
     }
@@ -66,6 +69,7 @@ class AnnotationsReader
     {
         $this->openApiAnnotationsReader->updateProperty($reflection, $property, $serializationGroups);
         $this->phpDocReader->updateProperty($reflection, $property);
+        $this->reflectionReader->updateProperty($reflection, $property);
         $this->symfonyConstraintAnnotationReader->updateProperty($reflection, $property, $serializationGroups);
     }
 

--- a/src/ModelDescriber/Annotations/ReflectionReader.php
+++ b/src/ModelDescriber/Annotations/ReflectionReader.php
@@ -43,9 +43,6 @@ class ReflectionReader
         OA\Property $property,
         ?array $validationGroups = null
     ): void {
-        if (PHP_VERSION_ID < 80000) {
-            return;
-        }
         // The default has been set by an Annotation or Attribute
         // We leave that as it is!
         if (Generator::UNDEFINED !== $property->default) {
@@ -53,7 +50,7 @@ class ReflectionReader
         }
 
         $serializedName = $reflection->getName();
-        foreach (['', 'get', 'is', 'has', 'can', 'add', 'remove', 'set'] as $prefix) {
+        foreach (['get', 'is', 'has', 'can', 'add', 'remove', 'set'] as $prefix) {
             if (0 === strpos($serializedName, $prefix)) {
                 $serializedName = substr($serializedName, strlen($prefix));
             }
@@ -106,7 +103,10 @@ class ReflectionReader
         $this->schema = $schema;
     }
 
-    private function getDefaultFromMethodReflection(\ReflectionMethod $reflection): mixed
+    /**
+     * @return mixed|string
+     */
+    private function getDefaultFromMethodReflection(\ReflectionMethod $reflection)
     {
         if (0 !== strpos($reflection->name, 'set')) {
             return Generator::UNDEFINED;
@@ -129,22 +129,22 @@ class ReflectionReader
         return $param->getDefaultValue();
     }
 
-    public function getDefaultFromPropertyReflection(\ReflectionProperty $reflection): mixed
+    /**
+     * @return mixed|string
+     */
+    public function getDefaultFromPropertyReflection(\ReflectionProperty $reflection)
     {
         $propertyName = $reflection->name;
         if (!$reflection->getDeclaringClass()->hasProperty($propertyName)) {
             return Generator::UNDEFINED;
         }
 
-        $reflectionProp = $reflection->getDeclaringClass()->getProperty($propertyName);
-        if (!$reflectionProp->hasDefaultValue()) {
+        $defaultValue = $reflection->getDeclaringClass()->getDefaultProperties()[$propertyName] ?? null;
+
+        if (null === $defaultValue) {
             return Generator::UNDEFINED;
         }
 
-        if (null === $reflectionProp->getDefaultValue()) {
-            return Generator::UNDEFINED;
-        }
-
-        return $reflectionProp->getDefaultValue();
+        return $defaultValue;
     }
 }

--- a/src/ModelDescriber/Annotations/ReflectionReader.php
+++ b/src/ModelDescriber/Annotations/ReflectionReader.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\ModelDescriber\Annotations;
+
+use Nelmio\ApiDocBundle\Util\SetsContextTrait;
+use OpenApi\Annotations as OA;
+use OpenApi\Generator;
+
+/**
+ * Read default values of a property from the function or property signature.
+ *
+ * This needs to be called before the SymfonyConstraintAnnotationReader,
+ * otherwise required properties might be considered wrongly.
+ *
+ * @internal
+ */
+class ReflectionReader
+{
+    use SetsContextTrait;
+
+    /**
+     * @var OA\Schema
+     */
+    private $schema;
+
+    /**
+     * Update the given property and schema with defined Symfony constraints.
+     *
+     * @param \ReflectionProperty|\ReflectionMethod $reflection
+     * @param string[]|null                         $validationGroups
+     */
+    public function updateProperty(
+        $reflection,
+        OA\Property $property,
+        ?array $validationGroups = null
+    ): void {
+        if (PHP_VERSION_ID < 80000) {
+            return;
+        }
+        // The default has been set by an Annotation or Attribute
+        // We leave that as it is!
+        if (Generator::UNDEFINED !== $property->default) {
+            return;
+        }
+
+        $serializedName = $reflection->getName();
+        foreach (['', 'get', 'is', 'has', 'can', 'add', 'remove', 'set'] as $prefix) {
+            if (0 === strpos($serializedName, $prefix)) {
+                $serializedName = substr($serializedName, strlen($prefix));
+            }
+        }
+
+        if ($reflection instanceof \ReflectionMethod) {
+            $methodDefault = $this->getDefaultFromMethodReflection($reflection);
+            if (Generator::UNDEFINED !== $methodDefault) {
+                $property->default = $methodDefault;
+
+                return;
+            }
+        }
+
+        if ($reflection instanceof \ReflectionProperty) {
+            $methodDefault = $this->getDefaultFromPropertyReflection($reflection);
+            if (Generator::UNDEFINED !== $methodDefault) {
+                $property->default = $methodDefault;
+
+                return;
+            }
+        }
+        // Fix for https://github.com/nelmio/NelmioApiDocBundle/issues/2222
+        // Promoted properties with a value initialized by the constructor are not considered to have a default value
+        // and are therefore not returned by ReflectionClass::getDefaultProperties(); see https://bugs.php.net/bug.php?id=81386
+        $reflClassConstructor = $reflection->getDeclaringClass()->getConstructor();
+        $reflClassConstructorParameters = null !== $reflClassConstructor ? $reflClassConstructor->getParameters() : [];
+        foreach ($reflClassConstructorParameters as $parameter) {
+            if ($parameter->name !== $serializedName) {
+                continue;
+            }
+            if (!$parameter->isDefaultValueAvailable()) {
+                continue;
+            }
+
+            if (null === $this->schema) {
+                continue;
+            }
+
+            if (!Generator::isDefault($property->default)) {
+                continue;
+            }
+
+            $property->default = $parameter->getDefaultValue();
+        }
+    }
+
+    public function setSchema(OA\Schema $schema): void
+    {
+        $this->schema = $schema;
+    }
+
+    private function getDefaultFromMethodReflection(\ReflectionMethod $reflection): mixed
+    {
+        if (0 !== strpos($reflection->name, 'set')) {
+            return Generator::UNDEFINED;
+        }
+
+        if (1 !== $reflection->getNumberOfParameters()) {
+            return Generator::UNDEFINED;
+        }
+
+        $param = $reflection->getParameters()[0];
+
+        if (!$param->isDefaultValueAvailable()) {
+            return Generator::UNDEFINED;
+        }
+
+        if (null === $param->getDefaultValue()) {
+            return Generator::UNDEFINED;
+        }
+
+        return $param->getDefaultValue();
+    }
+
+    public function getDefaultFromPropertyReflection(\ReflectionProperty $reflection): mixed
+    {
+        $propertyName = $reflection->name;
+        if (!$reflection->getDeclaringClass()->hasProperty($propertyName)) {
+            return Generator::UNDEFINED;
+        }
+
+        $reflectionProp = $reflection->getDeclaringClass()->getProperty($propertyName);
+        if (!$reflectionProp->hasDefaultValue()) {
+            return Generator::UNDEFINED;
+        }
+
+        if (null === $reflectionProp->getDefaultValue()) {
+            return Generator::UNDEFINED;
+        }
+
+        return $reflectionProp->getDefaultValue();
+    }
+}

--- a/src/ModelDescriber/Annotations/ReflectionReader.php
+++ b/src/ModelDescriber/Annotations/ReflectionReader.php
@@ -18,30 +18,25 @@ use OpenApi\Generator;
 /**
  * Read default values of a property from the function or property signature.
  *
- * This needs to be called before the SymfonyConstraintAnnotationReader,
+ * This needs to be called before the {@see SymfonyConstraintAnnotationReader},
  * otherwise required properties might be considered wrongly.
  *
  * @internal
  */
-class ReflectionReader
+final class ReflectionReader
 {
     use SetsContextTrait;
 
-    /**
-     * @var OA\Schema
-     */
-    private $schema;
+    private ?OA\Schema $schema;
 
     /**
      * Update the given property and schema with defined Symfony constraints.
      *
      * @param \ReflectionProperty|\ReflectionMethod $reflection
-     * @param string[]|null                         $validationGroups
      */
     public function updateProperty(
         $reflection,
-        OA\Property $property,
-        ?array $validationGroups = null
+        OA\Property $property
     ): void {
         // The default has been set by an Annotation or Attribute
         // We leave that as it is!

--- a/src/ModelDescriber/ObjectModelDescriber.php
+++ b/src/ModelDescriber/ObjectModelDescriber.php
@@ -172,6 +172,18 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
                 $property->default = $defaultValues[$propertyName];
             }
 
+            if (Generator::UNDEFINED !== $property->default) {
+                // Fix for https://github.com/nelmio/NelmioApiDocBundle/issues/2222
+                // When a default value has been set for the property, we can
+                // remove the field from the required fields.
+                if (is_array($schema->required) && ($key = array_search($propertyName, $schema->required, true)) !== false) {
+                    unset($schema->required[$key]);
+                }
+            }
+            if ([] === $schema->required) {
+                $schema->required = Generator::UNDEFINED;
+            }
+
             $types = $this->propertyInfo->getTypes($class, $propertyName);
             if (null === $types || 0 === count($types)) {
                 throw new \LogicException(sprintf('The PropertyInfo component was not able to guess the type of %s::$%s. You may need to add a `@var` annotation or use `@OA\Property(type="")` to make its type explicit.', $class, $propertyName));

--- a/src/ModelDescriber/ObjectModelDescriber.php
+++ b/src/ModelDescriber/ObjectModelDescriber.php
@@ -154,13 +154,6 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
 
             $property = Util::getProperty($schema, $serializedName);
 
-            // Fix for https://github.com/nelmio/NelmioApiDocBundle/issues/2222
-            // Property default value has to be set before SymfonyConstraintAnnotationReader::processPropertyAnnotations()
-            // is called to prevent wrongly detected required properties
-            if (Generator::UNDEFINED === $property->default && array_key_exists($propertyName, $defaultValues)) {
-                $property->default = $defaultValues[$propertyName];
-            }
-
             // Interpret additional options
             $groups = $model->getGroups();
             if (isset($groups[$propertyName]) && is_array($groups[$propertyName])) {
@@ -173,6 +166,10 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
             // If type manually defined
             if (Generator::UNDEFINED !== $property->type || Generator::UNDEFINED !== $property->ref) {
                 continue;
+            }
+
+            if (Generator::UNDEFINED === $property->default && array_key_exists($propertyName, $defaultValues)) {
+                $property->default = $defaultValues[$propertyName];
             }
 
             $types = $this->propertyInfo->getTypes($class, $propertyName);

--- a/src/ModelDescriber/ObjectModelDescriber.php
+++ b/src/ModelDescriber/ObjectModelDescriber.php
@@ -125,23 +125,6 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
         // The SerializerExtractor does expose private/protected properties for some reason, so we eliminate them here
         $propertyInfoProperties = array_intersect($propertyInfoProperties, $this->propertyInfo->getProperties($class, []) ?? []);
 
-        $defaultValues = array_filter($reflClass->getDefaultProperties(), static function ($value) {
-            return null !== $value;
-        });
-
-        // Fix for https://github.com/nelmio/NelmioApiDocBundle/issues/2222
-        // Promoted properties with a value initialized by the constructor are not considered to have a default value
-        // and are therefore not returned by ReflectionClass::getDefaultProperties(); see https://bugs.php.net/bug.php?id=81386
-        $reflClassConstructor = $reflClass->getConstructor();
-        $reflClassConstructorParameters = null !== $reflClassConstructor ? $reflClassConstructor->getParameters() : [];
-        foreach ($reflClassConstructorParameters as $parameter) {
-            if (!$parameter->isDefaultValueAvailable()) {
-                continue;
-            }
-
-            $defaultValues[$parameter->name] = $parameter->getDefaultValue();
-        }
-
         foreach ($propertyInfoProperties as $propertyName) {
             $serializedName = null !== $this->nameConverter ? $this->nameConverter->normalize($propertyName, $class, null, $model->getSerializationContext()) : $propertyName;
 
@@ -166,22 +149,6 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
             // If type manually defined
             if (Generator::UNDEFINED !== $property->type || Generator::UNDEFINED !== $property->ref) {
                 continue;
-            }
-
-            if (Generator::UNDEFINED === $property->default && array_key_exists($propertyName, $defaultValues)) {
-                $property->default = $defaultValues[$propertyName];
-            }
-
-            if (Generator::UNDEFINED !== $property->default) {
-                // Fix for https://github.com/nelmio/NelmioApiDocBundle/issues/2222
-                // When a default value has been set for the property, we can
-                // remove the field from the required fields.
-                if (is_array($schema->required) && ($key = array_search($propertyName, $schema->required, true)) !== false) {
-                    unset($schema->required[$key]);
-                }
-            }
-            if ([] === $schema->required) {
-                $schema->required = Generator::UNDEFINED;
             }
 
             $types = $this->propertyInfo->getTypes($class, $propertyName);

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -237,6 +237,7 @@ class FunctionalTest extends WebTestCase
                             '$ref' => '#/components/schemas/User',
                         ],
                         'type' => 'array',
+                        'default' => [],
                     ],
                     'dummy' => [
                         '$ref' => '#/components/schemas/Dummy2',

--- a/tests/Functional/JMSFunctionalTest.php
+++ b/tests/Functional/JMSFunctionalTest.php
@@ -328,9 +328,9 @@ class JMSFunctionalTest extends WebTestCase
                     'type' => 'string',
                     'maxLength' => 10,
                     'minLength' => 3,
+                    'default' => 'default'
                 ],
             ],
-            'required' => ['beautifulName'],
             'schema' => 'JMSNamingStrategyConstraints',
         ], json_decode($this->getModel('JMSNamingStrategyConstraints')->toJson(), true));
     }


### PR DESCRIPTION
## Description

This change allows that defaults that are set in attributes can override the ones that are read from the code.

This fixes https://github.com/nelmio/NelmioApiDocBundle/issues/2330

Closes #2330

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)