### PR TITLE
fix(MapQuery) better overwrite for arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 4.36.2
+- Support of attribute MapQueryParameter with a regexp has been improved, it now converts the regexp from PCRE to ECMA-262 for better compliance with OpenApi. 
+
 ## 4.36.1
 - Passing an array key `value` with a list of strings to the `Areas` annotation/attribute is deprecated. Pass the list of strings directly.
 ```diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 4.36.2
 - Support of attribute MapQueryParameter with a regexp has been improved, it now converts the regexp from PCRE to ECMA-262 for better compliance with OpenApi. 
+- Support of attribute MapQueryParameter and MapQueryString now allow to override properties mapped to arrays.
 
 ## 4.36.1
 - Passing an array key `value` with a list of strings to the `Areas` annotation/attribute is deprecated. Pass the list of strings directly.

--- a/tests/Functional/Controller/MapQueryParameterController.php
+++ b/tests/Functional/Controller/MapQueryParameterController.php
@@ -11,6 +11,7 @@
 
 namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
 
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
 use Symfony\Component\Routing\Annotation\Route;
 

--- a/tests/Functional/Controller/MapQueryParameterController.php
+++ b/tests/Functional/Controller/MapQueryParameterController.php
@@ -95,4 +95,12 @@ class MapQueryParameterController
         ?string $changedType,
     ) {
     }
+
+    #[Route('/article_array_parameter', methods: ['GET'], format: 'json')]
+    public function articleArrayParameter(
+        #[OA\Parameter(name: 'properties', description: 'Filter by property', in: 'query', required: false, style: 'pipeDelimited')]
+        #[MapQueryParameter(name: 'properties', filter: \FILTER_VALIDATE_REGEXP, options: ['regexp' => '/^test/'])]
+        array $properties,
+    ) {
+    }
 }

--- a/tests/Functional/Controller/MapQueryParameterWithInvalidPCREController.php
+++ b/tests/Functional/Controller/MapQueryParameterWithInvalidPCREController.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
+
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
+use Symfony\Component\Routing\Annotation\Route;
+
+class MapQueryParameterWithInvalidPCREController
+{
+    #[Route('/article_map_query_parameter_invalid_regexp', methods: ['GET'])]
+    #[OA\Response(response: '200', description: '')]
+    public function fetchArticleWithInvalidRegexp(
+        #[MapQueryParameter(filter: FILTER_VALIDATE_REGEXP, options: ['regexp' => 'This is not a valid regexp'])]
+        string $regexp,
+    ) {
+    }
+}

--- a/tests/Functional/Controller/MapQueryParameterWithUnsupportedFlagInPCREController.php
+++ b/tests/Functional/Controller/MapQueryParameterWithUnsupportedFlagInPCREController.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
+
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
+use Symfony\Component\Routing\Annotation\Route;
+
+class MapQueryParameterWithUnsupportedFlagInPCREController
+{
+    #[Route('/article_map_query_parameter_invalid_regexp', methods: ['GET'])]
+    #[OA\Response(response: '200', description: '')]
+    public function fetchArticleWithUnsupportedRegexpFlag(
+        #[MapQueryParameter(filter: FILTER_VALIDATE_REGEXP, options: ['regexp' => 'This is not a valid regexp'])]
+        string $regexp,
+    ) {
+    }
+}

--- a/tests/Functional/Controller/MapQueryStringController.php
+++ b/tests/Functional/Controller/MapQueryStringController.php
@@ -76,6 +76,12 @@ class MapQueryStringController
         in: 'query',
         description: 'Query parameter nullableArticleType81 description'
     )]
+    #[OA\Parameter(
+        name: 'array',
+        in: 'query',
+        required: false,
+        style: 'pipeDelimited'
+    )]
     #[OA\Response(response: '200', description: '')]
     public function fetchArticleFromMapQueryStringOverwriteParameters(
         #[MapQueryString]

--- a/tests/Functional/Entity/SymfonyMapQueryString.php
+++ b/tests/Functional/Entity/SymfonyMapQueryString.php
@@ -21,6 +21,7 @@ class SymfonyMapQueryString
         public ?string $nullableName,
         public ArticleType81 $articleType81,
         public ?ArticleType81 $nullableArticleType81,
+        public ?array $array,
     ) {
     }
 }

--- a/tests/Functional/Fixtures/MapQueryParameterController.json
+++ b/tests/Functional/Fixtures/MapQueryParameterController.json
@@ -53,7 +53,7 @@
                     }
                 ],
                 "responses": {
-                    "default": {
+                    "200": {
                         "description": ""
                     }
                 }
@@ -133,7 +133,7 @@
                         "required": true,
                         "schema": {
                             "type": "string",
-                            "pattern": "/^test/"
+                            "pattern": "^test"
                         }
                     },
                     {
@@ -147,7 +147,7 @@
                     }
                 ],
                 "responses": {
-                    "default": {
+                    "200": {
                         "description": ""
                     }
                 }
@@ -168,7 +168,7 @@
                     }
                 ],
                 "responses": {
-                    "default": {
+                    "200": {
                         "description": ""
                     }
                 }
@@ -189,7 +189,7 @@
                     }
                 ],
                 "responses": {
-                    "default": {
+                    "200": {
                         "description": ""
                     }
                 }
@@ -202,24 +202,28 @@
                     {
                         "name": "id",
                         "in": "query",
+                        "description": "Query parameter id description",
                         "required": false,
                         "schema": {
                             "type": "integer",
                             "nullable": true
-                        }
+                        },
+                        "example": 123
                     },
                     {
                         "name": "changedType",
                         "in": "query",
+                        "description": "Incorrectly described query parameter",
                         "required": false,
                         "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
+                            "type": "int",
+                            "nullable": false
+                        },
+                        "example": 123
                     }
                 ],
                 "responses": {
-                    "default": {
+                    "200": {
                         "description": ""
                     }
                 }

--- a/tests/Functional/Fixtures/MapQueryParameterController.json
+++ b/tests/Functional/Fixtures/MapQueryParameterController.json
@@ -228,6 +228,32 @@
                     }
                 }
             }
+        },
+        "/article_array_parameter": {
+            "get": {
+                "operationId": "get_nelmio_apidoc_tests_functional_mapqueryparameter_articlearrayparameter",
+                "parameters": [
+                    {
+                        "name": "properties",
+                        "in": "query",
+                        "description": "Filter by property",
+                        "required": true,
+                        "style": "pipeDelimited",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "pattern": "^test"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            }
         }
     }
 }

--- a/tests/Functional/Fixtures/MapQueryStringCleanupComponents.json
+++ b/tests/Functional/Fixtures/MapQueryStringCleanupComponents.json
@@ -54,6 +54,16 @@
                                 }
                             ]
                         }
+                    },
+                    {
+                        "name": "array[]",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {},
+                            "nullable": true
+                        }
                     }
                 ],
                 "responses": {
@@ -111,6 +121,16 @@
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
                             ]
+                        }
+                    },
+                    {
+                        "name": "array[]",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {},
+                            "nullable": true
                         }
                     }
                 ],
@@ -205,6 +225,17 @@
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
                             ]
+                        }
+                    },
+                    {
+                        "name": "array",
+                        "in": "query",
+                        "required": false,
+                        "style": "pipeDelimited",
+                        "schema": {
+                            "type": "array",
+                            "items": {},
+                            "nullable": true
                         }
                     }
                 ],

--- a/tests/Functional/Fixtures/MapQueryStringController.json
+++ b/tests/Functional/Fixtures/MapQueryStringController.json
@@ -54,6 +54,16 @@
                                 }
                             ]
                         }
+                    },
+                    {
+                        "name": "array[]",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {},
+                            "nullable": true
+                        }
                     }
                 ],
                 "responses": {
@@ -111,6 +121,16 @@
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
                             ]
+                        }
+                    },
+                    {
+                        "name": "array[]",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {},
+                            "nullable": true
                         }
                     }
                 ],
@@ -226,6 +246,17 @@
                                     "$ref": "#/components/schemas/ArticleType81"
                                 }
                             ]
+                        }
+                    },
+                    {
+                        "name": "array",
+                        "in": "query",
+                        "required": false,
+                        "style": "pipeDelimited",
+                        "schema": {
+                            "type": "array",
+                            "items": {},
+                            "nullable": true
                         }
                     }
                 ],
@@ -1071,6 +1102,11 @@
                                 "$ref": "#/components/schemas/ArticleType81"
                             }
                         ]
+                    },
+                    "array": {
+                        "type": "array",
+                        "items": {},
+                        "nullable": true
                     }
                 },
                 "type": "object"
@@ -1102,6 +1138,11 @@
                                 "$ref": "#/components/schemas/ArticleType81"
                             }
                         ]
+                    },
+                    "array": {
+                        "type": "array",
+                        "items": {},
+                        "nullable": true
                     }
                 },
                 "type": "object"


### PR DESCRIPTION
## Description
Hello everyone,

:warning: This pull request should be merged after #2435 as I fixed tests in #2345, so i started from here. In the meantime you can review [the actual new commit](https://github.com/nelmio/NelmioApiDocBundle/commit/d84c88d0a3f7d415dceb03c232398dd65b065e46).

The actual array detection on MapQueryParameter and MapQueryString makes parameters hard to combine with SF Attributes, this pull requests fixes it. I consider it as a bug fix, as the parameter overwriting is already implemented and working as intended for other types.

Thanks !

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [x] I have made corresponding changes to the changelog (`CHANGELOG.md`)