### PR TITLE
chore: symfony/phpunit-bridge version constraint & dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      symfony:
+        patterns:
+          - "symfony/*"
+      phpstan:
+        patterns:
+          - "phpstan/*"

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "symfony/dom-crawler": "^6.4 || ^7.1",
         "symfony/expression-language": "^6.4 || ^7.1",
         "symfony/form": "^6.4 || ^7.1",
-        "symfony/phpunit-bridge": "^6.4",
+        "symfony/phpunit-bridge": "^6.4 || ^7.1",
         "symfony/property-access": "^6.4 || ^7.1",
         "symfony/security-csrf": "^6.4 || ^7.1",
         "symfony/serializer": "^6.4 || ^7.1",


### PR DESCRIPTION
## Description

Replaces https://github.com/nelmio/NelmioApiDocBundle/pull/2459 & adds symfony & phpstan grouping for depandabot

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [x] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)