### PR TITLE
fix(#2403): deprecation warning in symfony 7.2 when using "tagged" type in service configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 4.33.5
 * Added new optional parameter `$context` to` PropertyDescriberInterface::supports()`
+* Fixed usage of `tagged` type in service configuration which is deprecated in Symfony `7.2`
 
 ## 4.33.4
 * Deprecated `null` type from `$options` in `Nelmio\ApiDocBundle\Attribute\Model::__construct()`. Pass an empty array (`[]`) instead.

--- a/config/services.xml
+++ b/config/services.xml
@@ -102,7 +102,7 @@
 
         <!-- Property Describers -->
         <service id="nelmio_api_doc.object_model.property_describer" class="Nelmio\ApiDocBundle\PropertyDescriber\PropertyDescriber" public="false">
-            <argument type="tagged" tag="nelmio_api_doc.object_model.property_describer" />
+            <argument type="tagged_iterator" tag="nelmio_api_doc.object_model.property_describer" />
 
             <tag name="nelmio_api_doc.object_model.property_describer" priority="100" />
         </service>


### PR DESCRIPTION
## Description

`tagged_iterator` is already available in Symfony 5.4 (https://symfony.com/doc/5.x/service_container/tags.html#reference-tagged-services).
Therefore, the deprecated type `tagged` can just be replaced with `tagged_iterator`.

Closes #2403 

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactor
- [x] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [x] I have made corresponding changes to the changelog (`CHANGELOG.md`)