### PR TITLE
ci: skip codecov upload for dependabot

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -104,6 +104,8 @@ jobs:
     needs: phpunit
     timeout-minutes: 5
 
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

@dependabot does not have access to the `CODECOV_TOKEN` which is causing the codecov job to fail in https://github.com/nelmio/NelmioApiDocBundle/pull/2383 for example.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot#adding-an-organization-secret-for-dependabot

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [x] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)