### PR TITLE
refactor: do not pass deprecated groups argument to PropertyDescriber

### DIFF
--- a/src/ModelDescriber/ObjectModelDescriber.php
+++ b/src/ModelDescriber/ObjectModelDescriber.php
@@ -210,7 +210,7 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
             }
             if ($propertyDescriber->supports($types, $model->getSerializationContext())) {
                 if ($propertyDescriber instanceof PropertyDescriberInterface) {
-                    $propertyDescriber->describe($types, $property, $model->getGroups(), $schema, $model->getSerializationContext());
+                    $propertyDescriber->describe($types, $property, null, $schema, $model->getSerializationContext());
                 } else {
                     $propertyDescriber->describe($types, $property, $model->getSerializationContext());
                 }


### PR DESCRIPTION
Refs: https://github.com/nelmio/NelmioApiDocBundle/issues/2450

## Description

Avoids triggering deprecation notices. The groups are already coming from the models serializationContext, so there is no need to even pass them because serializationContext is already passed.

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [x] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)