### PR TITLE
chore: allow zircote/swagger-php v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/options-resolver": "^5.4 || ^6.4 || ^7.1",
         "symfony/property-info": "^5.4.10 || ^6.4 || ^7.1",
         "symfony/routing": "^5.4 || ^6.4 || ^7.1",
-        "zircote/swagger-php": "^4.6.1 || ^5.0"
+        "zircote/swagger-php": "^4.11.1 || ^5.0"
     },
     "require-dev": {
         "api-platform/core": "^2.7.0 || ^3",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/options-resolver": "^5.4 || ^6.4 || ^7.1",
         "symfony/property-info": "^5.4.10 || ^6.4 || ^7.1",
         "symfony/routing": "^5.4 || ^6.4 || ^7.1",
-        "zircote/swagger-php": "^4.6.1"
+        "zircote/swagger-php": "^4.6.1 || ^5.0"
     },
     "require-dev": {
         "api-platform/core": "^2.7.0 || ^3",

--- a/src/ApiDocGenerator.php
+++ b/src/ApiDocGenerator.php
@@ -103,7 +103,10 @@ final class ApiDocGenerator
             $this->generator->setVersion($this->openApiVersion);
         }
 
-        $this->generator->setProcessors($this->getProcessors($this->generator));
+        // Remove OperationId processor as we use a lot of generated annotations which do not have enough information in their context
+        // to generate these ids properly.
+        // @see \Nelmio\ApiDocBundle\OpenApiPhp\Util::createContext
+        $this->generator->getProcessorPipeline()->remove(\OpenApi\Processors\OperationId::class);
 
         $context = Util::createContext(['version' => $this->generator->getVersion()]);
 
@@ -130,7 +133,7 @@ final class ApiDocGenerator
         // Calculate the associated schemas
         $modelRegistry->registerSchemas();
 
-        $analysis->process($this->generator->getProcessors());
+        $this->generator->getProcessorPipeline()->process($analysis);
         $analysis->validate();
 
         if (isset($item)) {
@@ -138,29 +141,5 @@ final class ApiDocGenerator
         }
 
         return $this->openApi;
-    }
-
-    /**
-     * Get an array of processors that will be used to process the OpenApi object.
-     *
-     * @param Generator $generator The generator instance to get the standard processors from
-     *
-     * @return array<callable> The array of processors
-     */
-    private function getProcessors(Generator $generator): array
-    {
-        // Get the standard processors from the generator.
-        $processors = $generator->getProcessors();
-
-        // Remove OperationId processor as we use a lot of generated annotations which do not have enough information in their context
-        // to generate these ids properly.
-        // @see \Nelmio\ApiDocBundle\OpenApiPhp\Util::createContext
-        foreach ($processors as $key => $processor) {
-            if ($processor instanceof \OpenApi\Processors\OperationId) {
-                unset($processors[$key]);
-            }
-        }
-
-        return $processors;
     }
 }

--- a/src/DependencyInjection/Compiler/CustomProcessorPass.php
+++ b/src/DependencyInjection/Compiler/CustomProcessorPass.php
@@ -45,7 +45,7 @@ final class CustomProcessorPass implements CompilerPassInterface
                 }
             }
 
-            $definition->addMethodCall('addProcessor', [$reference, $before]);
+            $definition->addMethodCall('addNelmioProcessor', [$reference, $before]);
         }
     }
 }

--- a/src/DependencyInjection/NelmioApiDocExtension.php
+++ b/src/DependencyInjection/NelmioApiDocExtension.php
@@ -21,6 +21,7 @@ use Nelmio\ApiDocBundle\Describer\RouteDescriber;
 use Nelmio\ApiDocBundle\ModelDescriber\BazingaHateoasModelDescriber;
 use Nelmio\ApiDocBundle\ModelDescriber\JMSModelDescriber;
 use Nelmio\ApiDocBundle\ModelDescriber\ModelDescriberInterface;
+use Nelmio\ApiDocBundle\OpenApiGenerator;
 use Nelmio\ApiDocBundle\Processor\MapQueryStringProcessor;
 use Nelmio\ApiDocBundle\Processor\MapRequestPayloadProcessor;
 use Nelmio\ApiDocBundle\RouteDescriber\RouteArgumentDescriber;
@@ -75,7 +76,7 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
         $container->setParameter('nelmio_api_doc.use_validation_groups', $config['use_validation_groups']);
 
         // Register the OpenAPI Generator as a service.
-        $container->register('nelmio_api_doc.open_api.generator', Generator::class)
+        $container->register('nelmio_api_doc.open_api.generator', OpenApiGenerator::class)
             ->setPublic(false);
 
         $cachePool = $config['cache']['pool'] ?? null;

--- a/src/OpenApiGenerator.php
+++ b/src/OpenApiGenerator.php
@@ -15,8 +15,10 @@ use OpenApi\Generator;
 
 /**
  * Extension of OpenApi\Generator to be able to inject processors with dependency injection.
+ *
+ * @internal
  */
-class OpenApiGenerator extends Generator
+final class OpenApiGenerator extends Generator
 {
     public function addNelmioProcessor(callable $processor, ?string $before = null): void
     {

--- a/src/OpenApiGenerator.php
+++ b/src/OpenApiGenerator.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle;
+
+use OpenApi\Generator;
+
+/**
+ * Extension of OpenApi\Generator to be able to inject processors with dependency injection.
+ */
+class OpenApiGenerator extends Generator
+{
+    public function addNelmioProcessor(callable $processor, ?string $before = null): void
+    {
+        if (null === $before) {
+            $this->getProcessorPipeline()->add($processor);
+        } else {
+            $this->getProcessorPipeline()->insert($processor, $before);
+        }
+    }
+}


### PR DESCRIPTION
## Description

zircote/swagger-php v5 has been released, and seems to only require minimal updates. See https://github.com/zircote/swagger-php/blob/master/docs/guide/migrating-to-v5.md.

I did need to migrate the current processor implementation to the one that is using the new processor pipeline introduced with 4.10.0, which is why I bumped the minimum constraint. In order to not mess up dependency injection, I was required to wrap the Generator class in order to allow adding additional processors using the existing compiler pass.

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [x] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)