### PR TITLE
docs(4.x): update references from `master` to `4.x`

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,11 +7,9 @@ on:
   pull_request:
     branches:
       - "*.x"
-      - master
   push:
     branches:
       - "*.x"
-      - master
 
 env:
   fail-fast: true

--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -1,6 +1,5 @@
-branches: ["2.x", "3.x", "master", "5.x"]
-maintained_branches: ["master", "5.x"]
-current_branch: "master"
-master_alias: "4.x"
+branches: ["2.x", "3.x", "4.x", "5.x"]
+maintained_branches: ["4.x", "5.x"]
+current_branch: "4.x"
 dev_branch: "5.x"
-doc_dir: { "3.x": "Resources/doc/", "master": "docs/", "5.x": "docs/" }
+doc_dir: { "3.x": "Resources/doc/", "4.x": "docs/", "5.x": "docs/" }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 NelmioApiDocBundle
 ==================
 
-[![Build Status](https://img.shields.io/github/actions/workflow/status/nelmio/NelmioApiDocBundle/continuous-integration.yml?branch=master&style=flat-square)](https://github.com/nelmio/NelmioApiDocBundle/actions?query=workflow:CI)
-[![Codecov](https://img.shields.io/codecov/c/github/nelmio/NelmioApiDocBundle?branch=master&style=flat-square)](https://app.codecov.io/gh/nelmio/NelmioApiDocBundle)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/nelmio/NelmioApiDocBundle/continuous-integration.yml?branch=4.x&style=flat-square)](https://github.com/nelmio/NelmioApiDocBundle/actions?query=workflow:CI)
+[![Codecov](https://img.shields.io/codecov/c/github/nelmio/NelmioApiDocBundle?branch=4.x&style=flat-square)](https://app.codecov.io/gh/nelmio/NelmioApiDocBundle)
 [![Total Downloads](https://img.shields.io/packagist/dt/nelmio/api-doc-bundle?style=flat-square)](https://packagist.org/packages/nelmio/api-doc-bundle)
 [![Latest Stable Version](https://img.shields.io/packagist/v/nelmio/api-doc-bundle?label=stable&style=flat-square)](https://packagist.org/packages/nelmio/api-doc-bundle)
 [![PHP Version](https://img.shields.io/packagist/dependency-v/nelmio/api-doc-bundle/PHP?style=flat-square)](https://packagist.org/packages/nelmio/api-doc-bundle)
@@ -12,13 +12,13 @@ for your APIs.
 
 ## Migrate from 3.x to 4.0
 
-[To migrate from 3.x to 4.0, follow our guide.](https://github.com/nelmio/NelmioApiDocBundle/blob/master/UPGRADE-4.0.md)
+[To migrate from 3.x to 4.0, follow our guide.](https://github.com/nelmio/NelmioApiDocBundle/blob/4.x/UPGRADE-4.0.md)
 
 Version 4.0 brings OpenAPI 3.0 support. If you want to stick to Swagger 2.0, you should use the version 3 of this bundle.
 
 ## Migrate from 2.x to 3.0
 
-[To migrate from 2.x to 3.0, follow our guide.](https://github.com/nelmio/NelmioApiDocBundle/blob/master/UPGRADE-3.0.md)
+[To migrate from 2.x to 3.0, follow our guide.](https://github.com/nelmio/NelmioApiDocBundle/blob/4.x/UPGRADE-3.0.md)
 
 ## Installation
 
@@ -35,7 +35,7 @@ composer require nelmio/api-doc-bundle
 ## Contributing
 
 See
-[CONTRIBUTING](https://github.com/nelmio/NelmioApiDocBundle/blob/master/CONTRIBUTING.md)
+[CONTRIBUTING](https://github.com/nelmio/NelmioApiDocBundle/blob/4.x/CONTRIBUTING.md)
 file.
 
 ## Running the Tests

--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.x-dev"
+            "dev-4.x": "4.x-dev"
         }
     },
     "scripts-descriptions": {

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -68,7 +68,7 @@ Just create a file ``templates/bundles/NelmioApiDocBundle/SwaggerUi/index.html.t
         <script type="text/javascript" src="{{ asset('js/custom-request-signer.js') }}"></script>
     {% endblock javascripts %}
 
-You can have a look at the `original template <https://github.com/nelmio/NelmioApiDocBundle/blob/master/templates/SwaggerUi/index.html.twig>`_, in ``/templates/SwaggerUi/index.html.twig``, to see which blocks can be overridden.
+You can have a look at the `original template <https://github.com/nelmio/NelmioApiDocBundle/blob/4.x/templates/SwaggerUi/index.html.twig>`_, in ``/templates/SwaggerUi/index.html.twig``, to see which blocks can be overridden.
 
 Assets Loading Options
 -----------------------
@@ -85,7 +85,7 @@ The `html_config` settings allow you to configure how assets are loaded for the 
 `assets_mode`
 ~~~~~~~~~~~~~
 
-The three values possible values can be found in `AssetsMode.php <https://github.com/nelmio/NelmioApiDocBundle/blob/master/src/Render/Html/AssetsMode.php>`_
+The three values possible values can be found in `AssetsMode.php <https://github.com/nelmio/NelmioApiDocBundle/blob/4.x/src/Render/Html/AssetsMode.php>`_
 - **cdn**: Loads assets from `jsDelivr <https://www.jsdelivr.com/>`_.
 - **bundle**: Fetches assets from the bundle in the vendor directory, including updates.
 - **offline**: Loads assets from the local `assets` directory, requiring the developer to update them manually.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@ Migrate from 3.x to 4.0
 
 `To migrate from 3.x to 4.0, follow our guide.`__
 
-__ https://github.com/nelmio/NelmioApiDocBundle/blob/master/UPGRADE-4.0.md
+__ https://github.com/nelmio/NelmioApiDocBundle/blob/4.x/UPGRADE-4.0.md
 
 Installation
 ------------

--- a/docs/symfony_attributes.rst
+++ b/docs/symfony_attributes.rst
@@ -237,4 +237,4 @@ Make sure to use at least php 8.1 (attribute support) to make use of this functi
 .. _`Symfony MapQueryParameter`: https://symfony.com/doc/current/controller.html#mapping-query-parameters-individually
 .. _`Symfony MapRequestPayload`: https://symfony.com/doc/current/controller.html#mapping-request-payload
 .. _`Symfony MapUploadedFile`: https://symfony.com/doc/current/controller.html#mapping-uploaded-files
-.. _`RouteArgumentDescriberInterface`: https://github.com/DjordyKoert/NelmioApiDocBundle/blob/master/src/RouteDescriber/RouteArgumentDescriber/RouteArgumentDescriberInterface.php
+.. _`RouteArgumentDescriberInterface`: https://github.com/DjordyKoert/NelmioApiDocBundle/blob/4.x/src/RouteDescriber/RouteArgumentDescriber/RouteArgumentDescriberInterface.php


### PR DESCRIPTION
## Description

Follow-up on https://github.com/nelmio/NelmioApiDocBundle/pull/2433 for `4.x` (previously called `master`)

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [x] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [x] Documentation Update
- [x] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)