### PR TITLE
refactor: add $context to PropertyDescriberInterface::supports()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 4.33.5
+* Added new optional parameter `$context` to` PropertyDescriberInterface::supports()`
+
 ## 4.33.4
 * Deprecated `null` type from `$options` in `Nelmio\ApiDocBundle\Attribute\Model::__construct()`. Pass an empty array (`[]`) instead.
 * Deprecated `null` type from `$options` in `NNelmio\ApiDocBundle\Attribute\Model::__construct()`. Pass an empty array (`[]`) instead.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,9 +26,24 @@ parameters:
 			path: src/Describer/ExternalDocDescriber.php
 
 		-
+			message: "#^Method Nelmio\\\\ApiDocBundle\\\\PropertyDescriber\\\\ArrayPropertyDescriber\\:\\:supports\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/PropertyDescriber/ArrayPropertyDescriber.php
+
+		-
 			message: "#^Method Nelmio\\\\ApiDocBundle\\\\PropertyDescriber\\\\PropertyDescriberInterface\\:\\:describe\\(\\) invoked with 5 parameters, 2\\-3 required\\.$#"
 			count: 1
 			path: src/PropertyDescriber/ArrayPropertyDescriber.php
+
+		-
+			message: "#^Method Nelmio\\\\ApiDocBundle\\\\PropertyDescriber\\\\BooleanPropertyDescriber\\:\\:supports\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/PropertyDescriber/BooleanPropertyDescriber.php
+
+		-
+			message: "#^Method Nelmio\\\\ApiDocBundle\\\\PropertyDescriber\\\\CompoundPropertyDescriber\\:\\:supports\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/PropertyDescriber/CompoundPropertyDescriber.php
 
 		-
 			message: "#^Method Nelmio\\\\ApiDocBundle\\\\PropertyDescriber\\\\PropertyDescriberInterface\\:\\:describe\\(\\) invoked with 5 parameters, 2\\-3 required\\.$#"
@@ -36,9 +51,34 @@ parameters:
 			path: src/PropertyDescriber/CompoundPropertyDescriber.php
 
 		-
+			message: "#^Method Nelmio\\\\ApiDocBundle\\\\PropertyDescriber\\\\DateTimePropertyDescriber\\:\\:supports\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/PropertyDescriber/DateTimePropertyDescriber.php
+
+		-
+			message: "#^Method Nelmio\\\\ApiDocBundle\\\\PropertyDescriber\\\\DictionaryPropertyDescriber\\:\\:supports\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/PropertyDescriber/DictionaryPropertyDescriber.php
+
+		-
 			message: "#^Method Nelmio\\\\ApiDocBundle\\\\PropertyDescriber\\\\PropertyDescriberInterface\\:\\:describe\\(\\) invoked with 5 parameters, 2\\-3 required\\.$#"
 			count: 1
 			path: src/PropertyDescriber/DictionaryPropertyDescriber.php
+
+		-
+			message: "#^Method Nelmio\\\\ApiDocBundle\\\\PropertyDescriber\\\\FloatPropertyDescriber\\:\\:supports\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/PropertyDescriber/FloatPropertyDescriber.php
+
+		-
+			message: "#^Method Nelmio\\\\ApiDocBundle\\\\PropertyDescriber\\\\IntegerPropertyDescriber\\:\\:supports\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/PropertyDescriber/IntegerPropertyDescriber.php
+
+		-
+			message: "#^Method Nelmio\\\\ApiDocBundle\\\\PropertyDescriber\\\\NullablePropertyDescriber\\:\\:supports\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/PropertyDescriber/NullablePropertyDescriber.php
 
 		-
 			message: "#^Method Nelmio\\\\ApiDocBundle\\\\PropertyDescriber\\\\PropertyDescriberInterface\\:\\:describe\\(\\) invoked with 5 parameters, 2\\-3 required\\.$#"
