### PR TITLE
fix: typo in documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -258,7 +258,7 @@ This attribute has two options:
         )]
 
 * ``groups`` may also be used to specify the constraint validation groups used
-  (de)serialize your model, but this must be enabled in configuration::
+  to (de)serialize your model, but this must be enabled in configuration::
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Description

Just a small typo in documentation page.

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [x] Documentation Update
- [ ] CI
