### PR TITLE
fix: deprecation warning for usage of "tagged"

### DIFF
--- a/config/services.xml
+++ b/config/services.xml
@@ -164,7 +164,7 @@
 
         <!-- Type describers (symfony/type-info) -->
         <service id="nelmio_api_doc.type_describer.chain" class="Nelmio\ApiDocBundle\TypeDescriber\ChainDescriber" public="false">
-            <argument type="tagged" tag="nelmio_api_doc.type_describer" />
+            <argument type="tagged_iterator" tag="nelmio_api_doc.type_describer" />
 
             <tag name="nelmio_api_doc.type_describer" priority="1000" />
         </service>


### PR DESCRIPTION
## Description

Fixes deprecation warning for usage of "tagged" that got added with https://github.com/nelmio/NelmioApiDocBundle/pull/2349

https://github.com/nelmio/NelmioApiDocBundle/pull/2410

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)