### PR TITLE
feat(Model): Allow customizing the name of generated schemas.

### DIFF
--- a/docs/alternative_names.rst
+++ b/docs/alternative_names.rst
@@ -1,8 +1,8 @@
 Alternative Names
 =================
 
-NelmioApiDoc automatically generates the model names but the ``nelmio_api_doc.models.names`` option allows to
-customize the names for some models.
+NelmioApiDoc automatically generates model names, but you can customize them using the
+``nelmio_api_doc.models.names`` configuration option or the ``name`` property on the ``#[Model]`` attribute.
 
 Configuration
 -------------
@@ -49,3 +49,36 @@ In this case the class ``App\Entity\User`` will be aliased into:
                 {
                 }
             }
+
+Using the Model attribute
+-------------------------
+
+You can also specify an alternative name directly within the ``#[Model]`` attribute by using the ``name`` property.
+This is useful when you want to define a custom name for a model in a specific context.
+
+.. configuration-block::
+
+    .. code-block:: php-attributes
+
+        use Nelmio\ApiDocBundle\Attribute\Model;
+        use OpenApi\Attributes as OA;
+        use App\Entity\User;
+
+        class UserController
+        {
+            #[OA\Response(
+                response: 200,
+                description: "Success",
+                content: new Model(type: User::class, name: "User_CustomName")
+            )]
+            public function getUser()
+            {
+                // ...
+            }
+        }
+
+This will register the ``User`` model with the name ``User_CustomName`` in the OpenAPI documentation.
+
+.. versionadded:: 5.6
+
+    The possibility to define alternative names for models through the ``#[Model]`` attribute was added in version 5.6.

--- a/docs/alternative_names.rst
+++ b/docs/alternative_names.rst
@@ -42,6 +42,8 @@ In this case the class ``App\Entity\User`` will be aliased into:
 
         .. code-block:: php-attributes
 
