### PR TITLE
refactor(command): use #[AsCommand] to describe command

### DIFF
--- a/config/services.xml
+++ b/config/services.xml
@@ -7,7 +7,7 @@
         <!-- Commands -->
         <service id="nelmio_api_doc.command.dump" class="Nelmio\ApiDocBundle\Command\DumpCommand" public="true">
             <argument type="service" id="nelmio_api_doc.render_docs" />
-            <tag name="console.command" command="nelmio:apidoc:dump" />
+            <tag name="console.command" />
         </service>
 
         <!-- Controllers -->

--- a/src/Command/DumpCommand.php
+++ b/src/Command/DumpCommand.php
@@ -13,11 +13,13 @@ namespace Nelmio\ApiDocBundle\Command;
 
 use Nelmio\ApiDocBundle\Render\Html\AssetsMode;
 use Nelmio\ApiDocBundle\Render\RenderOpenApi;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'nelmio:apidoc:dump')]
 final class DumpCommand extends Command
 {
     private RenderOpenApi $renderOpenApi;

--- a/src/Command/DumpCommand.php
+++ b/src/Command/DumpCommand.php
@@ -49,6 +49,17 @@ final class DumpCommand extends Command
         $availableFormats = $this->renderOpenApi->getAvailableFormats();
         $this
             ->setDescription('Dumps documentation in OpenAPI format to: '.implode(', ', $availableFormats))
+            ->setHelp(<<<'EOF'
+The <info>%command.name%</info> command dumps the OpenAPI documentation in the specified format to the standard output.
+You can specify the "area" option to select a specific documentation area (if multiple areas are defined).
+
+  <info>php %command.full_name%</info>  
+  <info>php %command.full_name% --area MyAreaName</info>
+
+<href=https://symfony.com/bundles/NelmioApiDocBundle/current/commands.html>Read the documentation here.</href>
+
+EOF
+            )
             ->addOption('area', '', InputOption::VALUE_OPTIONAL, '', 'default')
             ->addOption(
                 'format',

--- a/src/Command/DumpCommand.php
+++ b/src/Command/DumpCommand.php
@@ -49,16 +49,17 @@ final class DumpCommand extends Command
         $availableFormats = $this->renderOpenApi->getAvailableFormats();
         $this
             ->setDescription('Dumps documentation in OpenAPI format to: '.implode(', ', $availableFormats))
-            ->setHelp(<<<'EOF'
-The <info>%command.name%</info> command dumps the OpenAPI documentation in the specified format to the standard output.
-You can specify the "area" option to select a specific documentation area (if multiple areas are defined).
+            ->setHelp(
+                <<<'EOF'
+                    The <info>%command.name%</info> command dumps the OpenAPI documentation in the specified format to the standard output.
+                    You can specify the "area" option to select a specific documentation area (if multiple areas are defined).
 
-  <info>php %command.full_name%</info>  
-  <info>php %command.full_name% --area MyAreaName</info>
+                      <info>php %command.full_name%</info>  
+                      <info>php %command.full_name% --area MyAreaName</info>
 
-<href=https://symfony.com/bundles/NelmioApiDocBundle/current/commands.html>Read the documentation here.</href>
+                    <href=https://symfony.com/bundles/NelmioApiDocBundle/current/commands.html>Read the documentation here.</href>
 
-EOF
+                    EOF
             )
             ->addOption('area', '', InputOption::VALUE_OPTIONAL, '', 'default')
             ->addOption(


### PR DESCRIPTION
## Description

Refactor the `DumpCommand` to use the `#[AsCommand]` attribute.

Also improves the command `--help`

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [x] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [x] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)