### PR TITLE
chore: cleanup Areas annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 -#[Areas(properties: ['value' => ['foo', 'bar']])]
 +#[Areas(properties: ['foo', 'bar'])]
 
--#[Areas(['values' => ['foo', 'bar']])]
+-#[Areas(['value' => ['foo', 'bar']])]
 +#[Areas(['foo', 'bar'])]
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 4.36.1
+- Passing an array key `value` with a list of strings to the `Areas` annotation/attribute is deprecated. Pass the list of strings directly.
+```diff
+-#[Areas(properties: ['value' => ['foo', 'bar']])]
++#[Areas(properties: ['foo', 'bar'])]
+
+-#[Areas(['values' => ['foo', 'bar']])]
++#[Areas(['foo', 'bar'])]
+```
+
 ## 4.36.0
 * Configuration option `with_annotation` has been deprecated in favor of `with_attribute`
 ```diff

--- a/phpunit-ignore.txt
+++ b/phpunit-ignore.txt
@@ -7,3 +7,6 @@
 # Ignoring deprecations from Nelmio\ApiDocBundle 4.33.4
 /^Since nelmio\/api-doc-bundle 4\.33\.4: Passing null to the "\$options" argument of "Nelmio\\ApiDocBundle\\Model\\Model\:\:\_\_construct\(\)" is deprecated\, pass an empty array instead\./
 /^Since nelmio\/api-doc-bundle 4\.33\.4: Passing null to the "\$options" argument of "Nelmio\\ApiDocBundle\\Attribute\\Model\:\:\_\_construct\(\)" is deprecated\, pass an empty array instead\./
+
+# Ignoring deprecations from Nelmio\ApiDocBundle 4.36.1
+/^Since nelmio\/api-doc-bundle 4\.36\.1: Passing an array with key "value" to "Nelmio\\ApiDocBundle\\Attribute\\Areas\:\:\_\_construct" is deprecated\, pass the list of strings directly\./

--- a/src/Attribute/Areas.php
+++ b/src/Attribute/Areas.php
@@ -26,7 +26,7 @@ class Areas
     public function __construct(array $properties)
     {
         if (array_key_exists('value', $properties) && is_array($properties['value'])) {
-            trigger_deprecation('nelmio/api-doc-bundle', '4.36.1', 'Passing an array with key `value` is deprecated, pass the list of strings directly.');
+            trigger_deprecation('nelmio/api-doc-bundle', '4.36.1', 'Passing an array with key "value" to "%s" is deprecated, pass the list of strings directly.', __METHOD__);
 
             $this->areas = array_values($properties['value']);
         } else {

--- a/src/Attribute/Areas.php
+++ b/src/Attribute/Areas.php
@@ -43,7 +43,7 @@ class Areas
         }
 
         if ([] === $this->areas) {
-            throw new \InvalidArgumentException('An array of areas was expected');
+            throw new \InvalidArgumentException('A list of areas was expected');
         }
     }
 

--- a/src/Attribute/Areas.php
+++ b/src/Attribute/Areas.php
@@ -25,26 +25,26 @@ class Areas
      */
     public function __construct(array $properties)
     {
-        if (!array_key_exists('value', $properties) || !is_array($properties['value'])) {
-            $properties['value'] = array_values($properties);
+        if (array_key_exists('value', $properties) && is_array($properties['value'])) {
+            trigger_deprecation('nelmio/api-doc-bundle', '4.36.1', 'Passing an array with key `value` is deprecated, pass the list of strings directly.');
+
+            $this->areas = array_values($properties['value']);
+        } else {
+            $this->areas = [];
+            foreach ($properties as $area) {
+                if (!is_string($area)) {
+                    throw new \InvalidArgumentException('An area must be given as a string');
+                }
+
+                if (!in_array($area, $this->areas, true)) {
+                    $this->areas[] = $area;
+                }
+            }
         }
 
-        if ([] === $properties['value']) {
+        if ([] === $this->areas) {
             throw new \InvalidArgumentException('An array of areas was expected');
         }
-
-        $areas = [];
-        foreach ($properties['value'] as $area) {
-            if (!is_string($area)) {
-                throw new \InvalidArgumentException('An area must be given as a string');
-            }
-
-            if (!in_array($area, $areas, true)) {
-                $areas[] = $area;
-            }
-        }
-
-        $this->areas = $areas;
     }
 
     public function has(string $area): bool

--- a/tests/Attribute/AreasTest.php
+++ b/tests/Attribute/AreasTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Attribute;
+
+use Nelmio\ApiDocBundle\Attribute\Areas;
+use PHPUnit\Framework\TestCase;
+
+class AreasTest extends TestCase
+{
+    /**
+     * @dataProvider provideData
+     *
+     * @param string[] $areas
+     */
+    public function testConstruct(array $areas): void
+    {
+        $areasAttribute = new Areas($areas);
+
+        foreach ($areas as $area) {
+            self::assertTrue($areasAttribute->has($area));
+        }
+    }
+
+    /**
+     * @dataProvider provideData
+     *
+     * @param string[] $areas
+     *
+     * @group legacy
+     */
+    public function testDeprecatedConstruct(array $areas): void
+    {
+        $areasAttribute = new Areas(['value' => $areas]);
+
+        foreach ($areas as $area) {
+            self::assertTrue($areasAttribute->has($area));
+        }
+    }
+
+    public static function provideData(): \Generator
+    {
+        yield [
+            ['foo', 'bar'],
+        ];
+
+        yield [
+            ['foo']
+        ];
+
+        yield [
+            ['bar']
+        ];
+    }
+}

--- a/tests/Attribute/AreasTest.php
+++ b/tests/Attribute/AreasTest.php
@@ -60,4 +60,40 @@ class AreasTest extends TestCase
             ['bar']
         ];
     }
+
+    /**
+     * @dataProvider provideInvalidData
+     *
+     * @param string[] $areas
+     */
+    public function testItChecksArrayItemType(array $areas): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+        self::expectExceptionMessage('An area must be given as a string');
+
+        new Areas($areas);
+    }
+
+    public function testItChecksEmptyArray(): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+        self::expectExceptionMessage('A list of areas was expected');
+
+        new Areas([]);
+    }
+
+    public static function provideInvalidData(): \Generator
+    {
+        yield [
+            ['foo', 'bar', 42],
+        ];
+
+        yield [
+            ['foo', 'bar', []],
+        ];
+
+        yield [
+            ['foo', 'bar', new \stdClass()],
+        ];
+    }
 }

--- a/tests/Routing/FilteredRouteCollectionBuilderTest.php
+++ b/tests/Routing/FilteredRouteCollectionBuilderTest.php
@@ -213,7 +213,7 @@ class FilteredRouteCollectionBuilderTest extends TestCase
             $annotationReader
                 ->method('getMethodAnnotation')
                 ->with($reflectionMethodStub, Areas::class)
-                ->willReturn(new Areas(['value' => [$area]]))
+                ->willReturn(new Areas([$area]))
             ;
         }
 


### PR DESCRIPTION
## Description

Cleans up the `Area` annotation/attribute to trigger a deprecation warning whenever a list of strings isn't passed.

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactor
- [x] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [x] I have made corresponding changes to the changelog (`CHANGELOG.md`)