### PR TITLE
fix: stoplight ui height

### DIFF
--- a/templates/Stoplight/index.html.twig
+++ b/templates/Stoplight/index.html.twig
@@ -14,7 +14,7 @@
         {{ nelmioAsset(assets_mode, 'stoplight/styles.min.css') }}
     {% endblock stylesheets %}
 </head>
-<body>
+<body style="height: 100vh;">
     {% block swagger_ui %}
         <elements-api id="docs"/>
     {% endblock swagger_ui %}

--- a/tests/Command/DumpCommandTest.php
+++ b/tests/Command/DumpCommandTest.php
@@ -68,7 +68,9 @@ class DumpCommandTest extends WebTestCase
             '--format' => 'html',
             '--html-config' => json_encode($htmlConfig),
         ]);
-        self::assertStringContainsString('<body>', $output);
+        self::assertStringContainsString('<html>', $output);
+        self::assertStringContainsString('<body', $output);
+        self::assertStringContainsString('</body>', $output);
         self::assertStringContainsString($expectedHtml, $output);
     }
 


### PR DESCRIPTION
## Description

Fixes stoplight ui on massive documentation
https://docs.stoplight.io/docs/elements/d536b917a4e1d-layout

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)