### PR TITLE
fix: before implementation with custom processors

### DIFF
--- a/src/DependencyInjection/Compiler/CustomProcessorPass.php
+++ b/src/DependencyInjection/Compiler/CustomProcessorPass.php
@@ -14,7 +14,6 @@ namespace Nelmio\ApiDocBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Compiler Pass to identify and register custom processors.
@@ -36,24 +35,17 @@ final class CustomProcessorPass implements CompilerPassInterface
         $definition = $container->findDefinition('nelmio_api_doc.open_api.generator');
 
         foreach ($this->findAndSortTaggedServices('nelmio_api_doc.swagger.processor', $container) as $reference) {
-            $id = (string) $reference;
-            $tags = $container->findDefinition($id)->getTags();
-
-            /**
-             * Before which processor should this processor be run?
-             *
-             * @var string|null
-             */
-            $before = null;
+            $tags = $container->findDefinition((string) $reference)->getTag('nelmio_api_doc.swagger.processor');
 
             // See if the processor has a 'before' attribute.
+            $before = null;
             foreach ($tags as $tag) {
                 if (isset($tag['before'])) {
                     $before = $tag['before'];
                 }
             }
 
-            $definition->addMethodCall('addProcessor', [new Reference($id), $before]);
+            $definition->addMethodCall('addProcessor', [$reference, $before]);
         }
     }
 }

--- a/tests/Functional/Configs/StubProcessor.yaml
+++ b/tests/Functional/Configs/StubProcessor.yaml
@@ -1,0 +1,4 @@
+services:
+  Nelmio\ApiDocBundle\Tests\Functional\StubProcessor:
+    tags:
+      - { name: 'nelmio_api_doc.swagger.processor', priority: -100, before: OpenApi\Processors\CleanUnusedComponents }

--- a/tests/Functional/ControllerTest.php
+++ b/tests/Functional/ControllerTest.php
@@ -202,7 +202,7 @@ final class ControllerTest extends WebTestCase
             null,
             'VendorExtension',
             [],
-            [__DIR__.'/Configs/VendorExtension.yaml'],
+            [__DIR__.'/Configs/VendorExtension.yaml', __DIR__.'/Configs/StubProcessor.yaml'],
         ];
     }
 

--- a/tests/Functional/StubProcessor.php
+++ b/tests/Functional/StubProcessor.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional;
+
+use OpenApi\Analysis;
+
+class StubProcessor
+{
+    public function __invoke(Analysis $analysis): void
+    {
+        // Does nothing
+    }
+}


### PR DESCRIPTION
## Description

The before implementation was never functional, as the returned tags array is a tag name indexed array of tags. This change resolves that, and adds a test to actually insert a processor with the before attribute.

![image](https://github.com/user-attachments/assets/eba83f7a-45ba-4fac-b05b-7e43bd80f33b)

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)