@@ -46,13 +86,28 @@ parameters:
 			path: src/PropertyDescriber/NullablePropertyDescriber.php
 
 		-
+			message: "#^Method Nelmio\\\\ApiDocBundle\\\\PropertyDescriber\\\\ObjectPropertyDescriber\\:\\:supports\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/PropertyDescriber/ObjectPropertyDescriber.php
+
+		-
+			message: "#^Method Nelmio\\\\ApiDocBundle\\\\PropertyDescriber\\\\PropertyDescriber\\:\\:supports\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/PropertyDescriber/PropertyDescriber.php
+
+		-
 			message: "#^Method Nelmio\\\\ApiDocBundle\\\\PropertyDescriber\\\\PropertyDescriberInterface\\:\\:describe\\(\\) invoked with 5 parameters, 2\\-3 required\\.$#"
 			count: 1
 			path: src/PropertyDescriber/PropertyDescriber.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$context$#"
+			message: "#^Method Nelmio\\\\ApiDocBundle\\\\PropertyDescriber\\\\PropertyDescriberInterface\\:\\:supports\\(\\) invoked with 2 parameters, 1 required\\.$#"
 			count: 1
+			path: src/PropertyDescriber/PropertyDescriber.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$context$#"
+			count: 2
 			path: src/PropertyDescriber/PropertyDescriberInterface.php
 
 		-
@@ -64,6 +119,21 @@ parameters:
 			message: "#^Method Nelmio\\\\ApiDocBundle\\\\PropertyDescriber\\\\PropertyDescriberInterface\\:\\:describe\\(\\) invoked with 5 parameters, 2\\-3 required\\.$#"
 			count: 1
 			path: src/PropertyDescriber/RequiredPropertyDescriber.php
+
+		-
+			message: "#^Method Nelmio\\\\ApiDocBundle\\\\PropertyDescriber\\\\RequiredPropertyDescriber\\:\\:supports\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/PropertyDescriber/RequiredPropertyDescriber.php
+
+		-
+			message: "#^Method Nelmio\\\\ApiDocBundle\\\\PropertyDescriber\\\\StringPropertyDescriber\\:\\:supports\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/PropertyDescriber/StringPropertyDescriber.php
+
+		-
+			message: "#^Method Nelmio\\\\ApiDocBundle\\\\PropertyDescriber\\\\UuidPropertyDescriber\\:\\:supports\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/PropertyDescriber/UuidPropertyDescriber.php
 
 		-
 			message: "#^Call to method render\\(\\) on an unknown class Twig_Environment\\.$#"

--- a/src/ModelDescriber/ObjectModelDescriber.php
+++ b/src/ModelDescriber/ObjectModelDescriber.php
@@ -201,7 +201,7 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
             if ($propertyDescriber instanceof ModelRegistryAwareInterface) {
                 $propertyDescriber->setModelRegistry($this->modelRegistry);
             }