+            use OpenApi\Attributes as OA;
+
             class HomeController
             {
                 #[OA\Response(response: 200, content: new OA\JsonContent(ref: "#/components/schemas/MyModel"))]
@@ -60,9 +62,9 @@ This is useful when you want to define a custom name for a model in a specific c
 
     .. code-block:: php-attributes
 
+        use App\Entity\User;
         use Nelmio\ApiDocBundle\Attribute\Model;
         use OpenApi\Attributes as OA;
-        use App\Entity\User;
 
         class UserController
         {

--- a/src/Attribute/Model.php
+++ b/src/Attribute/Model.php
@@ -22,6 +22,7 @@ final class Model extends Attachable
         'type' => 'string',
         'groups' => '[string]',
         'options' => '[mixed]',
+        'name' => 'string',
     ];
 
     public static $_required = ['type'];
@@ -59,6 +60,7 @@ final class Model extends Attachable
         ?array $groups = null,
         array $options = [],
         array $serializationContext = [],
+        public readonly ?string $name = null,
     ) {
         parent::__construct($properties + [
             'type' => $type,

--- a/src/Attribute/Model.php
+++ b/src/Attribute/Model.php
@@ -49,10 +49,11 @@ final class Model extends Attachable
     public array $serializationContext;
 
     /**
-     * @param mixed[]              $properties
-     * @param string[]             $groups
-     * @param mixed[]              $options
-     * @param array<string, mixed> $serializationContext
+     * @param mixed[]               $properties
+     * @param string[]              $groups
+     * @param mixed[]               $options
+     * @param array<string, mixed>  $serializationContext
+     * @param non-empty-string|null $name                 An optional custom name for the generated schema
      */
     public function __construct(
         array $properties = [],

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -56,7 +56,7 @@ final class Model
 
     public function getHash(): string
     {
-        return md5(serialize([$this->type, $this->getSerializationContext(), $this->name]));
+        return md5(serialize([$this->type, $this->getSerializationContext()]));
     }
 
     /**

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -16,10 +16,10 @@ use Symfony\Component\PropertyInfo\Type;
 final class Model
 {
     /**
-     * @param string[]|null $groups
-     * @param mixed[]       $options
-     * @param mixed[]       $serializationContext
-     * @param string|null   $name                 An optional custom name for the generated schema
+     * @param string[]|null         $groups
+     * @param mixed[]               $options
+     * @param mixed[]               $serializationContext
+     * @param non-empty-string|null $name                 An optional custom name for the generated schema
      */
     public function __construct(
         private Type $type,

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -15,28 +15,19 @@ use Symfony\Component\PropertyInfo\Type;
 
 final class Model
 {
-    private Type $type;
-
-    /**
-     * @var mixed[]
-     */
-    private array $options;
-
-    /**
-     * @var mixed[]
-     */
-    private array $serializationContext;
-
     /**
      * @param string[]|null $groups
      * @param mixed[]       $options
      * @param mixed[]       $serializationContext
+     * @param string|null   $name                 An optional custom name for the generated schema
      */
-    public function __construct(Type $type, ?array $groups = null, array $options = [], array $serializationContext = [])
-    {
-        $this->type = $type;
-        $this->options = $options;
-        $this->serializationContext = $serializationContext;
+    public function __construct(
+        private Type $type,
+        ?array $groups = null,
+        private array $options = [],
+        private array $serializationContext = [],
+        public readonly ?string $name = null,
+    ) {
         if (null !== $groups) {
             $this->serializationContext['groups'] = $groups;
         }

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -56,7 +56,7 @@ final class Model
 
     public function getHash(): string
     {
-        return md5(serialize([$this->type, $this->getSerializationContext()]));
+        return md5(serialize([$this->type, $this->getSerializationContext(), $this->name]));
     }
 
     /**

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -82,7 +82,11 @@ final class ModelRegistry
     public function register(Model $model, ?string $alternativeName = null): string
     {
         $hash = $model->getHash();
-        $identifier = $this->getTypeShortName($model->getType()).$model->name;
+        $identifier = \sprintf(
+            '%s|%s',
+            $this->getTypeShortName($model->getType()),
+            $model->name ?? $alternativeName,
+        );
 
         $schema = null;
         if (!isset($this->names[$hash])) {

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -29,6 +29,11 @@ final class ModelRegistry
     private array $registeredModelNames = [];
 
     /**
+     * @var Model[]
+     */
+    private array $alternativeNames = [];
+
+    /**
      * @var string[] List of hashes of models that have not been registered yet
      */
     private array $unregistered = [];
@@ -67,13 +72,16 @@ final class ModelRegistry
         $this->api = $api;
         $this->logger = new NullLogger();
         foreach (array_reverse($alternativeNames) as $alternativeName => $criteria) {
-            $this->register(new Model(
+            $this->alternativeNames[] = $model = new Model(
                 new Type('object', false, $criteria['type']),
                 $criteria['groups'],
                 $criteria['options'] ?? [],
                 $criteria['serializationContext'] ?? [],
                 name: $alternativeName,
-            ));
+            );
+            $this->names[$model->getHash()] = $alternativeName;
+            $this->registeredModelNames[$alternativeName] = $model;
+            Util::getSchema($this->api, $alternativeName);
         }
     }
 

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -72,19 +72,21 @@ final class ModelRegistry
                 $criteria['groups'],
                 $criteria['options'] ?? [],
                 $criteria['serializationContext'] ?? [],
-                name: $alternativeName,
-            ));
+            ), $alternativeName);
         }
     }
 
-    public function register(Model $model): string
+    /**
+     * @param string|null $alternativeName An optional custom name for the generated schema, all models with the same hash will share the same name
+     */
+    public function register(Model $model, ?string $alternativeName = null): string
     {
         $hash = $model->getHash();
         $identifier = $this->getTypeShortName($model->getType()).$model->name;
 
         $schema = null;
-        if (null !== $model->name || !isset($this->names[$hash])) {
-            $this->names[$hash] = $name = $this->generateModelName($model);
+        if (!isset($this->names[$hash])) {
+            $this->names[$hash] = $name = $this->generateModelName($model, $alternativeName);
             $this->registeredModelNames[$name] = $model;
 
             $schema = $this->describeSchema($model, null);
@@ -170,9 +172,9 @@ final class ModelRegistry
         }
     }
 
-    private function generateModelName(Model $model): string
+    private function generateModelName(Model $model, ?string $alternativeName): string
     {
-        $name = $base = $model->name ?? $this->getTypeShortName($model->getType());
+        $name = $base = $alternativeName ?? $model->name ?? $this->getTypeShortName($model->getType());
         $names = array_column(
             $this->api->components instanceof OA\Components && \is_array($this->api->components->schemas) ? $this->api->components->schemas : [],
             'schema'

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -180,6 +180,10 @@ final class ModelRegistry
         $i = 1;
         while (\in_array($name, $names, true)) {
             if (isset($this->registeredModelNames[$name])) {
+                if ($this->registeredModelNames[$name]->getHash() === $model->getHash()) {
+                    return $name;
+                }
+
                 $this->logger->info(\sprintf('Can not assign a name for the model, the name "%s" has already been taken.', $name), [
                     'model' => $this->modelToArray($model),
                     'taken_by' => $this->modelToArray($this->registeredModelNames[$name]),

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -77,6 +77,7 @@ final class ModelRegistry
                 $criteria['groups'],
                 $criteria['options'] ?? [],
                 $criteria['serializationContext'] ?? [],
+                name: $alternativeName,
             );
             $this->names[$model->getHash()] = $alternativeName;
             $this->registeredModelNames[$alternativeName] = $model;
@@ -176,7 +177,7 @@ final class ModelRegistry
             }
         }
 
-        if ([] === $this->unregistered && [] !== $this->alternativeNames) {
+        if ([] !== $this->alternativeNames) {
             foreach ($this->alternativeNames as $model) {
                 $this->register($model);
             }

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -188,7 +188,7 @@ final class ModelRegistry
 
     private function generateModelName(Model $model): string
     {
-        $name = $base = $this->getTypeShortName($model->getType());
+        $name = $base = $model->name ?: $this->getTypeShortName($model->getType());
         $names = array_column(
             $this->api->components instanceof OA\Components && \is_array($this->api->components->schemas) ? $this->api->components->schemas : [],
             'schema'

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -182,10 +182,6 @@ final class ModelRegistry
         $i = 1;
         while (\in_array($name, $names, true)) {
             if (isset($this->registeredModelNames[$name])) {
-                if ($this->registeredModelNames[$name]->getHash() === $model->getHash()) {
-                    return $name;
-                }
-
                 $this->logger->info(\sprintf('Can not assign a name for the model, the name "%s" has already been taken.', $name), [
                     'model' => $this->modelToArray($model),
                     'taken_by' => $this->modelToArray($this->registeredModelNames[$name]),

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -44,6 +44,11 @@ final class ModelRegistry
     private array $names = [];
 
     /**
+     * @var array<string, string> List of model hashes to model alternative names
+     */
+    private array $alternativeNames = [];
+
+    /**
      * @var array<string, array<string, Model>> Map from identifier and schema content to Model
      */
     private array $schemaToModelMap = [];
@@ -66,27 +71,31 @@ final class ModelRegistry
         $this->modelDescribers = $modelDescribers;
         $this->api = $api;
         $this->logger = new NullLogger();
+
+        // The array is reversed to ensure that the first defined alternative name for a model is used.
         foreach (array_reverse($alternativeNames) as $alternativeName => $criteria) {
-            $this->register(new Model(
+            $model = new Model(
                 new Type('object', false, $criteria['type']),
                 $criteria['groups'],
                 $criteria['options'] ?? [],
                 $criteria['serializationContext'] ?? [],
-            ), $alternativeName);
+            );
+
+            $this->alternativeNames[$model->getHash()] = $alternativeName;
+
+            $this->register($model);
         }
     }
 
-    /**
-     * @param string|null $alternativeName An optional custom name for the generated schema, all models with the same hash will share the same name
-     */
-    public function register(Model $model, ?string $alternativeName = null): string
+    public function register(Model $model): string
     {
         $hash = $model->getHash();
-        $identifier = $this->getTypeShortName($model->getType()).($model->name ?? $alternativeName);
+
+        $identifier = $this->determineModelName($model);
 
         $schema = null;
         if (!isset($this->names[$hash])) {
-            $this->names[$hash] = $name = $this->generateModelName($model, $alternativeName);
+            $this->names[$hash] = $name = $this->generateUniqueModelName($model);
             $this->registeredModelNames[$name] = $model;
 
             $schema = $this->describeSchema($model, null);
@@ -172,9 +181,27 @@ final class ModelRegistry
         }
     }
 
-    private function generateModelName(Model $model, ?string $alternativeName): string
+    private function determineModelName(Model $model): string
     {
-        $name = $base = $alternativeName ?? $model->name ?? $this->getTypeShortName($model->getType());
+        $hash = $model->getHash();
+
+        // 1. From the alternative names configuration
+        if (isset($this->alternativeNames[$hash])) {
+            return $this->alternativeNames[$hash];
+        }
+
+        // 2. From the model itself (e.g. #[Model(name: "MyModel")])
+        if (null !== $model->name) {
+            return $model->name;
+        }
+
+        // 3. Generate from the type
+        return $this->getTypeShortName($model->getType());
+    }
+
+    private function generateUniqueModelName(Model $model): string
+    {
+        $name = $base = $this->determineModelName($model);
         $names = array_column(
             $this->api->components instanceof OA\Components && \is_array($this->api->components->schemas) ? $this->api->components->schemas : [],
             'schema'

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -77,7 +77,6 @@ final class ModelRegistry
                 $criteria['groups'],
                 $criteria['options'] ?? [],
                 $criteria['serializationContext'] ?? [],
-                name: $alternativeName,
             );
             $this->names[$model->getHash()] = $alternativeName;
             $this->registeredModelNames[$alternativeName] = $model;
@@ -175,6 +174,14 @@ final class ModelRegistry
                     throw new \LogicException($errorMessage);
                 }
             }
+        }
+
+        if ([] !== $this->alternativeNames) {
+            foreach ($this->alternativeNames as $model) {
+                $this->register($model);
+            }
+            $this->alternativeNames = [];
+            $this->registerSchemas();
         }
     }
 

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -80,7 +80,7 @@ final class ModelRegistry
     public function register(Model $model): string
     {
         $hash = $model->getHash();
-        $type = $this->getTypeShortName($model->getType());
+        $type = $this->getTypeShortName($model->getType()) . $model->name;
 
         $schema = null;
         if (!isset($this->names[$hash])) {
@@ -167,14 +167,6 @@ final class ModelRegistry
                     throw new \LogicException($errorMessage);
                 }
             }
-        }
-
-        if ([] !== $this->alternativeNames) {
-            foreach ($this->alternativeNames as $model) {
-                $this->register($model);
-            }
-            $this->alternativeNames = [];
-            $this->registerSchemas();
         }
     }
 

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -77,6 +77,7 @@ final class ModelRegistry
                 $criteria['groups'],
                 $criteria['options'] ?? [],
                 $criteria['serializationContext'] ?? [],
+                name: $alternativeName,
             );
             $this->names[$model->getHash()] = $alternativeName;
             $this->registeredModelNames[$alternativeName] = $model;
@@ -174,14 +175,6 @@ final class ModelRegistry
                     throw new \LogicException($errorMessage);
                 }
             }
-        }
-
-        if ([] !== $this->alternativeNames) {
-            foreach ($this->alternativeNames as $model) {
-                $this->register($model);
-            }
-            $this->alternativeNames = [];
-            $this->registerSchemas();
         }
     }
 

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -83,7 +83,7 @@ final class ModelRegistry
         $identifier = $this->getTypeShortName($model->getType()).$model->name;
 
         $schema = null;
-        if (!isset($this->names[$hash])) {
+        if ($model->name || !isset($this->names[$hash])) {
             $this->names[$hash] = $name = $this->generateModelName($model);
             $this->registeredModelNames[$name] = $model;
 

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -83,7 +83,7 @@ final class ModelRegistry
         $identifier = $this->getTypeShortName($model->getType()).$model->name;
 
         $schema = null;
-        if ($model->name || !isset($this->names[$hash])) {
+        if (null !== $model->name || !isset($this->names[$hash])) {
             $this->names[$hash] = $name = $this->generateModelName($model);
             $this->registeredModelNames[$name] = $model;
 

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -157,14 +157,13 @@ final class ModelRegistry
      */
     public function registerSchemas(): void
     {
-        while (\count($this->unregistered)) {
-            $tmp = [];
-            foreach ($this->unregistered as $hash) {
-                $tmp[$this->names[$hash]] = $this->models[$hash];
-            }
+        while (!empty($this->unregistered)) {
+            $unregistered = $this->unregistered;
             $this->unregistered = [];
 
-            foreach ($tmp as $name => $model) {
+            foreach ($unregistered as $hash) {
+                $name = $this->names[$hash];
+                $model = $this->models[$hash];
                 $schema = $this->describeSchema($model, $name);
 
                 if (null === $schema) {

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -44,9 +44,9 @@ final class ModelRegistry
     private array $names = [];
 
     /**
-     * @var array<string, array{'schema': string, 'model': Model}[]> List of schemas and Model per type
+     * @var array<string, array<string, Model>> Map from identifier and schema content to Model
      */
-    private array $schemasPerType = [];
+    private array $schemaToModelMap = [];
 
     /**
      * @var iterable<ModelDescriberInterface>
@@ -80,23 +80,23 @@ final class ModelRegistry
     public function register(Model $model): string
     {
         $hash = $model->getHash();
-        $type = $this->getTypeShortName($model->getType()) . $model->name;
+        $identifier = $this->getTypeShortName($model->getType()).$model->name;
 
         $schema = null;
         if (!isset($this->names[$hash])) {
-            $this->names[$hash] = $this->generateModelName($model);
-            $this->registeredModelNames[$this->names[$hash]] = $model;
+            $this->names[$hash] = $name = $this->generateModelName($model);
+            $this->registeredModelNames[$name] = $model;
 
             $schema = $this->describeSchema($model, null);
             // Only try to match schemas if we successfully got one
             if (null !== $schema) {
-                foreach ($this->schemasPerType[$type] ?? [] as $schemaAndModel) {
-                    if ($schemaAndModel['schema'] === json_encode($schema->jsonSerialize())) {
-                        $newHash = $schemaAndModel['model']->getHash();
-                        unset($this->names[$hash], $this->registeredModelNames[$hash]);
+                $schemaJson = json_encode($schema);
+                if (isset($this->schemaToModelMap[$identifier][json_encode($schema)])) {
+                    $existingModel = $this->schemaToModelMap[$identifier][json_encode($schema)];
+                    $newHash = $existingModel->getHash();
+                    unset($this->names[$hash], $this->registeredModelNames[$name]);
 
-                        return OA\Components::SCHEMA_REF.$this->names[$newHash];
-                    }
+                    return OA\Components::SCHEMA_REF.$this->names[$newHash];
                 }
             }
         }
@@ -107,7 +107,7 @@ final class ModelRegistry
             $this->unregistered = array_unique($this->unregistered);
             // Only store schema if it was successfully generated
             if (null !== $schema) {
-                $this->schemasPerType[$type][] = ['schema' => json_encode($schema), 'model' => $model];
+                $this->schemaToModelMap[$identifier][$schemaJson ?? json_encode($schema)] = $model;
             }
         }
 
@@ -150,7 +150,7 @@ final class ModelRegistry
      */
     public function registerSchemas(): void
     {
-        while (!empty($this->unregistered)) {
+        while (\count($this->unregistered)) {
             $unregistered = $this->unregistered;
             $this->unregistered = [];
 
@@ -172,7 +172,7 @@ final class ModelRegistry
 
     private function generateModelName(Model $model): string
     {
-        $name = $base = $model->name ?: $this->getTypeShortName($model->getType());
+        $name = $base = $model->name ?? $this->getTypeShortName($model->getType());
         $names = array_column(
             $this->api->components instanceof OA\Components && \is_array($this->api->components->schemas) ? $this->api->components->schemas : [],
             'schema'

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -29,11 +29,6 @@ final class ModelRegistry
     private array $registeredModelNames = [];
 
     /**
-     * @var Model[]
-     */
-    private array $alternativeNames = [];
-
-    /**
      * @var string[] List of hashes of models that have not been registered yet
      */
     private array $unregistered = [];
@@ -72,16 +67,13 @@ final class ModelRegistry
         $this->api = $api;
         $this->logger = new NullLogger();
         foreach (array_reverse($alternativeNames) as $alternativeName => $criteria) {
-            $this->alternativeNames[] = $model = new Model(
+            $this->register(new Model(
                 new Type('object', false, $criteria['type']),
                 $criteria['groups'],
                 $criteria['options'] ?? [],
                 $criteria['serializationContext'] ?? [],
                 name: $alternativeName,
-            );
-            $this->names[$model->getHash()] = $alternativeName;
-            $this->registeredModelNames[$alternativeName] = $model;
-            Util::getSchema($this->api, $alternativeName);
+            ));
         }
     }
 

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -91,8 +91,8 @@ final class ModelRegistry
             // Only try to match schemas if we successfully got one
             if (null !== $schema) {
                 $schemaJson = json_encode($schema);
-                if (isset($this->schemaToModelMap[$identifier][json_encode($schema)])) {
-                    $existingModel = $this->schemaToModelMap[$identifier][json_encode($schema)];
+                if (isset($this->schemaToModelMap[$identifier][$schemaJson])) {
+                    $existingModel = $this->schemaToModelMap[$identifier][$schemaJson];
                     $newHash = $existingModel->getHash();
                     unset($this->names[$hash], $this->registeredModelNames[$name]);
 

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -82,11 +82,7 @@ final class ModelRegistry
     public function register(Model $model, ?string $alternativeName = null): string
     {
         $hash = $model->getHash();
-        $identifier = \sprintf(
-            '%s|%s',
-            $this->getTypeShortName($model->getType()),
-            $model->name ?? $alternativeName,
-        );
+        $identifier = $this->getTypeShortName($model->getType()).($model->name ?? $alternativeName);
 
         $schema = null;
         if (!isset($this->names[$hash])) {

--- a/src/OpenApiPhp/ModelRegister.php
+++ b/src/OpenApiPhp/ModelRegister.php
@@ -50,7 +50,7 @@ final class ModelRegister
             if ($annotation instanceof OA\Schema && $annotation->ref instanceof ModelAnnotation) {
                 $model = $annotation->ref;
 
-                $annotation->ref = $this->modelRegistry->register(new Model($this->createType($model->type), $this->getGroups($model, $parentGroups), $model->options, $model->serializationContext));
+                $annotation->ref = $this->modelRegistry->register(new Model($this->createType($model->type), $this->getGroups($model, $parentGroups), $model->options, $model->serializationContext, $model->name));
 
                 // It is no longer an unmerged annotation
                 $this->detach($model, $annotation, $analysis);
@@ -76,7 +76,7 @@ final class ModelRegister
             if ($annotation instanceof OA\Response || $annotation instanceof OA\RequestBody) {
                 $properties = [
                     '_context' => Util::createContext(['nested' => $annotation], $annotation->_context),
-                    'ref' => $this->modelRegistry->register(new Model($this->createType($model->type), $this->getGroups($model, $parentGroups), $model->options, $model->serializationContext)),
+                    'ref' => $this->modelRegistry->register(new Model($this->createType($model->type), $this->getGroups($model, $parentGroups), $model->options, $model->serializationContext, $model->name)),
                 ];
 
                 foreach ($this->mediaTypes as $mediaType) {
@@ -98,7 +98,7 @@ final class ModelRegister
             }
 
             $annotation->merge([new $annotationClass([
-                'ref' => $this->modelRegistry->register(new Model($this->createType($model->type), $this->getGroups($model, $parentGroups), $model->options, $model->serializationContext)),
+                'ref' => $this->modelRegistry->register(new Model($this->createType($model->type), $this->getGroups($model, $parentGroups), $model->options, $model->serializationContext, $model->name)),
             ])]);
 
             // It is no longer an unmerged annotation

--- a/tests/Functional/Controller/ApiController.php
+++ b/tests/Functional/Controller/ApiController.php
@@ -550,4 +550,18 @@ class ApiController
     public function entityWithIgnoredProperty()
     {
     }
+
+    #[Route('/swagger/model-parameter', methods: 'GET')]
+    #[OA\Parameter(name: 'user', in: 'query', content: new Model(type: User::class))]
+    #[OA\Parameter(
+        name: 'list',
+        in: 'query',
+        schema: new OA\Schema(
+            type: 'array',
+            items: new OA\Items(new Model(type: Article::class, groups: ['light'])),
+        ),
+    )]
+    public function modelParameter(): void
+    {
+    }
 }

--- a/tests/Functional/Controller/ApiController.php
+++ b/tests/Functional/Controller/ApiController.php
@@ -205,6 +205,16 @@ class ApiController
     {
     }
 
+    #[Route('/form-model-renamed', methods: ['POST'])]
+    #[OA\RequestBody(
+        description: 'Request content',
+        content: new Model(type: FormWithModel::class, name: 'RenamedFormWithModel'),
+    )]
+    #[OA\Response(response: 201, description: '')]
+    public function formWithModelRenamed()
+    {
+    }
+
     #[Route('/security', methods: ['GET'])]
     #[OA\Response(response: 201, description: '')]
     #[Security(name: 'api_key')]

--- a/tests/Functional/Controller/CustomModelNameController.php
+++ b/tests/Functional/Controller/CustomModelNameController.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
+
+use Nelmio\ApiDocBundle\Attribute\Model;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\Article;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/custom_model_names')]
+final class CustomModelNameController
+{
+    #[Route('/unique', methods: 'POST')]
+    #[OA\RequestBody(
+        description: 'Request body description',
+        content: new Model(type: Article::class, name: 'MyUniqueArticle'),
+    )]
+    public function postUniqueArticles(): void
+    {
+    }
+
+    #[Route('/plain', methods: 'POST')]
+    #[OA\RequestBody(
+        description: 'Request body description',
+        content: new Model(type: Article::class, name: 'MyPlainArticle'),
+    )]
+    public function postPlainArticle(): void
+    {
+    }
+
+    #[Route('/plain', methods: 'GET')]
+    #[OA\Response(
+        response: Response::HTTP_OK,
+        description: 'An article',
+        content: new Model(type: Article::class, name: 'MyPlainArticle'),
+    )]
+    public function getPlainArticle(): void
+    {
+    }
+
+    #[Route('/plain/all', methods: 'GET')]
+    #[OA\Response(
+        response: Response::HTTP_OK,
+        description: 'Array of articles',
+        content: new OA\JsonContent(
+            type: 'array',
+            items: new OA\Items(ref: new Model(type: Article::class, name: 'MyPlainArticle'))
+        )
+    )]
+    public function getAllPlainArticles(): void
+    {
+    }
+
+    #[Route(methods: 'GET')]
+    #[OA\Response(
+        response: Response::HTTP_OK,
+        description: 'Normal article without custom model name',
+        content: new Model(type: Article::class),
+    )]
+    public function getNormalArticle(): void
+    {
+    }
+}

--- a/tests/Functional/ControllerTest.php
+++ b/tests/Functional/ControllerTest.php
@@ -671,6 +671,10 @@ final class ControllerTest extends WebTestCase
                 ],
             ];
         }
+
+        yield 'Custom model names' => [
+            'CustomModelNameController',
+        ];
     }
 
     private static function getFixture(string $fixture): string

--- a/tests/Functional/Fixtures/CustomModelNameController.json
+++ b/tests/Functional/Fixtures/CustomModelNameController.json
@@ -1,0 +1,256 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "",
+        "version": "0.0.0"
+    },
+    "paths": {
+        "/custom_model_names/unique": {
+            "post": {
+                "operationId": "post_nelmio_apidoc_tests_functional_custommodelname_postuniquearticles",
+                "requestBody": {
+                    "description": "Request body description",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MyUniqueArticle"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/custom_model_names/plain": {
+            "get": {
+                "operationId": "get_nelmio_apidoc_tests_functional_custommodelname_getplainarticle",
+                "responses": {
+                    "200": {
+                        "description": "An article",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MyPlainArticle"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "operationId": "post_nelmio_apidoc_tests_functional_custommodelname_postplainarticle",
+                "requestBody": {
+                    "description": "Request body description",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MyPlainArticle"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/custom_model_names/plain/all": {
+            "get": {
+                "operationId": "get_nelmio_apidoc_tests_functional_custommodelname_getallplainarticles",
+                "responses": {
+                    "200": {
+                        "description": "Array of articles",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/MyPlainArticle"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/custom_model_names": {
+            "get": {
+                "operationId": "get_nelmio_apidoc_tests_functional_custommodelname_getnormalarticle",
+                "responses": {
+                    "200": {
+                        "description": "Normal article without custom model name",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Article"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "User": {
+                "required": [
+                    "email",
+                    "location",
+                    "friendsNumber",
+                    "creationDate",
+                    "users",
+                    "dummy",
+                    "status",
+                    "dateAsInterface"
+                ],
+                "properties": {
+                    "money": {
+                        "type": "number",
+                        "format": "float",
+                        "default": 0
+                    },
+                    "id": {
+                        "title": "userid",
+                        "description": "User id",
+                        "type": "integer",
+                        "default": null,
+                        "readOnly": true,
+                        "example": 1
+                    },
+                    "email": {
+                        "type": "string",
+                        "readOnly": false
+                    },
+                    "roles": {
+                        "title": "roles",
+                        "description": "User roles",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "default": [
+                            "user"
+                        ],
+                        "example": "[\"ADMIN\",\"SUPERUSER\"]"
+                    },
+                    "location": {
+                        "title": "User Location.",
+                        "type": "string"
+                    },
+                    "friendsNumber": {
+                        "type": "string"
+                    },
+                    "creationDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "users": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/User"
+                        }
+                    },
+                    "friend": {
+                        "nullable": true,
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/User"
+                            }
+                        ]
+                    },
+                    "friends": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/User"
+                        },
+                        "default": [],
+                        "nullable": true
+                    },
+                    "dummy": {
+                        "$ref": "#/components/schemas/Dummy"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "disabled",
+                            "enabled"
+                        ]
+                    },
+                    "dateAsInterface": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "Dummy": {
+                "required": [
+                    "id",
+                    "name"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "MyUniqueArticle": {
+                "required": [
+                    "author",
+                    "content"
+                ],
+                "properties": {
+                    "author": {
+                        "$ref": "#/components/schemas/User"
+                    },
+                    "content": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "MyPlainArticle": {
+                "required": [
+                    "author",
+                    "content"
+                ],
+                "properties": {
+                    "author": {
+                        "$ref": "#/components/schemas/User"
+                    },
+                    "content": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "Article": {
+                "required": [
+                    "author",
+                    "content"
+                ],
+                "properties": {
+                    "author": {
+                        "$ref": "#/components/schemas/User"
+                    },
+                    "content": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            }
+        }
+    }
+}

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -228,7 +228,7 @@ class FunctionalTest extends WebTestCase
                         'default' => [],
                     ],
                     'dummy' => [
-                        '$ref' => '#/components/schemas/Dummy',
+                        '$ref' => '#/components/schemas/Dummy2',
                     ],
                     'status' => [
                         'type' => 'string',

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -228,7 +228,7 @@ class FunctionalTest extends WebTestCase
                         'default' => [],
                     ],
                     'dummy' => [
-                        '$ref' => '#/components/schemas/Dummy2',
+                        '$ref' => '#/components/schemas/Dummy',
                     ],
                     'status' => [
                         'type' => 'string',

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -1378,4 +1378,28 @@ class FunctionalTest extends WebTestCase
             ],
         ], $operation->security);
     }
+
+    public function testModelInParameter(): void
+    {
+        $operation = $this->getOperation('/api/swagger/model-parameter', 'get');
+
+        self::assertSame([
+            'name' => 'user',
+            'in' => 'query',
+            'schema' => [
+                '$ref' => '#/components/schemas/User2',
+            ],
+        ], json_decode($this->getParameter($operation, 'user', 'query')->toJson(), true));
+
+        self::assertSame([
+            'name' => 'list',
+            'in' => 'query',
+            'schema' => [
+                'type' => 'array',
+                'items' => [
+                    '$ref' => '#/components/schemas/Article',
+                ],
+            ],
+        ], json_decode($this->getParameter($operation, 'list', 'query')->toJson(), true));
+    }
 }

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -365,6 +365,31 @@ class FunctionalTest extends WebTestCase
         ], json_decode($this->getModel('FormWithModel')->toJson(), true));
     }
 
+    public function testFormSupportWithRenamedModel(): void
+    {
+        self::assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'quz' => [
+                    '$ref' => '#/components/schemas/User2',
+                ],
+            ],
+            'required' => ['quz'],
+            'schema' => 'FormWithModel',
+        ], json_decode($this->getModel('FormWithModel')->toJson(), true));
+
+        self::assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'quz' => [
+                    '$ref' => '#/components/schemas/User2',
+                ],
+            ],
+            'required' => ['quz'],
+            'schema' => 'RenamedFormWithModel',
+        ], json_decode($this->getModel('RenamedFormWithModel')->toJson(), true));
+    }
+
     #[DataProvider('provideSecurityRoute')]
     public function testSecurityAction(string $route): void
     {

--- a/tests/Functional/TestKernel.php
+++ b/tests/Functional/TestKernel.php
@@ -187,9 +187,6 @@ class TestKernel extends Kernel
                 'type' => SymfonyConstraintsWithValidationGroups::class,
                 'groups' => null,
             ],
-        ];
-
-        $models = array_merge($models, [
             [
                 'alias' => 'JMSComplex',
                 'type' => JMSComplex::class,
@@ -204,7 +201,7 @@ class TestKernel extends Kernel
                 'type' => JMSComplex::class,
                 'groups' => null,
             ],
-        ]);
+        ];
 
         // Filter routes
         $c->loadFromExtension('nelmio_api_doc', [

--- a/tests/Functional/WebTestCase.php
+++ b/tests/Functional/WebTestCase.php
@@ -80,10 +80,7 @@ class WebTestCase extends BaseWebTestCase
         return $annotation->properties[$key];
     }
 
-    /**
-     * @param OA\Operation|OA\OpenApi $annotation
-     */
-    protected function getParameter(OA\AbstractAnnotation $annotation, string $name, string $in): OA\Parameter
+    protected function getParameter(OA\Operation|OA\OpenApi $annotation, string $name, string $in): OA\Parameter
     {
         $this->assertHasParameter($name, $in, $annotation);
         $parameters = array_filter($annotation->parameters ?? [], function (OA\Parameter $parameter) use ($name, $in) {

--- a/tests/Model/ModelRegistryTest.php
+++ b/tests/Model/ModelRegistryTest.php
@@ -280,10 +280,12 @@ class ModelRegistryTest extends TestCase
         $registry = new ModelRegistry([], $this->createOpenApi());
         $name = 'CustomName';
 
-        self::assertEquals('#/components/schemas/CustomName', $registry->register(new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, self::class.'ReUsed'), name: $name)));
-        self::assertEquals('#/components/schemas/CustomName', $registry->register(new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, self::class.'ReUsed'), name: $name)));
-        self::assertEquals('#/components/schemas/CustomName', $registry->register(new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, self::class.'ReUsed'), name: $name)));
-        self::assertEquals('#/components/schemas/CustomName2', $registry->register(new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, self::class.'ReUsed'))));
+        $type = new Type(Type::BUILTIN_TYPE_OBJECT, false, self::class.'ReUsed');
+
+        self::assertEquals('#/components/schemas/CustomName', $registry->register(new Model($type, name: $name)));
+        self::assertEquals('#/components/schemas/CustomName', $registry->register(new Model($type, name: $name)));
+        self::assertEquals('#/components/schemas/CustomName', $registry->register(new Model($type, name: $name)));
+        self::assertEquals('#/components/schemas/ModelRegistryTestReUsed', $registry->register(new Model($type)));
     }
 
     #[DataProvider('unsupportedTypesProvider')]

