### PR TITLE
refactor: [5.x] mixed types & trailing comma

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -20,6 +20,5 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 HEADER
         ],
-        'trailing_comma_in_multiline' => false,
     ])
     ->setFinder($finder);

--- a/src/Attribute/Model.php
+++ b/src/Attribute/Model.php
@@ -58,7 +58,7 @@ final class Model extends Attachable
         string $type = Generator::UNDEFINED,
         ?array $groups = null,
         array $options = [],
-        array $serializationContext = []
+        array $serializationContext = [],
     ) {
         parent::__construct($properties + [
             'type' => $type,

--- a/src/Attribute/Security.php
+++ b/src/Attribute/Security.php
@@ -37,7 +37,7 @@ class Security extends AbstractAnnotation
     public function __construct(
         array $properties = [],
         ?string $name = null,
-        array $scopes = []
+        array $scopes = [],
     ) {
         parent::__construct($properties + [
             'name' => $name,

--- a/src/ModelDescriber/Annotations/AnnotationsReader.php
+++ b/src/ModelDescriber/Annotations/AnnotationsReader.php
@@ -31,7 +31,7 @@ class AnnotationsReader
     public function __construct(
         ModelRegistry $modelRegistry,
         array $mediaTypes,
-        bool $useValidationGroups = false
+        bool $useValidationGroups = false,
     ) {
         $this->phpDocReader = new PropertyPhpDocReader();
         $this->openApiAnnotationsReader = new OpenApiAnnotationsReader($modelRegistry, $mediaTypes);

--- a/src/ModelDescriber/Annotations/ReflectionReader.php
+++ b/src/ModelDescriber/Annotations/ReflectionReader.php
@@ -36,7 +36,7 @@ final class ReflectionReader
      */
     public function updateProperty(
         $reflection,
-        OA\Property $property
+        OA\Property $property,
     ): void {
         // The default has been set by an Annotation or Attribute
         // We leave that as it is!

--- a/src/ModelDescriber/ApplyOpenApiDiscriminatorTrait.php
+++ b/src/ModelDescriber/ApplyOpenApiDiscriminatorTrait.php
@@ -41,7 +41,7 @@ trait ApplyOpenApiDiscriminatorTrait
         OA\Schema $schema,
         ModelRegistry $modelRegistry,
         string $discriminatorProperty,
-        array $typeMap
+        array $typeMap,
     ): void {
         $weakContext = Util::createWeakContext($schema->_context);
 

--- a/src/ModelDescriber/FormModelDescriber.php
+++ b/src/ModelDescriber/FormModelDescriber.php
@@ -53,7 +53,7 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
         FormFactoryInterface $formFactory,
         array $mediaTypes,
         bool $useValidationGroups,
-        bool $isFormCsrfExtensionEnabled
+        bool $isFormCsrfExtensionEnabled,
     ) {
         $this->formFactory = $formFactory;
         $this->mediaTypes = $mediaTypes;

--- a/src/ModelDescriber/JMSModelDescriber.php
+++ b/src/ModelDescriber/JMSModelDescriber.php
@@ -71,7 +71,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
         array $mediaTypes,
         ?PropertyNamingStrategyInterface $namingStrategy = null,
         bool $useValidationGroups = false,
-        ?SerializationContextFactoryInterface $contextFactory = null
+        ?SerializationContextFactoryInterface $contextFactory = null,
     ) {
         $this->factory = $factory;
         $this->namingStrategy = $namingStrategy;

--- a/src/ModelDescriber/ObjectModelDescriber.php
+++ b/src/ModelDescriber/ObjectModelDescriber.php
@@ -49,7 +49,7 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
         array $mediaTypes,
         ?NameConverterInterface $nameConverter = null,
         bool $useValidationGroups = false,
-        ?ClassMetadataFactoryInterface $classMetadataFactory = null
+        ?ClassMetadataFactoryInterface $classMetadataFactory = null,
     ) {
         $this->propertyInfo = $propertyInfo;
         $this->propertyDescriber = $propertyDescribers;

--- a/src/OpenApiPhp/ModelRegister.php
+++ b/src/OpenApiPhp/ModelRegister.php
@@ -164,7 +164,7 @@ final class ModelRegister
         string $type,
         array $properties,
         OA\AbstractAnnotation $annotation,
-        Analysis $analysis
+        Analysis $analysis,
     ): void {
         switch ($type) {
             case 'json':

--- a/src/OpenApiPhp/Util.php
+++ b/src/OpenApiPhp/Util.php
@@ -252,7 +252,7 @@ final class Util
      *
      * @see OA\AbstractAnnotation::$_nested
      */
-    public static function getIndexedCollectionItem(OA\AbstractAnnotation $parent, string $class, $value): OA\AbstractAnnotation
+    public static function getIndexedCollectionItem(OA\AbstractAnnotation $parent, string $class, mixed $value): OA\AbstractAnnotation
     {
         $nested = $parent::$_nested;
         [$collection, $property] = $nested[$class];
@@ -302,7 +302,7 @@ final class Util
      *
      * @return false|int|string
      */
-    public static function searchIndexedCollectionItem(array $collection, string $member, $value)
+    public static function searchIndexedCollectionItem(array $collection, string $member, mixed $value)
     {
         foreach ($collection as $i => $child) {
             if ($child->{$member} === $value) {
@@ -508,7 +508,7 @@ final class Util
      * @param class-string<T> $className
      * @param mixed           $value     The value of the property
      */
-    private static function mergeChild(OA\AbstractAnnotation $annotation, string $className, $value, bool $overwrite): void
+    private static function mergeChild(OA\AbstractAnnotation $annotation, string $className, mixed $value, bool $overwrite): void
     {
         self::merge(self::getChild($annotation, $className), $value, $overwrite);
     }

--- a/src/PropertyDescriber/PropertyDescriber.php
+++ b/src/PropertyDescriber/PropertyDescriber.php
@@ -32,7 +32,7 @@ final class PropertyDescriber implements PropertyDescriberInterface, ModelRegist
      * @param iterable<PropertyDescriberInterface> $propertyDescribers
      */
     public function __construct(
-        iterable $propertyDescribers
+        iterable $propertyDescribers,
     ) {
         $this->propertyDescribers = $propertyDescribers;
     }

--- a/src/RouteDescriber/RouteArgumentDescriber.php
+++ b/src/RouteDescriber/RouteArgumentDescriber.php
@@ -30,7 +30,7 @@ final class RouteArgumentDescriber implements RouteDescriberInterface, ModelRegi
      */
     public function __construct(
         private ArgumentMetadataFactoryInterface $argumentMetadataFactory,
-        private iterable $inlineParameterDescribers
+        private iterable $inlineParameterDescribers,
     ) {
     }
 

--- a/src/Routing/FilteredRouteCollectionBuilder.php
+++ b/src/Routing/FilteredRouteCollectionBuilder.php
@@ -35,7 +35,7 @@ final class FilteredRouteCollectionBuilder
     public function __construct(
         ControllerReflector $controllerReflector,
         string $area,
-        array $options = []
+        array $options = [],
     ) {
         $resolver = new OptionsResolver();
         $resolver

--- a/tests/Functional/Controller/ApiController.php
+++ b/tests/Functional/Controller/ApiController.php
@@ -465,7 +465,7 @@ class ApiController
     #[Route('/inline_path_parameters')]
     #[OA\Response(response: '200', description: '')]
     public function inlinePathParameters(
-        #[OA\PathParameter] string $product_id
+        #[OA\PathParameter] string $product_id,
     ) {
     }
 

--- a/tests/Functional/Controller/MapQueryStringController.php
+++ b/tests/Functional/Controller/MapQueryStringController.php
@@ -27,14 +27,14 @@ class MapQueryStringController
     #[Route('/article_map_query_string', methods: ['GET'])]
     #[OA\Response(response: '200', description: '')]
     public function fetchArticleFromMapQueryString(
-        #[MapQueryString] SymfonyMapQueryString $article81Query
+        #[MapQueryString] SymfonyMapQueryString $article81Query,
     ) {
     }
 
     #[Route('/article_map_query_string_nullable', methods: ['GET'])]
     #[OA\Response(response: '200', description: '')]
     public function fetchArticleFromMapQueryStringNullable(
-        #[MapQueryString] ?SymfonyMapQueryString $article81Query
+        #[MapQueryString] ?SymfonyMapQueryString $article81Query,
     ) {
     }
 
@@ -74,7 +74,7 @@ class MapQueryStringController
     )]
     #[OA\Response(response: '200', description: '')]
     public function fetchArticleFromMapQueryStringOverwriteParameters(
-        #[MapQueryString] SymfonyMapQueryString $article81Query
+        #[MapQueryString] SymfonyMapQueryString $article81Query,
     ) {
     }
 

--- a/tests/Functional/JMSFunctionalTest.php
+++ b/tests/Functional/JMSFunctionalTest.php
@@ -328,7 +328,7 @@ class JMSFunctionalTest extends WebTestCase
                     'type' => 'string',
                     'maxLength' => 10,
                     'minLength' => 3,
-                    'default' => 'default'
+                    'default' => 'default',
                 ],
             ],
             'schema' => 'JMSNamingStrategyConstraints',
@@ -376,8 +376,8 @@ class JMSFunctionalTest extends WebTestCase
             'type' => 'string',
             'enum' => [
                 'draft',
-                'final'
-            ]
+                'final',
+            ],
         ], json_decode($this->getModel('ArticleType81')->toJson(), true));
 
         if (TestKernel::isAnnotationsAvailable()) {
@@ -390,8 +390,8 @@ class JMSFunctionalTest extends WebTestCase
             'type' => 'string',
             'enum' => [
                 'DRAFT',
-                'FINAL'
-            ]
+                'FINAL',
+            ],
         ], json_decode($this->getModel('ArticleType812')->toJson(), true));
 
         self::assertEquals([
@@ -399,24 +399,24 @@ class JMSFunctionalTest extends WebTestCase
             'type' => 'object',
             'properties' => [
                 'enum_value' => [
-                    '$ref' => '#/components/schemas/ArticleType81'
+                    '$ref' => '#/components/schemas/ArticleType81',
                 ],
                 'enum_values' => [
                     'type' => 'array',
                     'items' => [
-                        '$ref' => '#/components/schemas/ArticleType81'
-                    ]
+                        '$ref' => '#/components/schemas/ArticleType81',
+                    ],
                 ],
                 'enum_name' => [
-                    '$ref' => '#/components/schemas/ArticleType812'
+                    '$ref' => '#/components/schemas/ArticleType812',
                 ],
                 'enum_names' => [
                     'type' => 'array',
                     'items' => [
-                        '$ref' => '#/components/schemas/ArticleType812'
-                    ]
+                        '$ref' => '#/components/schemas/ArticleType812',
+                    ],
                 ],
-            ]
+            ],
         ], json_decode($this->getModel('JMSEnum')->toJson(), true));
     }
 

--- a/tests/Routing/FilteredRouteCollectionBuilderTest.php
+++ b/tests/Routing/FilteredRouteCollectionBuilderTest.php
@@ -244,7 +244,7 @@ class FilteredRouteCollectionBuilderTest extends TestCase
         Route $route,
         \ReflectionMethod $reflectionMethod,
         array $options,
-        int $expectedRoutesCount
+        int $expectedRoutesCount,
     ): void {
         $routes = new RouteCollection();
         $routes->add($name, $route);


### PR DESCRIPTION
## Description

Adds `mixed` php type in code & allows trailing comma's to be used in [PHP-CS-Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer)

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [x] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)