-            if ($propertyDescriber->supports($types)) {
+            if ($propertyDescriber->supports($types, $model->getSerializationContext())) {
                 $propertyDescriber->describe($types, $property, $model->getGroups(), $schema, $model->getSerializationContext());
 
                 return;

--- a/src/PropertyDescriber/ArrayPropertyDescriber.php
+++ b/src/PropertyDescriber/ArrayPropertyDescriber.php
@@ -52,7 +52,7 @@ class ArrayPropertyDescriber implements PropertyDescriberInterface, ModelRegistr
         foreach ($types[0]->getCollectionValueTypes() as $type) {
             // Handle list pseudo type
             // https://symfony.com/doc/current/components/property_info.html#type-getcollectionkeytypes-type-getcollectionvaluetypes
-            if ($this->supports([$type]) && [] === $type->getCollectionValueTypes()) {
+            if ($this->supports([$type], $context) && [] === $type->getCollectionValueTypes()) {
                 continue;
             }
 
@@ -60,7 +60,7 @@ class ArrayPropertyDescriber implements PropertyDescriberInterface, ModelRegistr
         }
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
         if (1 !== count($types) || !$types[0]->isCollection()) {
             return false;

--- a/src/PropertyDescriber/BooleanPropertyDescriber.php
+++ b/src/PropertyDescriber/BooleanPropertyDescriber.php
@@ -42,7 +42,7 @@ class BooleanPropertyDescriber implements PropertyDescriberInterface
         $property->type = 'boolean';
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
         return 1 === count($types) && Type::BUILTIN_TYPE_BOOL === $types[0]->getBuiltinType();
     }

--- a/src/PropertyDescriber/CompoundPropertyDescriber.php
+++ b/src/PropertyDescriber/CompoundPropertyDescriber.php
@@ -54,7 +54,7 @@ class CompoundPropertyDescriber implements PropertyDescriberInterface, ModelRegi
         }
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
         return count($types) >= 2;
     }

--- a/src/PropertyDescriber/DateTimePropertyDescriber.php
+++ b/src/PropertyDescriber/DateTimePropertyDescriber.php
@@ -43,7 +43,7 @@ class DateTimePropertyDescriber implements PropertyDescriberInterface
         $property->format = 'date-time';
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
         return 1 === count($types)
             && Type::BUILTIN_TYPE_OBJECT === $types[0]->getBuiltinType()

--- a/src/PropertyDescriber/DictionaryPropertyDescriber.php
+++ b/src/PropertyDescriber/DictionaryPropertyDescriber.php
@@ -52,7 +52,7 @@ final class DictionaryPropertyDescriber implements PropertyDescriberInterface, M
         $this->propertyDescriber->describe($types[0]->getCollectionValueTypes(), $additionalProperties, $groups, $schema, $context);
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
         return 1 === count($types)
             && $types[0]->isCollection()

--- a/src/PropertyDescriber/FloatPropertyDescriber.php
+++ b/src/PropertyDescriber/FloatPropertyDescriber.php
@@ -43,7 +43,7 @@ class FloatPropertyDescriber implements PropertyDescriberInterface
         $property->format = 'float';
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
         return 1 === count($types) && Type::BUILTIN_TYPE_FLOAT === $types[0]->getBuiltinType();
     }

--- a/src/PropertyDescriber/IntegerPropertyDescriber.php
+++ b/src/PropertyDescriber/IntegerPropertyDescriber.php
@@ -42,7 +42,7 @@ class IntegerPropertyDescriber implements PropertyDescriberInterface
         $property->type = 'integer';
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
         return 1 === count($types) && Type::BUILTIN_TYPE_INT === $types[0]->getBuiltinType();
     }

--- a/src/PropertyDescriber/NullablePropertyDescriber.php
+++ b/src/PropertyDescriber/NullablePropertyDescriber.php
@@ -48,7 +48,7 @@ final class NullablePropertyDescriber implements PropertyDescriberInterface, Pro
         $this->propertyDescriber->describe($types, $property, $groups, $schema, $context);
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
         foreach ($types as $type) {
             if ($type->isNullable()) {

--- a/src/PropertyDescriber/ObjectPropertyDescriber.php
+++ b/src/PropertyDescriber/ObjectPropertyDescriber.php
@@ -65,7 +65,7 @@ class ObjectPropertyDescriber implements PropertyDescriberInterface, ModelRegist
         $property->ref = $this->modelRegistry->register(new Model($type, $groups, [], $context));
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
         return 1 === count($types)
             && Type::BUILTIN_TYPE_OBJECT === $types[0]->getBuiltinType();

--- a/src/PropertyDescriber/PropertyDescriber.php
+++ b/src/PropertyDescriber/PropertyDescriber.php
@@ -60,7 +60,7 @@ final class PropertyDescriber implements PropertyDescriberInterface, ModelRegist
             );
         }
 
