### PR TITLE
fix(#2509): fatal reflection error when controller class doesn't exist

### DIFF
--- a/src/Describer/OpenApiPhpDescriber.php
+++ b/src/Describer/OpenApiPhpDescriber.php
@@ -52,12 +52,16 @@ final class OpenApiPhpDescriber
             $path = $this->normalizePath($route->getPath());
             $supportedHttpMethods = $this->getSupportedHttpMethods($route);
 
-            $classReflector = $reflectedMethod->getDeclaringClass();
             if (\is_array($controller) && method_exists(...$controller)) {
-                $classReflector = new \ReflectionClass($controller[0]);
+                $class = $controller[0];
             } elseif (\is_string($controller) && false !== $i = strpos($controller, '::')) {
-                $classReflector = new \ReflectionClass(substr($controller, 0, $i));
+                $class = substr($controller, 0, $i);
             }
+
+            $classReflector = isset($class) && class_exists($class)
+                ? new \ReflectionClass($class)
+                : $reflectedMethod->getDeclaringClass();
+
 
             $path = Util::getPath($api, $path);
 

--- a/src/Describer/OpenApiPhpDescriber.php
+++ b/src/Describer/OpenApiPhpDescriber.php
@@ -62,7 +62,6 @@ final class OpenApiPhpDescriber
                 ? new \ReflectionClass($class)
                 : $reflectedMethod->getDeclaringClass();
 
-
             $path = Util::getPath($api, $path);
 
             $context = Util::createContext(['nested' => $path], $path->_context);

--- a/src/Describer/OpenApiPhpDescriber.php
+++ b/src/Describer/OpenApiPhpDescriber.php
@@ -52,15 +52,16 @@ final class OpenApiPhpDescriber
             $path = $this->normalizePath($route->getPath());
             $supportedHttpMethods = $this->getSupportedHttpMethods($route);
 
-            if (\is_array($controller) && method_exists(...$controller)) {
-                $class = $controller[0];
-            } elseif (\is_string($controller) && false !== $i = strpos($controller, '::')) {
-                $class = substr($controller, 0, $i);
+            $classReflector = $reflectedMethod->getDeclaringClass();
+            try {
+                if (\is_array($controller) && method_exists(...$controller)) {
+                    $classReflector = new \ReflectionClass($controller[0]);
+                } elseif (\is_string($controller) && false !== $i = strpos($controller, '::')) {
+                    $classReflector = new \ReflectionClass(substr($controller, 0, $i));
+                }
+            } catch (\ReflectionException) {
+                // Fallback to the declaring class if the controller class does not exist
             }
-
-            $classReflector = isset($class) && class_exists($class)
-                ? new \ReflectionClass($class)
-                : $reflectedMethod->getDeclaringClass();
 
             $path = Util::getPath($api, $path);
 

--- a/src/Describer/SecurityDescriber.php
+++ b/src/Describer/SecurityDescriber.php
@@ -78,6 +78,7 @@ final class SecurityDescriber implements DescriberInterface
             return;
         }
 
+        $classReflector = null;
         try {
             if (\is_array($controller) && method_exists(...$controller)) {
                 $classReflector = new \ReflectionClass($controller[0]);

--- a/src/Describer/SecurityDescriber.php
+++ b/src/Describer/SecurityDescriber.php
@@ -86,7 +86,7 @@ final class SecurityDescriber implements DescriberInterface
                 $classReflector = new \ReflectionClass(substr($controller, 0, $i));
             }
         } catch (\ReflectionException) {
-            // Fallback to the declaring class if the controller class does not exist
+            // Fallback
         }
 
         $attributes = array_map(

--- a/src/Describer/SecurityDescriber.php
+++ b/src/Describer/SecurityDescriber.php
@@ -78,12 +78,15 @@ final class SecurityDescriber implements DescriberInterface
             return;
         }
 
-        $classReflector = null;
         if (\is_array($controller) && method_exists(...$controller)) {
-            $classReflector = new \ReflectionClass($controller[0]);
+            $class = $controller[0];
         } elseif (\is_string($controller) && false !== $i = strpos($controller, '::')) {
-            $classReflector = new \ReflectionClass(substr($controller, 0, $i));
+            $class = substr($controller, 0, $i);
         }
+
+        $classReflector = isset($class) && class_exists($class)
+            ? new \ReflectionClass($class)
+            : null;
 
         $attributes = array_map(
             static fn (\ReflectionAttribute $attribute): IsGranted => $attribute->newInstance(),

--- a/src/Describer/SecurityDescriber.php
+++ b/src/Describer/SecurityDescriber.php
@@ -78,15 +78,15 @@ final class SecurityDescriber implements DescriberInterface
             return;
         }
 
-        if (\is_array($controller) && method_exists(...$controller)) {
-            $class = $controller[0];
-        } elseif (\is_string($controller) && false !== $i = strpos($controller, '::')) {
-            $class = substr($controller, 0, $i);
+        try {
+            if (\is_array($controller) && method_exists(...$controller)) {
+                $classReflector = new \ReflectionClass($controller[0]);
+            } elseif (\is_string($controller) && false !== $i = strpos($controller, '::')) {
+                $classReflector = new \ReflectionClass(substr($controller, 0, $i));
+            }
+        } catch (\ReflectionException) {
+            // Fallback to the declaring class if the controller class does not exist
         }
-
-        $classReflector = isset($class) && class_exists($class)
-            ? new \ReflectionClass($class)
-            : null;
 
         $attributes = array_map(
             static fn (\ReflectionAttribute $attribute): IsGranted => $attribute->newInstance(),

--- a/tests/Functional/ControllerTest.php
+++ b/tests/Functional/ControllerTest.php
@@ -579,7 +579,7 @@ final class ControllerTest extends WebTestCase
             'InvoiceDocumentController',
         ];
 
-        yield '' => [
+        yield 'Controller as service' => [
             null,
             'controller-as-service',
             [],
@@ -587,6 +587,35 @@ final class ControllerTest extends WebTestCase
             [
                 'web_custom_controller' => (new Definition(SecuredApiController::class))
                 ->setPublic(true),
+            ],
+            function (RoutingConfigurator $routes) {
+                $routes->add('route_name', '/')
+                    ->controller('web_custom_controller::fetchArticleAction')
+                    ->methods(['GET']);
+            },
+        ];
+
+        yield 'Controller as service with security' => [
+            null,
+            'controller-as-service-with-security',
+            [],
+            [
+                'nelmio_api_doc' => [
+                    'areas' => [
+                        'default' => [
+                            'security' => [
+                                'BasicAuth' => [
+                                    'type' => 'http',
+                                    'scheme' => 'basic',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'web_custom_controller' => (new Definition(SecuredApiController::class))
+                    ->setPublic(true),
             ],
             function (RoutingConfigurator $routes) {
                 $routes->add('route_name', '/')

--- a/tests/Functional/ControllerTest.php
+++ b/tests/Functional/ControllerTest.php
@@ -578,6 +578,22 @@ final class ControllerTest extends WebTestCase
         yield 'Tag from class on inherited controller' => [
             'InvoiceDocumentController',
         ];
+
+        yield '' => [
+            null,
+            'controller-as-service',
+            [],
+            [],
+            [
+                'web_custom_controller' => (new Definition(SecuredApiController::class))
+                ->setPublic(true),
+            ],
+            function (RoutingConfigurator $routes) {
+                $routes->add('route_name', '/')
+                    ->controller('web_custom_controller::fetchArticleAction')
+                    ->methods(['GET']);
+            },
+        ];
     }
 
     private static function getFixture(string $fixture): string

--- a/tests/Functional/Fixtures/.controller-as-service-with-security.json
+++ b/tests/Functional/Fixtures/.controller-as-service-with-security.json
@@ -1,0 +1,32 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "",
+        "version": "0.0.0"
+    },
+    "paths": {
+        "/": {
+            "get": {
+                "operationId": "get_route_name",
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                },
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "securitySchemes": {
+            "BasicAuth": {
+                "type": "http",
+                "scheme": "basic"
+            }
+        }
+    }
+}

--- a/tests/Functional/Fixtures/.controller-as-service.json
+++ b/tests/Functional/Fixtures/.controller-as-service.json
@@ -1,0 +1,19 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "",
+        "version": "0.0.0"
+    },
+    "paths": {
+        "/": {
+            "get": {
+                "operationId": "get_route_name",
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes fatal reflection error when class doesn't exist. This for example might happen when the controller is defined as a service which isn't a class-string.

Closes https://github.com/nelmio/NelmioApiDocBundle/issues/2509

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)