### PR TITLE
Remove deprecate use of tagged argument in favor of tagged_iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 4.33.6
+* Fixed Symfony 7.2 deprecation of tagged arguments
+
 ## 4.33.5
 * Added new optional parameter `$context` to` PropertyDescriberInterface::supports()`
 

--- a/config/services.xml
+++ b/config/services.xml
@@ -102,7 +102,7 @@
 
         <!-- Property Describers -->
         <service id="nelmio_api_doc.object_model.property_describer" class="Nelmio\ApiDocBundle\PropertyDescriber\PropertyDescriber" public="false">
-            <argument type="tagged" tag="nelmio_api_doc.object_model.property_describer" />
+            <argument type="tagged_iterator" tag="nelmio_api_doc.object_model.property_describer" />
 
             <tag name="nelmio_api_doc.object_model.property_describer" priority="100" />
         </service>


### PR DESCRIPTION
## Description

I now get this error on a 7.2 project:

> Since symfony/dependency-injection 7.2: Type "tagged" is deprecated for tag <argument>, use "tagged_iterator" instead in ".../vendor/nelmio/api-doc-bundle/src/DependencyInjection/../../config/services.xml".

tagged_iterator exists on https://symfony.com/doc/5.x/service_container/tags.html so I believe this is safe to use already for v4 / symfony 5.4+.

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [x] I have made corresponding changes to the changelog (`CHANGELOG.md`)