-        if (null === $propertyDescriber = $this->getPropertyDescriber($types)) {
+        if (null === $propertyDescriber = $this->getPropertyDescriber($types, $context)) {
             return;
         }
 
@@ -69,9 +69,9 @@ final class PropertyDescriber implements PropertyDescriberInterface, ModelRegist
         $this->called = []; // Reset recursion helper
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
-        return null !== $this->getPropertyDescriber($types);
+        return null !== $this->getPropertyDescriber($types, $context);
     }
 
     /**
@@ -83,9 +83,10 @@ final class PropertyDescriber implements PropertyDescriberInterface, ModelRegist
     }
 
     /**
-     * @param Type[] $types
+     * @param Type[]               $types
+     * @param array<string, mixed> $context
      */
-    private function getPropertyDescriber(array $types): ?PropertyDescriberInterface
+    private function getPropertyDescriber(array $types, array $context): ?PropertyDescriberInterface
     {
         foreach ($this->propertyDescribers as $propertyDescriber) {
             /* BC layer for Symfony < 6.3 @see https://symfony.com/doc/6.3/service_container/tags.html#reference-tagged-services */
@@ -108,7 +109,7 @@ final class PropertyDescriber implements PropertyDescriberInterface, ModelRegist
                 $propertyDescriber->setPropertyDescriber($this);
             }
 
-            if ($propertyDescriber->supports($types)) {
+            if ($propertyDescriber->supports($types, $context)) {
                 return $propertyDescriber;
             }
         }

--- a/src/PropertyDescriber/PropertyDescriberInterface.php
+++ b/src/PropertyDescriber/PropertyDescriberInterface.php
@@ -30,5 +30,5 @@ interface PropertyDescriberInterface
      * @param Type[]               $types
      * @param array<string, mixed> $context Context options for describing the property
      */
-    public function supports(array $types, array $context = []): bool;
+    public function supports(array $types /* , array $context = [] */): bool;
 }

--- a/src/PropertyDescriber/PropertyDescriberInterface.php
+++ b/src/PropertyDescriber/PropertyDescriberInterface.php
@@ -27,7 +27,8 @@ interface PropertyDescriberInterface
     public function describe(array $types, Schema $property, ?array $groups = null /* , ?Schema $schema = null */ /* , array $context = [] */);
 
     /**
-     * @param Type[] $types
+     * @param Type[]               $types
+     * @param array<string, mixed> $context Context options for describing the property
      */
-    public function supports(array $types): bool;
+    public function supports(array $types, array $context = []): bool;
 }

--- a/src/PropertyDescriber/RequiredPropertyDescriber.php
+++ b/src/PropertyDescriber/RequiredPropertyDescriber.php
@@ -66,7 +66,7 @@ final class RequiredPropertyDescriber implements PropertyDescriberInterface, Pro
         $schema->required = array_values(array_unique($existingRequiredFields));
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
         return true;
     }

--- a/src/PropertyDescriber/StringPropertyDescriber.php
+++ b/src/PropertyDescriber/StringPropertyDescriber.php
@@ -42,7 +42,7 @@ class StringPropertyDescriber implements PropertyDescriberInterface
         $property->type = 'string';
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
         return 1 === count($types) && Type::BUILTIN_TYPE_STRING === $types[0]->getBuiltinType();
     }

--- a/src/PropertyDescriber/UuidPropertyDescriber.php
+++ b/src/PropertyDescriber/UuidPropertyDescriber.php
@@ -26,7 +26,7 @@ final class UuidPropertyDescriber implements PropertyDescriberInterface
         $property->format = 'uuid';
     }
 
-    public function supports(array $types): bool
+    public function supports(array $types, array $context = []): bool
     {
         return 1 === count($types)
             && Type::BUILTIN_TYPE_OBJECT === $types[0]->getBuiltinType()


### PR DESCRIPTION
## Description

https://github.com/nelmio/NelmioApiDocBundle/pull/2388#discussion_r1838271248

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [x] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)