### PR TITLE
feat(#1461): filter JMS properties by route area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+* Add filtering model properties by route area to `JMSModelDescriber`
+
 ## 4.33.5
 * Added new optional parameter `$context` to` PropertyDescriberInterface::supports()`
 
@@ -25,7 +27,7 @@
 ## 4.32.3
 
 * Deprecated `Nelmio\ApiDocBundle\Annotation` namespace in favor of `Nelmio\ApiDocBundle\Attribute` namespace in preparation for 5.x. Consider upgrading to the new attribute syntax.
-```diff 
+```diff
 - use Nelmio\ApiDocBundle\Annotation\Areas;
 - use Nelmio\ApiDocBundle\Annotation\Model;
 - use Nelmio\ApiDocBundle\Annotation\Operation;
@@ -84,7 +86,7 @@ nelmio_api_doc:
 
 ## 4.24.0
 
-* Added support for some integer ranges (https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges).  
+* Added support for some integer ranges (https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges).
   Annotations attached to integer properties like:
   ```php
     /**
@@ -109,9 +111,9 @@ Dropped support for PHP 7.2 and PHP 7.3. PHP 7.4 is the minimum required version
           pool: app.cache
           item_id: nelmio_api_doc.docs
       areas:
-          default: 
+          default:
               ...
-          area1:   
+          area1:
               ...
   ```
   Result in cache keys: `nelmio_api_doc.docs.default` & `nelmio_api_doc.docs.area1` to be used respectively.
@@ -124,7 +126,7 @@ Dropped support for PHP 7.2 and PHP 7.3. PHP 7.4 is the minimum required version
                   pool: app.cache
                   item_id: nelmio_api_doc.docs.default
               ...
-          area1:   
+          area1:
               cache:
                   pool: app.cache
                   item_id: nelmio_api_doc.docs.area1
@@ -186,7 +188,7 @@ doc-api:
           pool: app.cache
           item_id: nelmio_api_doc.docs
   ```
-  
+
 ## 4.20.0
 
 * Added Redocly as an alternative to Swagger UI. https://github.com/Redocly/redoc.

--- a/src/ApiDocGenerator.php
+++ b/src/ApiDocGenerator.php
@@ -50,6 +50,8 @@ final class ApiDocGenerator
      */
     private $openApiVersion;
 
+    private ?string $area = null;
+
     private Generator $generator;
 
     /**
@@ -86,6 +88,11 @@ final class ApiDocGenerator
         $this->openApiVersion = $openApiVersion;
     }
 
+    public function setArea(string $area): void
+    {
+        $this->area = $area;
+    }
+
     public function generate(): OpenApi
     {
         if (null !== $this->openApi) {
@@ -108,7 +115,7 @@ final class ApiDocGenerator
         $context = Util::createContext(['version' => $this->generator->getVersion()]);
 
         $this->openApi = new OpenApi(['_context' => $context]);
-        $modelRegistry = new ModelRegistry($this->modelDescribers, $this->openApi, $this->alternativeNames);
+        $modelRegistry = new ModelRegistry($this->modelDescribers, $this->openApi, $this->alternativeNames, $this->area);
         if (null !== $this->logger) {
             $modelRegistry->setLogger($this->logger);
         }

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -27,6 +27,8 @@ final class Model
      */
     private array $serializationContext;
 
+    private ?string $area = null;
+
     /**
      * @param string[]|null $groups
      * @param mixed[]|null  $options
@@ -71,6 +73,16 @@ final class Model
     public function getHash(): string
     {
         return md5(serialize([$this->type, $this->getSerializationContext()]));
+    }
+
+    public function setArea(?string $area): void
+    {
+        $this->area = $area;
+    }
+
+    public function getArea(): ?string
+    {
+        return $this->area;
     }
 
     /**

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -53,6 +53,8 @@ final class ModelRegistry
      */
     private iterable $modelDescribers;
 
+    private ?string $area;
+
     private OA\OpenApi $api;
 
     /**
@@ -61,10 +63,11 @@ final class ModelRegistry
      *
      * @internal
      */
-    public function __construct($modelDescribers, OA\OpenApi $api, array $alternativeNames = [])
+    public function __construct($modelDescribers, OA\OpenApi $api, array $alternativeNames = [], ?string $area = null)
     {
         $this->modelDescribers = $modelDescribers;
         $this->api = $api;
+        $this->area = $area;
         $this->logger = new NullLogger();
         foreach (array_reverse($alternativeNames) as $alternativeName => $criteria) {
             $this->alternativeNames[] = $model = new Model(
@@ -81,6 +84,7 @@ final class ModelRegistry
 
     public function register(Model $model): string
     {
+        $model->setArea($this->area);
         $hash = $model->getHash();
         if (!isset($this->models[$hash])) {
             $this->models[$hash] = $model;

--- a/src/ModelDescriber/JMSModelDescriber.php
+++ b/src/ModelDescriber/JMSModelDescriber.php
@@ -234,7 +234,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
         }
 
         $area = $model->getArea();
-        if ( null !== $area ) {
+        if (null !== $area) {
             $context->addExclusionStrategy(new VersionExclusionStrategy($area));
         }
 

--- a/src/ModelDescriber/JMSModelDescriber.php
+++ b/src/ModelDescriber/JMSModelDescriber.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Annotations\Reader;
 use JMS\Serializer\Context;
 use JMS\Serializer\ContextFactory\SerializationContextFactoryInterface;
 use JMS\Serializer\Exclusion\GroupsExclusionStrategy;
+use JMS\Serializer\Exclusion\VersionExclusionStrategy;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
 use JMS\Serializer\SerializationContext;
@@ -230,6 +231,11 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
             if (null !== $model->getGroups()) {
                 $context->addExclusionStrategy(new GroupsExclusionStrategy($model->getGroups()));
             }
+        }
+
+        $area = $model->getArea();
+        if ( null !== $area ) {
+            $context->addExclusionStrategy(new VersionExclusionStrategy($area));
         }
 
         return $context;

--- a/src/Render/RenderOpenApi.php
+++ b/src/Render/RenderOpenApi.php
@@ -11,6 +11,7 @@
 
 namespace Nelmio\ApiDocBundle\Render;
 
+use Nelmio\ApiDocBundle\ApiDocGenerator;
 use Nelmio\ApiDocBundle\Exception\RenderInvalidArgumentException;
 use OpenApi\Annotations\OpenApi;
 use OpenApi\Annotations\Server;
@@ -18,7 +19,6 @@ use OpenApi\Context;
 use OpenApi\Generator;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Nelmio\ApiDocBundle\ApiDocGenerator;
 
 class RenderOpenApi
 {

--- a/src/Render/RenderOpenApi.php
+++ b/src/Render/RenderOpenApi.php
@@ -18,6 +18,7 @@ use OpenApi\Context;
 use OpenApi\Generator;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Nelmio\ApiDocBundle\ApiDocGenerator;
 
 class RenderOpenApi
 {
@@ -81,8 +82,14 @@ class RenderOpenApi
             throw new RenderInvalidArgumentException(sprintf('Format "%s" is not supported.', $format));
         }
 
+        $generator = $this->generatorLocator->get($area);
+
+        if ($generator instanceof ApiDocGenerator) {
+            $generator->setArea($area);
+        }
+
         /** @var OpenApi $spec */
-        $spec = $this->generatorLocator->get($area)->generate();
+        $spec = $generator->generate();
         $tmpServers = $spec->servers;
         try {
             $spec->servers = $this->getServersFromOptions($spec, $options);


### PR DESCRIPTION
## Description

This PR uses the area configured in the route (like `/api/{area}/doc/`) to filter out properties on the model, which should be excluded based on JMS's versioning (also see demo below.)

Closes #1461
Refs #2129

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [x] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [x] I have made corresponding changes to the changelog (`CHANGELOG.md`)

## Demo from our project

We have an entity property:
```php
// MyEntity.php

#[Serializer\Until('v3')]
private \DateTimeInterface $createdAt;                                                                                                     
```

Opening the docs on the route: `/api/v4.3/doc/`,
which is configured as:
```yaml
# config/routes/nelmio_api_doc.yaml

nelmio_api_doc_index:
  path: /api/{area}/doc/
  defaults: { _controller: nelmio_api_doc.controller.swagger_ui }
  methods: [GET]
```

**before this PR**
<img width="487" alt="Screenshot 2024-12-09 at 12 53 27" src="https://github.com/user-attachments/assets/2adc29ac-d523-4db7-9c12-c5b3f947fda3">
**after this PR**
<img width="459" alt="Screenshot 2024-12-09 at 12 54 45" src="https://github.com/user-attachments/assets/1696dcad-6025-41bb-a60b-dff944b593e1">

## Implementation

I opted for the word "area", since it is used in the route definition.
I proceeded as adviced in #1461.

Could you point me to where you would like to see tests created/adjusted?