--- a/tests/Model/ModelRegistryTest.php
+++ b/tests/Model/ModelRegistryTest.php
@@ -283,6 +283,7 @@ class ModelRegistryTest extends TestCase
         self::assertEquals('#/components/schemas/CustomName', $registry->register(new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, self::class.'ReUsed'), name: $name)));
         self::assertEquals('#/components/schemas/CustomName', $registry->register(new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, self::class.'ReUsed'), name: $name)));
         self::assertEquals('#/components/schemas/CustomName', $registry->register(new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, self::class.'ReUsed'), name: $name)));
+        self::assertEquals('#/components/schemas/CustomName2', $registry->register(new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, self::class.'ReUsed'))));
     }
 
     #[DataProvider('unsupportedTypesProvider')]

--- a/tests/Model/ModelRegistryTest.php
+++ b/tests/Model/ModelRegistryTest.php
@@ -169,18 +169,19 @@ class ModelRegistryTest extends TestCase
      * @param array<string, mixed> $alternativeNames
      */
     #[DataProvider('getNameAlternatives')]
-    public function testNameAliasingForObjects(string $expected, ?array $groups, array $alternativeNames): void
+    public function testNameAliasingForObjects(string $expected, ?array $groups, ?string $name, array $alternativeNames): void
     {
         $registry = new ModelRegistry([], $this->createOpenApi(), $alternativeNames);
         $type = new Type(Type::BUILTIN_TYPE_OBJECT, false, self::class);
 
-        self::assertEquals($expected, $registry->register(new Model($type, $groups)));
+        self::assertEquals($expected, $registry->register(new Model($type, $groups, name: $name)));
     }
 
     public static function getNameAlternatives(): \Generator
     {
         yield [
             '#/components/schemas/ModelRegistryTest',
+            null,
             null,
             [
                 'Foo1' => [
@@ -193,6 +194,31 @@ class ModelRegistryTest extends TestCase
         yield [
             '#/components/schemas/Foo1',
             ['group1'],
+            null,
+            [
+                'Foo1' => [
+                    'type' => self::class,
+                    'groups' => ['group1'],
+                ],
+            ],
+        ];
+
+        yield [
+            '#/components/schemas/FooManualNaming',
+            null,
+            'FooManualNaming',
+            [
+                'Foo1' => [
+                    'type' => self::class,
+                    'groups' => ['group1'],
+                ],
+            ],
+        ];
+
+        yield [
+            '#/components/schemas/FooManualNaming',
+            ['group1'],
+            'FooManualNaming',
             [
                 'Foo1' => [
                     'type' => self::class,
@@ -204,6 +230,7 @@ class ModelRegistryTest extends TestCase
         yield [
             '#/components/schemas/Foo1',
             ['group1', 'group2'],
+            null,
             [
                 'Foo1' => [
                     'type' => self::class,
@@ -214,6 +241,7 @@ class ModelRegistryTest extends TestCase
 
         yield [
             '#/components/schemas/ModelRegistryTest',
+            null,
             null,
             [
                 'Foo1' => [
@@ -226,6 +254,7 @@ class ModelRegistryTest extends TestCase
         yield [
             '#/components/schemas/Foo1',
             [],
+            null,
             [
                 'Foo1' => [
                     'type' => self::class,
@@ -233,6 +262,27 @@ class ModelRegistryTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    public function testMultipleSchemasSameCustomName(): void
+    {
+        $registry = new ModelRegistry([], $this->createOpenApi());
+        $name = 'CustomName';
+
+        self::assertEquals('#/components/schemas/CustomName', $registry->register(new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, self::class), name: $name)));
+        self::assertEquals('#/components/schemas/CustomName2', $registry->register(new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, self::class.'Foo'), name: $name)));
+        self::assertEquals('#/components/schemas/CustomName3', $registry->register(new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, self::class.'Bar'), name: $name)));
+    }
+
+    // Re-using the same custom name with an identical model should return the same schema reference
+    public function testMultipleSchemasSameCustomNameReusesReference(): void
+    {
+        $registry = new ModelRegistry([], $this->createOpenApi());
+        $name = 'CustomName';
+
+        self::assertEquals('#/components/schemas/CustomName', $registry->register(new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, self::class.'ReUsed'), name: $name)));
+        self::assertEquals('#/components/schemas/CustomName', $registry->register(new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, self::class.'ReUsed'), name: $name)));
+        self::assertEquals('#/components/schemas/CustomName', $registry->register(new Model(new Type(Type::BUILTIN_TYPE_OBJECT, false, self::class.'ReUsed'), name: $name)));
     }
 
     #[DataProvider('unsupportedTypesProvider')]


### PR DESCRIPTION
## Description

Adds a new `name` property the `#[Model]` attribute & `Model` class for registering schema's.

This makes it possible to customize the name that needs to be registered for a model schema.

This PR also comes with a refactor to the "alternative names" logic, to ensure deduplication logic (introduced in https://github.com/nelmio/NelmioApiDocBundle/pull/2461) is also retained for manually registered schema's through the bundle config.

> [!NOTE]
> This PR, also changes that manually registered schema's get registered **first** now. (Instead of registering these last)

Closes #2540, closes #2113, closes #2515

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [x] Feature
- [x] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [x] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)