### PR TITLE
fix(#2480): Tag ignored on subclasses when routes are inherited from abstract controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 5.2.1
+Fixed a bug where using abstract controllers would ignore various attributes like ``#[OA\Tag]`` & ``#[Security]`` on child classes
+
 ## 5.2.0
 Made it possible to automatically generate security definitions based on the ``#[IsGranted]`` attribute.
 

--- a/src/DependencyInjection/NelmioApiDocExtension.php
+++ b/src/DependencyInjection/NelmioApiDocExtension.php
@@ -117,7 +117,6 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
                 ->setArguments([
                     new Reference(\sprintf('nelmio_api_doc.routes.%s', $area)),
                     new Reference('nelmio_api_doc.controller_reflector'),
-                    new Reference('logger'),
                     $config['operation_id_generation'] instanceof OperationIdGeneration ?
                         $config['operation_id_generation'] :
                         OperationIdGeneration::from($config['operation_id_generation']),

--- a/src/Describer/OpenApiPhpDescriber.php
+++ b/src/Describer/OpenApiPhpDescriber.php
@@ -44,9 +44,24 @@ final class OpenApiPhpDescriber
     {
         $classAnnotations = [];
 
-        /** @var \ReflectionMethod $method */
-        foreach ($this->getMethodsToParse() as $method => [$path, $httpMethods, $routeName, $controller]) {
-            $classReflector = $method->getDeclaringClass();
+        foreach ($this->getRoutesToParse() as $routeName => $route) {
+            $controller = $route->getDefault('_controller');
+            $reflectedMethod = $this->controllerReflector->getReflectionMethod($controller);
+            if (null === $reflectedMethod) {
+                continue;
+            }
+
+            $path = $this->normalizePath($route->getPath());
+            $supportedHttpMethods = $this->getSupportedHttpMethods($route);
+            if ([] === $supportedHttpMethods) {
+                $this->logger->warning('None of the HTTP methods specified for path {path} are supported by swagger-ui, skipping this path', [
+                    'path' => $path,
+                ]);
+
+                continue;
+            }
+
+            $classReflector = $reflectedMethod->getDeclaringClass();
             if (\is_array($controller) && method_exists(...$controller)) {
                 $classReflector = new \ReflectionClass($controller[0]);
             } elseif (\is_string($controller) && false !== $i = strpos($controller, '::')) {
@@ -58,8 +73,8 @@ final class OpenApiPhpDescriber
             $context = Util::createContext(['nested' => $path], $path->_context);
             $context->namespace = $classReflector->getNamespaceName();
             $context->class = $classReflector->getShortName();
-            $context->method = $method->name;
-            $context->filename = $method->getFileName();
+            $context->method = $reflectedMethod->name;
+            $context->filename = $reflectedMethod->getFileName();
 
             $this->setContext($context);
 
@@ -67,14 +82,14 @@ final class OpenApiPhpDescriber
                 $classAnnotations[$classReflector->getName()] ??= $this->getAttributesAsAnnotation($classReflector, $context);
             }
 
-            $annotations = $this->getAttributesAsAnnotation($method, $context);
+            $annotations = $this->getAttributesAsAnnotation($reflectedMethod, $context);
 
             $implicitAnnotations = [];
             $mergeProperties = new \stdClass();
 
             foreach (array_merge($annotations, $classAnnotations[$classReflector->getName()]) as $annotation) {
                 if ($annotation instanceof Operation) {
-                    foreach ($httpMethods as $httpMethod) {
+                    foreach ($supportedHttpMethods as $httpMethod) {
                         $operation = Util::getOperation($path, $httpMethod);
                         $operation->mergeProperties($annotation);
                     }
@@ -83,7 +98,7 @@ final class OpenApiPhpDescriber
                 }
 
                 if ($annotation instanceof OA\Operation) {
-                    if (!\in_array($annotation->method, $httpMethods, true)) {
+                    if (!\in_array($annotation->method, $supportedHttpMethods, true)) {
                         continue;
                     }
                     if (Generator::UNDEFINED !== $annotation->path && $path->path !== $annotation->path) {
@@ -99,7 +114,7 @@ final class OpenApiPhpDescriber
                 if ($annotation instanceof Security) {
                     $annotation->validate();
 
-                    foreach ($httpMethods as $httpMethod) {
+                    foreach ($supportedHttpMethods as $httpMethod) {
                         $operation = Util::getOperation($path, $httpMethod);
 
                         if (Generator::UNDEFINED === $operation->security) {
@@ -134,13 +149,13 @@ final class OpenApiPhpDescriber
                     && !$annotation instanceof OA\Parameter
                     && !$annotation instanceof OA\ExternalDocumentation
                 ) {
-                    throw new \LogicException(\sprintf('Using the annotation "%s" as a root annotation in "%s::%s()" is not allowed.', $annotation::class, $method->getDeclaringClass()->name, $method->name));
+                    throw new \LogicException(\sprintf('Using the annotation "%s" as a root annotation in "%s::%s()" is not allowed.', $annotation::class, $reflectedMethod->getDeclaringClass()->name, $reflectedMethod->name));
                 }
 
                 $implicitAnnotations[] = $annotation;
             }
 
-            foreach ($httpMethods as $httpMethod) {
+            foreach ($supportedHttpMethods as $httpMethod) {
                 $operation = Util::getOperation($path, $httpMethod);
                 if ([] !== $implicitAnnotations) {
                     $operation->merge($implicitAnnotations);
@@ -163,26 +178,9 @@ final class OpenApiPhpDescriber
         $this->setContext(null);
     }
 
-    private function getMethodsToParse(): \Generator
+    private function getRoutesToParse(): \Generator
     {
-        foreach ($this->routeCollection->all() as $routeName => $route) {
-            $controller = $route->getDefault('_controller');
-            $reflectedMethod = $this->controllerReflector->getReflectionMethod($controller);
-            if (null === $reflectedMethod) {
-                continue;
-            }
-
-            $path = $this->normalizePath($route->getPath());
-            $supportedHttpMethods = $this->getSupportedHttpMethods($route);
-            if ([] === $supportedHttpMethods) {
-                $this->logger->warning('None of the HTTP methods specified for path {path} are supported by swagger-ui, skipping this path', [
-                    'path' => $path,
-                ]);
-
-                continue;
-            }
-            yield $reflectedMethod => [$path, $supportedHttpMethods, $routeName, $controller];
-        }
+        yield from $this->routeCollection->all();
     }
 
     /**

--- a/src/Describer/OpenApiPhpDescriber.php
+++ b/src/Describer/OpenApiPhpDescriber.php
@@ -14,6 +14,7 @@ namespace Nelmio\ApiDocBundle\Describer;
 use Nelmio\ApiDocBundle\Attribute\Operation;
 use Nelmio\ApiDocBundle\Attribute\Security;
 use Nelmio\ApiDocBundle\OpenApiPhp\Util;
+use Nelmio\ApiDocBundle\RouteDescriber\RouteDescriberTrait;
 use Nelmio\ApiDocBundle\Util\ControllerReflector;
 use Nelmio\ApiDocBundle\Util\SetsContextTrait;
 use OpenApi\Analysers\AttributeAnnotationFactory;
@@ -28,6 +29,7 @@ class_exists(OA\OpenApi::class);
 
 final class OpenApiPhpDescriber
 {
+    use RouteDescriberTrait;
     use SetsContextTrait;
 
     public function __construct(
@@ -43,21 +45,26 @@ final class OpenApiPhpDescriber
         $classAnnotations = [];
 
         /** @var \ReflectionMethod $method */
-        foreach ($this->getMethodsToParse() as $method => [$path, $httpMethods, $routeName]) {
-            $declaringClass = $method->getDeclaringClass();
+        foreach ($this->getMethodsToParse() as $method => [$path, $httpMethods, $routeName, $controller]) {
+            $classReflector = $method->getDeclaringClass();
+            if (\is_array($controller) && method_exists(...$controller)) {
+                $classReflector = new \ReflectionClass($controller[0]);
+            } elseif (\is_string($controller) && false !== $i = strpos($controller, '::')) {
+                $classReflector = new \ReflectionClass(substr($controller, 0, $i));
+            }
 
             $path = Util::getPath($api, $path);
 
             $context = Util::createContext(['nested' => $path], $path->_context);
-            $context->namespace = $declaringClass->getNamespaceName();
-            $context->class = $declaringClass->getShortName();
+            $context->namespace = $classReflector->getNamespaceName();
+            $context->class = $classReflector->getShortName();
             $context->method = $method->name;
             $context->filename = $method->getFileName();
 
             $this->setContext($context);
 
-            if (!\array_key_exists($declaringClass->getName(), $classAnnotations)) {
-                $classAnnotations[$declaringClass->getName()] = $this->getAttributesAsAnnotation($declaringClass, $context);
+            if (!\array_key_exists($classReflector->getName(), $classAnnotations)) {
+                $classAnnotations[$classReflector->getName()] ??= $this->getAttributesAsAnnotation($classReflector, $context);
             }
 
             $annotations = $this->getAttributesAsAnnotation($method, $context);
@@ -65,7 +72,7 @@ final class OpenApiPhpDescriber
             $implicitAnnotations = [];
             $mergeProperties = new \stdClass();
 
-            foreach (array_merge($annotations, $classAnnotations[$declaringClass->getName()]) as $annotation) {
+            foreach (array_merge($annotations, $classAnnotations[$classReflector->getName()]) as $annotation) {
                 if ($annotation instanceof Operation) {
                     foreach ($httpMethods as $httpMethod) {
                         $operation = Util::getOperation($path, $httpMethod);
@@ -159,14 +166,12 @@ final class OpenApiPhpDescriber
     private function getMethodsToParse(): \Generator
     {
         foreach ($this->routeCollection->all() as $routeName => $route) {
-            if (!$route->hasDefault('_controller')) {
-                continue;
-            }
             $controller = $route->getDefault('_controller');
             $reflectedMethod = $this->controllerReflector->getReflectionMethod($controller);
             if (null === $reflectedMethod) {
                 continue;
             }
+
             $path = $this->normalizePath($route->getPath());
             $supportedHttpMethods = $this->getSupportedHttpMethods($route);
             if ([] === $supportedHttpMethods) {
@@ -176,7 +181,7 @@ final class OpenApiPhpDescriber
 
                 continue;
             }
-            yield $reflectedMethod => [$path, $supportedHttpMethods, $routeName];
+            yield $reflectedMethod => [$path, $supportedHttpMethods, $routeName, $controller];
         }
     }
 
@@ -194,15 +199,6 @@ final class OpenApiPhpDescriber
         }
 
         return array_intersect($methods, $allMethods);
-    }
-
-    private function normalizePath(string $path): string
-    {
-        if ('.{_format}' === substr($path, -10)) {
-            $path = substr($path, 0, -10);
-        }
-
-        return $path;
     }
 
     /**

--- a/src/Describer/OpenApiPhpDescriber.php
+++ b/src/Describer/OpenApiPhpDescriber.php
@@ -53,13 +53,6 @@ final class OpenApiPhpDescriber
 
             $path = $this->normalizePath($route->getPath());
             $supportedHttpMethods = $this->getSupportedHttpMethods($route);
-            if ([] === $supportedHttpMethods) {
-                $this->logger->warning('None of the HTTP methods specified for path {path} are supported by swagger-ui, skipping this path', [
-                    'path' => $path,
-                ]);
-
-                continue;
-            }
 
             $classReflector = $reflectedMethod->getDeclaringClass();
             if (\is_array($controller) && method_exists(...$controller)) {

--- a/src/Describer/OpenApiPhpDescriber.php
+++ b/src/Describer/OpenApiPhpDescriber.php
@@ -20,7 +20,6 @@ use Nelmio\ApiDocBundle\Util\SetsContextTrait;
 use OpenApi\Analysers\AttributeAnnotationFactory;
 use OpenApi\Annotations as OA;
 use OpenApi\Generator;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -35,7 +34,6 @@ final class OpenApiPhpDescriber
     public function __construct(
         private readonly RouteCollection $routeCollection,
         private readonly ControllerReflector $controllerReflector,
-        private readonly LoggerInterface $logger,
         private readonly OperationIdGeneration $operationIdGeneration = OperationIdGeneration::ALWAYS_PREPEND,
     ) {
     }

--- a/tests/Functional/Controller/AbstractDocumentController.php
+++ b/tests/Functional/Controller/AbstractDocumentController.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
+
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+
+abstract class AbstractDocumentController
+{
+    #[Route('', methods: ['GET'])]
+    #[OA\Response(response: 200, description: 'List documents')]
+    public function getDocuments(): JsonResponse
+    {
+    }
+}

--- a/tests/Functional/Controller/InvoiceDocumentController.php
+++ b/tests/Functional/Controller/InvoiceDocumentController.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
+
+use OpenApi\Attributes as OA;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/invoices', methods: 'GET')]
+#[OA\Tag(name: 'Invoices')]
+final class InvoiceDocumentController extends AbstractDocumentController
+{
+}

--- a/tests/Functional/ControllerTest.php
+++ b/tests/Functional/ControllerTest.php
@@ -574,6 +574,10 @@ final class ControllerTest extends WebTestCase
                 ],
             ],
         ];
+
+        yield 'Tag from class on inherited controller' => [
+            'InvoiceDocumentController',
+        ];
     }
 
     private static function getFixture(string $fixture): string

--- a/tests/Functional/Fixtures/InvoiceDocumentController.json
+++ b/tests/Functional/Fixtures/InvoiceDocumentController.json
@@ -1,0 +1,27 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "",
+        "version": "0.0.0"
+    },
+    "paths": {
+        "/invoices": {
+            "get": {
+                "tags": [
+                    "Invoices"
+                ],
+                "operationId": "get_nelmio_apidoc_tests_functional_invoicedocument_getdocuments",
+                "responses": {
+                    "200": {
+                        "description": "List documents"
+                    }
+                }
+            }
+        }
+    },
+    "tags": [
+        {
+            "name": "Invoices"
+        }
+    ]
+}


### PR DESCRIPTION
## Description

Fixes attributes being ignored on subclasses when extending from controllers.

Closes #2480

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [x] I have made corresponding changes to the changelog (`CHANGELOG.md`)