### PR TITLE
fix(MapQueryParameter): convert pcre regex to ecma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 4.38.1
+- Support of attribute MapQueryParameter with a regexp has been improved, it now converts the regexp from PCRE to ECMA-262 for better compliance with OpenApi. 
+
 ## 4.38.0
 * Added a `#[Ignore]` attribute that allows a property to be excluded from the generated schema.
 ```php

--- a/src/RouteDescriber/RouteArgumentDescriber/SymfonyMapQueryParameterDescriber.php
+++ b/src/RouteDescriber/RouteArgumentDescriber/SymfonyMapQueryParameterDescriber.php
@@ -128,7 +128,7 @@ final class SymfonyMapQueryParameterDescriber implements RouteArgumentDescriberI
         }
 
         if (FILTER_VALIDATE_REGEXP === $filter) {
-            return ['type' => 'string', 'pattern' => $options['regexp']];
+            return ['type' => 'string', 'pattern' => $this->getEcmaRegexpFromPCRE($options['regexp'])];
         }
 
         if (FILTER_VALIDATE_URL === $filter) {
@@ -140,5 +140,31 @@ final class SymfonyMapQueryParameterDescriber implements RouteArgumentDescriberI
         }
 
         return [];
+    }
+
+    private function getEcmaRegexpFromPCRE(string $pcreRegex): string
+    {
+        // Check if PCRE regex has delimiters
+        if (preg_match('/^(.)(.*)\1([a-zA-Z]*)$/s', $pcreRegex, $matches)) {
+            [$fullMatch, $delimiter, $pattern, $flags] = $matches;
+            // Remove escaped delimiters in the pattern
+            $pattern = str_replace('\\'.$delimiter, $delimiter, $pattern);
+        } else {
+            // No delimiter has been found, let's consider it's a valid regex without delimiter. Happens when regexp has been takend from "requirements" in route.
+            $pattern = $pcreRegex;
+        }
+
+        $pattern = str_replace(['\A', '\z'], ['^', '$'], $pattern); // Supported features but different syntax
+
+        // Check for unsupported PCRE specific constructs
+        $unsupportedFeatures = [
+            '\Z', // End of string before newline (not supported in JavaScript)
+            '\R', // Any Unicode newline sequence (not supported in JavaScript)
+            '\K', // Resets the start of the current match (not supported in JavaScript)
+        ];
+        $pattern = str_replace($unsupportedFeatures, '', $pattern);
+
+        // Return only the pattern (without flags or delimiters)
+        return $pattern;
     }
 }

--- a/tests/Functional/Controller/MapQueryParameterController.php
+++ b/tests/Functional/Controller/MapQueryParameterController.php
@@ -11,6 +11,7 @@
 
 namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
 
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -92,6 +93,30 @@ class MapQueryParameterController
         ?int $id,
         #[MapQueryParameter]
         ?string $changedType,
+    ) {
+    }
+
+    #[Route('/article_map_query_parameter_invalid_regexp', methods: ['GET'])]
+    #[OA\Response(response: '200', description: '')]
+    public function fetchArticleWithInvalidRegexp(
+        #[MapQueryParameter(filter: FILTER_VALIDATE_REGEXP, options: ['regexp' => 'This is not a valid regexp'])]
+        string $regexp,
+    ) {
+    }
+
+    #[Route('/article_map_query_parameter_unsupported_flag', methods: ['GET'])]
+    #[OA\Response(response: '200', description: '')]
+    public function fetchArticleWithUnsupportedRegexpFlag(
+        #[MapQueryParameter(filter: FILTER_VALIDATE_REGEXP, options: ['regexp' => '/\ZUnsupportedFlag/'])]
+        string $regexp,
+    ) {
+    }
+
+    #[Route('/article_map_query_parameter_replaced_flag', methods: ['GET'])]
+    #[OA\Response(response: '200', description: '')]
+    public function fetchArticleWithReplacedRegexpFlag(
+        #[MapQueryParameter(filter: FILTER_VALIDATE_REGEXP, options: ['regexp' => '/\ADifferentFlag/'])]
+        string $regexp,
     ) {
     }
 }

--- a/tests/Functional/Fixtures/MapQueryParameterController.json
+++ b/tests/Functional/Fixtures/MapQueryParameterController.json
@@ -53,7 +53,7 @@
                     }
                 ],
                 "responses": {
-                    "default": {
+                    "200": {
                         "description": ""
                     }
                 }
@@ -133,7 +133,7 @@
                         "required": true,
                         "schema": {
                             "type": "string",
-                            "pattern": "/^test/"
+                            "pattern": "^test"
                         }
                     },
                     {
@@ -147,7 +147,7 @@
                     }
                 ],
                 "responses": {
-                    "default": {
+                    "200": {
                         "description": ""
                     }
                 }
@@ -168,7 +168,7 @@
                     }
                 ],
                 "responses": {
-                    "default": {
+                    "200": {
                         "description": ""
                     }
                 }
@@ -189,7 +189,7 @@
                     }
                 ],
                 "responses": {
-                    "default": {
+                    "200": {
                         "description": ""
                     }
                 }
@@ -202,24 +202,91 @@
                     {
                         "name": "id",
                         "in": "query",
+                        "description": "Query parameter id description",
                         "required": false,
                         "schema": {
                             "type": "integer",
                             "nullable": true
-                        }
+                        },
+                        "example": 123
                     },
                     {
                         "name": "changedType",
                         "in": "query",
+                        "description": "Incorrectly described query parameter",
                         "required": false,
                         "schema": {
+                            "type": "int",
+                            "nullable": false
+                        },
+                        "example": 123
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/article_map_query_parameter_invalid_regexp": {
+            "get": {
+                "operationId": "get_nelmio_apidoc_tests_functional_mapqueryparameter_fetcharticlewithinvalidregexp",
+                "parameters": [
+                    {
+                        "name": "regexp",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
                             "type": "string",
-                            "nullable": true
+                            "pattern": "This is not a valid regexp"
                         }
                     }
                 ],
                 "responses": {
-                    "default": {
+                    "200": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/article_map_query_parameter_unsupported_flag": {
+            "get": {
+                "operationId": "get_nelmio_apidoc_tests_functional_mapqueryparameter_fetcharticlewithunsupportedregexpflag",
+                "parameters": [
+                    {
+                        "name": "regexp",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "UnsupportedFlag"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/article_map_query_parameter_replaced_flag": {
+            "get": {
+                "operationId": "get_nelmio_apidoc_tests_functional_mapqueryparameter_fetcharticlewithreplacedregexpflag",
+                "parameters": [
+                    {
+                        "name": "regexp",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^DifferentFlag"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
                         "description": ""
                     }
                 }


### PR DESCRIPTION
## Description
Hello everyone,
The current QueryParameterDescriber may generate an invalid definition, as [we should have only ECMA 262 patterns](https://swagger.io/docs/specification/v3_0/data-models/data-types/#strings).
This pull request ensure a better compliance, converting regexp to ecma syntax. It also fixes tests for the MapQueryParameterController, as in #2423 the namespace was not imported, so fixtures were incorrect.

Thanks !

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [x] I have made corresponding changes to the changelog (`CHANGELOG.md`)