### PR TITLE
fix: mark PropertyDescribers with @final

### DIFF
--- a/src/PropertyDescriber/ArrayPropertyDescriber.php
+++ b/src/PropertyDescriber/ArrayPropertyDescriber.php
@@ -17,6 +17,9 @@ use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 use OpenApi\Annotations as OA;
 use Symfony\Component\PropertyInfo\Type;
 
+/**
+ * @final
+ */
 class ArrayPropertyDescriber implements PropertyDescriberInterface, ModelRegistryAwareInterface, PropertyDescriberAwareInterface
 {
     use ModelRegistryAwareTrait;

--- a/src/PropertyDescriber/BooleanPropertyDescriber.php
+++ b/src/PropertyDescriber/BooleanPropertyDescriber.php
@@ -14,6 +14,9 @@ namespace Nelmio\ApiDocBundle\PropertyDescriber;
 use OpenApi\Annotations as OA;
 use Symfony\Component\PropertyInfo\Type;
 
+/**
+ * @final
+ */
 class BooleanPropertyDescriber implements PropertyDescriberInterface
 {
     /**

--- a/src/PropertyDescriber/CompoundPropertyDescriber.php
+++ b/src/PropertyDescriber/CompoundPropertyDescriber.php
@@ -17,6 +17,9 @@ use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 use OpenApi\Annotations as OA;
 use OpenApi\Generator;
 
+/**
+ * @final
+ */
 class CompoundPropertyDescriber implements PropertyDescriberInterface, ModelRegistryAwareInterface, PropertyDescriberAwareInterface
 {
     use ModelRegistryAwareTrait;

--- a/src/PropertyDescriber/DateTimePropertyDescriber.php
+++ b/src/PropertyDescriber/DateTimePropertyDescriber.php
@@ -14,6 +14,9 @@ namespace Nelmio\ApiDocBundle\PropertyDescriber;
 use OpenApi\Annotations as OA;
 use Symfony\Component\PropertyInfo\Type;
 
+/**
+ * @final
+ */
 class DateTimePropertyDescriber implements PropertyDescriberInterface
 {
     /**

--- a/src/PropertyDescriber/FloatPropertyDescriber.php
+++ b/src/PropertyDescriber/FloatPropertyDescriber.php
@@ -14,6 +14,9 @@ namespace Nelmio\ApiDocBundle\PropertyDescriber;
 use OpenApi\Annotations as OA;
 use Symfony\Component\PropertyInfo\Type;
 
+/**
+ * @final
+ */
 class FloatPropertyDescriber implements PropertyDescriberInterface
 {
     /**

--- a/src/PropertyDescriber/IntegerPropertyDescriber.php
+++ b/src/PropertyDescriber/IntegerPropertyDescriber.php
@@ -14,6 +14,9 @@ namespace Nelmio\ApiDocBundle\PropertyDescriber;
 use OpenApi\Annotations as OA;
 use Symfony\Component\PropertyInfo\Type;
 
+/**
+ * @final
+ */
 class IntegerPropertyDescriber implements PropertyDescriberInterface
 {
     /**

--- a/src/PropertyDescriber/ObjectPropertyDescriber.php
+++ b/src/PropertyDescriber/ObjectPropertyDescriber.php
@@ -18,6 +18,9 @@ use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 use OpenApi\Annotations as OA;
 use Symfony\Component\PropertyInfo\Type;
 
+/**
+ * @final
+ */
 class ObjectPropertyDescriber implements PropertyDescriberInterface, ModelRegistryAwareInterface
 {
     use ModelRegistryAwareTrait;

--- a/src/PropertyDescriber/StringPropertyDescriber.php
+++ b/src/PropertyDescriber/StringPropertyDescriber.php
@@ -14,6 +14,9 @@ namespace Nelmio\ApiDocBundle\PropertyDescriber;
 use OpenApi\Annotations as OA;
 use Symfony\Component\PropertyInfo\Type;
 
+/**
+ * @final
+ */
 class StringPropertyDescriber implements PropertyDescriberInterface
 {
     /**


### PR DESCRIPTION
## Description

Marks non-final PropertyDescribers  with `@final` in preparation for 5.x

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [x] Refactor
- [x] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)