### PR TITLE
fix: Handle Symfony serializer `datetime_format` context for date formatting

### DIFF
--- a/src/ModelDescriber/Annotations/AnnotationsReader.php
+++ b/src/ModelDescriber/Annotations/AnnotationsReader.php
@@ -60,13 +60,14 @@ class AnnotationsReader
     /**
      * @param \ReflectionProperty|\ReflectionMethod $reflection
      * @param string[]|null                         $serializationGroups
+     * @param array<string, mixed>                  $context
      */
-    public function updateProperty($reflection, OA\Property $property, ?array $serializationGroups = null): void
+    public function updateProperty($reflection, OA\Property $property, array &$context, ?array $serializationGroups = null): void
     {
         $this->openApiAnnotationsReader->updateProperty($reflection, $property, $serializationGroups);
         $this->phpDocReader->updateProperty($reflection, $property);
         $this->reflectionReader->updateProperty($reflection, $property);
-        $this->symfonyAnnotationReader->updateProperty($reflection, $property, $serializationGroups);
+        $this->symfonyAnnotationReader->updateProperty($reflection, $property, $context, $serializationGroups);
     }
 
     /**

--- a/src/ModelDescriber/Annotations/AnnotationsReader.php
+++ b/src/ModelDescriber/Annotations/AnnotationsReader.php
@@ -23,7 +23,7 @@ class AnnotationsReader
 {
     private PropertyPhpDocReader $phpDocReader;
     private OpenApiAnnotationsReader $openApiAnnotationsReader;
-    private SymfonyConstraintAnnotationReader $symfonyConstraintAnnotationReader;
+    private SymfonyAnnotationReader $symfonyAnnotationReader;
     private ReflectionReader $reflectionReader;
 
     /**
@@ -36,14 +36,14 @@ class AnnotationsReader
     ) {
         $this->phpDocReader = new PropertyPhpDocReader();
         $this->openApiAnnotationsReader = new OpenApiAnnotationsReader($modelRegistry, $mediaTypes);
-        $this->symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader($useValidationGroups);
+        $this->symfonyAnnotationReader = new SymfonyAnnotationReader($useValidationGroups);
         $this->reflectionReader = new ReflectionReader();
     }
 
     public function updateDefinition(\ReflectionClass $reflectionClass, OA\Schema $schema): bool
     {
         $this->openApiAnnotationsReader->updateSchema($reflectionClass, $schema);
-        $this->symfonyConstraintAnnotationReader->setSchema($schema);
+        $this->symfonyAnnotationReader->setSchema($schema);
         $this->reflectionReader->setSchema($schema);
 
         return $this->shouldDescribeModelProperties($schema);
@@ -66,7 +66,7 @@ class AnnotationsReader
         $this->openApiAnnotationsReader->updateProperty($reflection, $property, $serializationGroups);
         $this->phpDocReader->updateProperty($reflection, $property);
         $this->reflectionReader->updateProperty($reflection, $property);
-        $this->symfonyConstraintAnnotationReader->updateProperty($reflection, $property, $serializationGroups);
+        $this->symfonyAnnotationReader->updateProperty($reflection, $property, $serializationGroups);
     }
 
     /**

--- a/src/ModelDescriber/Annotations/ReflectionReader.php
+++ b/src/ModelDescriber/Annotations/ReflectionReader.php
@@ -18,7 +18,7 @@ use OpenApi\Generator;
 /**
  * Read default values of a property from the function or property signature.
  *
- * This needs to be called before the {@see SymfonyConstraintAnnotationReader},
+ * This needs to be called before the {@see SymfonyAnnotationReader},
  * otherwise required properties might be considered wrongly.
  *
  * @internal

--- a/src/ModelDescriber/Annotations/SymfonyAnnotationReader.php
+++ b/src/ModelDescriber/Annotations/SymfonyAnnotationReader.php
@@ -22,7 +22,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 /**
  * @internal
  */
-class SymfonyConstraintAnnotationReader
+class SymfonyAnnotationReader
 {
     use SetsContextTrait;
 
@@ -39,19 +39,29 @@ class SymfonyConstraintAnnotationReader
     }
 
     /**
-     * Update the given property and schema with defined Symfony constraints.
+     * Update the given property and schema with defined Symfony attributes.
      *
      * @param \ReflectionProperty|\ReflectionMethod $reflection
      * @param string[]|null                         $validationGroups
      */
     public function updateProperty($reflection, OA\Property $property, ?array $validationGroups = null): void
     {
-        foreach ($this->getAttributes($property->_context, $reflection, $validationGroups) as $outerAttribute) {
+        // Handle constraints
+        foreach ($this->getConstraintAttributes($property->_context, $reflection, $validationGroups) as $outerAttribute) {
             $innerAttributes = $outerAttribute instanceof Assert\Compound || $outerAttribute instanceof Assert\Sequentially
                 ? $outerAttribute->constraints
                 : [$outerAttribute];
 
-            $this->processPropertyAttributes($reflection, $property, $innerAttributes);
+            $this->processConstraintPropertyAttributes($reflection, $property, $innerAttributes);
+        }
+
+        // Handle context
+        $context = $reflection->getAttributes(\Symfony\Component\Serializer\Attribute\Context::class);
+        if (1 === \count($context)) {
+            $contextArgs = $context[0]->getArguments()[0];
+            if ('Y-m-d' === ($contextArgs['datetime_format'] ?? null)) {
+                $property->format = 'date';
+            }
         }
     }
 
@@ -59,7 +69,7 @@ class SymfonyConstraintAnnotationReader
      * @param \ReflectionProperty|\ReflectionMethod $reflection
      * @param Constraint[]                          $attributes
      */
-    private function processPropertyAttributes($reflection, OA\Property $property, array $attributes): void
+    private function processConstraintPropertyAttributes($reflection, OA\Property $property, array $attributes): void
     {
         foreach ($attributes as $attribute) {
             if ($attribute instanceof Assert\NotBlank || $attribute instanceof Assert\NotNull) {
@@ -179,7 +189,7 @@ class SymfonyConstraintAnnotationReader
      *
      * @return iterable<Constraint>
      */
-    private function getAttributes(Context $parentContext, $reflection, ?array $validationGroups): iterable
+    private function getConstraintAttributes(Context $parentContext, $reflection, ?array $validationGroups): iterable
     {
         // To correctly load OA attributes
         $this->setContextFromReflection($parentContext, $reflection);

--- a/src/ModelDescriber/Annotations/SymfonyAnnotationReader.php
+++ b/src/ModelDescriber/Annotations/SymfonyAnnotationReader.php
@@ -42,9 +42,10 @@ class SymfonyAnnotationReader
      * Update the given property and schema with defined Symfony attributes.
      *
      * @param \ReflectionProperty|\ReflectionMethod $reflection
+     * @param array<string, mixed>                  $context
      * @param string[]|null                         $validationGroups
      */
-    public function updateProperty($reflection, OA\Property $property, ?array $validationGroups = null): void
+    public function updateProperty($reflection, OA\Property $property, array &$context = [], ?array $validationGroups = null): void
     {
         // Handle constraints
         foreach ($this->getConstraintAttributes($property->_context, $reflection, $validationGroups) as $outerAttribute) {
@@ -58,10 +59,7 @@ class SymfonyAnnotationReader
         // Handle context
         $context = $reflection->getAttributes(\Symfony\Component\Serializer\Attribute\Context::class);
         if (1 === \count($context)) {
-            $contextArgs = $context[0]->getArguments()[0];
-            if ('Y-m-d' === ($contextArgs['datetime_format'] ?? null)) {
-                $property->format = 'date';
-            }
+            $context['symfony_context'] = $context[0]->getArguments()[0];
         }
     }
 

--- a/src/ModelDescriber/JMSModelDescriber.php
+++ b/src/ModelDescriber/JMSModelDescriber.php
@@ -120,6 +120,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
         $context = $this->getSerializationContext($model);
         $context->pushClassMetadata($metadata);
         foreach ($metadata->propertyMetadata as $item) {
+            $propertyContext = $model->getSerializationContext();
             // filter groups
             if (null !== $context->getExclusionStrategy() && $context->getExclusionStrategy()->shouldSkipProperty($item, $context)) {
                 continue;
@@ -176,7 +177,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
             $property = Util::getProperty($schema, $name);
 
             foreach ($reflections as $reflection) {
-                $annotationsReader->updateProperty($reflection, $property, $groups);
+                $annotationsReader->updateProperty($reflection, $property, $propertyContext, $groups);
             }
 
             if (Generator::UNDEFINED !== $property->type || Generator::UNDEFINED !== $property->ref) {
@@ -197,7 +198,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
                 continue;
             }
 
-            $this->describeItem($item->type, $property, $context, $model->getSerializationContext());
+            $this->describeItem($item->type, $property, $context, $propertyContext);
             $context->popPropertyMetadata();
         }
         $context->popClassMetadata();

--- a/src/ModelDescriber/ObjectModelDescriber.php
+++ b/src/ModelDescriber/ObjectModelDescriber.php
@@ -113,6 +113,7 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
         $propertyInfoProperties = array_intersect($propertyInfoProperties, $this->propertyInfo->getProperties($class, []) ?? []);
 
         foreach ($propertyInfoProperties as $propertyName) {
+            $propertyContext = [];
             $serializedName = null !== $this->nameConverter ? $this->nameConverter->normalize($propertyName, $class, null, $model->getSerializationContext()) : $propertyName;
 
             $reflections = $this->getReflections($reflClass, $propertyName);
@@ -134,7 +135,7 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
                 $groups = $model->getGroups()[$propertyName];
             }
             foreach ($reflections as $reflection) {
-                $annotationsReader->updateProperty($reflection, $property, $groups);
+                $annotationsReader->updateProperty($reflection, $property, $propertyContext, $groups);
             }
 
             // If type manually defined
@@ -152,7 +153,7 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
                 throw new \LogicException(\sprintf('The PropertyInfo component was not able to guess the type of %s::$%s. You may need to add a `@var` annotation or use `#[OA\Property(type="")]` to make its type explicit.', $class, $propertyName));
             }
 
-            $this->describeProperty($types, $model, $property, $propertyName);
+            $this->describeProperty($types, $model, $property, $propertyName, $propertyContext);
         }
 
         $this->markRequiredProperties($schema);
@@ -187,15 +188,17 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
     }
 
     /**
-     * @param LegacyType[]|Type $types
+     * @param LegacyType[]|Type    $types
+     * @param array<string, mixed> $context
      */
-    private function describeProperty(array|Type $types, Model $model, OA\Schema $property, string $propertyName): void
+    private function describeProperty(array|Type $types, Model $model, OA\Schema $property, string $propertyName, array $context): void
     {
         if ($this->propertyDescriber instanceof ModelRegistryAwareInterface) {
             $this->propertyDescriber->setModelRegistry($this->modelRegistry);
         }
-        if ($this->propertyDescriber->supports($types, $model->getSerializationContext())) {
-            $this->propertyDescriber->describe($types, $property, $model->getSerializationContext());
+        $context = array_merge($context, $model->getSerializationContext());
+        if ($this->propertyDescriber->supports($types, $context)) {
+            $this->propertyDescriber->describe($types, $property, $context);
 
             return;
         }

--- a/src/PropertyDescriber/DateTimePropertyDescriber.php
+++ b/src/PropertyDescriber/DateTimePropertyDescriber.php
@@ -12,6 +12,7 @@
 namespace Nelmio\ApiDocBundle\PropertyDescriber;
 
 use OpenApi\Annotations as OA;
+use OpenApi\Generator;
 use Symfony\Component\PropertyInfo\Type;
 
 final class DateTimePropertyDescriber implements PropertyDescriberInterface
@@ -22,7 +23,9 @@ final class DateTimePropertyDescriber implements PropertyDescriberInterface
     public function describe(array $types, OA\Schema $property, array $context = []): void
     {
         $property->type = 'string';
-        $property->format = 'date-time';
+        if (Generator::UNDEFINED === $property->format) {
+            $property->format = 'date-time';
+        }
     }
 
     public function supports(array $types, array $context = []): bool

--- a/src/PropertyDescriber/DateTimePropertyDescriber.php
+++ b/src/PropertyDescriber/DateTimePropertyDescriber.php
@@ -12,7 +12,6 @@
 namespace Nelmio\ApiDocBundle\PropertyDescriber;
 
 use OpenApi\Annotations as OA;
-use OpenApi\Generator;
 use Symfony\Component\PropertyInfo\Type;
 
 final class DateTimePropertyDescriber implements PropertyDescriberInterface
@@ -23,8 +22,12 @@ final class DateTimePropertyDescriber implements PropertyDescriberInterface
     public function describe(array $types, OA\Schema $property, array $context = []): void
     {
         $property->type = 'string';
-        if (Generator::UNDEFINED === $property->format) {
-            $property->format = 'date-time';
+        $property->format = 'date-time';
+        if (
+            \array_key_exists('symfony_context', $context)
+            && 'Y-m-d' === ($context['symfony_context']['datetime_format'] ?? null)
+        ) {
+            $property->format = 'date';
         }
     }
 

--- a/tests/Functional/Entity/SymfonyContext.php
+++ b/tests/Functional/Entity/SymfonyContext.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
+
+use Symfony\Component\Serializer\Attribute\Context;
+
+class SymfonyContext
+{
+    /**
+     * @var \DateTime
+     */
+    #[Context(['datetime_format' => 'Y-m-d'])]
+    public $date;
+
+    #[Context(['datetime_format' => 'Y-m-d'])]
+    public ?\DateTime $nullableDate = null;
+}

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -780,6 +780,29 @@ class FunctionalTest extends WebTestCase
         $this->assertNotHasProperty('protected', $model);
     }
 
+    public function testContextSupport(): void
+    {
+        self::assertEquals(
+            [
+                'schema' => 'SymfonyContext',
+                'type' => 'object',
+                'required' => ['date'],
+                'properties' => [
+                    'date' => [
+                        'type' => 'string',
+                        'format' => 'date',
+                    ],
+                    'nullableDate' => [
+                        'type' => 'string',
+                        'format' => 'date',
+                        'nullable' => true,
+                    ],
+                ],
+            ],
+            json_decode($this->getModel('SymfonyContext')->toJson(), true)
+        );
+    }
+
     public function testModelsWithDiscriminatorMapAreLoadedWithOpenApiPolymorphism(): void
     {
         $model = $this->getModel('SymfonyDiscriminator');

--- a/tests/Functional/TestKernel.php
+++ b/tests/Functional/TestKernel.php
@@ -22,6 +22,7 @@ use Nelmio\ApiDocBundle\Tests\Functional\Entity\JMSComplex;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup\JMSPicture;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\PrivateProtectedExposure;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\SymfonyConstraintsWithValidationGroups;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\SymfonyContext;
 use Nelmio\ApiDocBundle\Tests\Functional\ModelDescriber\NameConverter;
 use Nelmio\ApiDocBundle\Tests\Functional\ModelDescriber\VirtualTypeClassDoesNotExistsHandlerDefinedDescriber;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
@@ -176,6 +177,11 @@ class TestKernel extends Kernel
                 'alias' => 'BazingaUser_grouped',
                 'type' => BazingaUser::class,
                 'groups' => ['foo'],
+            ],
+            [
+                'alias' => 'SymfonyContext',
+                'type' => SymfonyContext::class,
+                'groups' => null,
             ],
             [
                 'alias' => 'SymfonyConstraintsTestGroup',

--- a/tests/ModelDescriber/Annotations/SymfonyAnnotationReaderTest.php
+++ b/tests/ModelDescriber/Annotations/SymfonyAnnotationReaderTest.php
@@ -11,7 +11,7 @@
 
 namespace Nelmio\ApiDocBundle\Tests\ModelDescriber\Annotations;
 
-use Nelmio\ApiDocBundle\ModelDescriber\Annotations\SymfonyConstraintAnnotationReader;
+use Nelmio\ApiDocBundle\ModelDescriber\Annotations\SymfonyAnnotationReader;
 use Nelmio\ApiDocBundle\Tests\ModelDescriber\Annotations\Fixture as CustomAssert;
 use OpenApi\Annotations as OA;
 use OpenApi\Context;
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints as Assert;
 
-class SymfonyConstraintAnnotationReaderTest extends TestCase
+class SymfonyAnnotationReaderTest extends TestCase
 {
     public function testUpdatePropertyFix1283(): void
     {
@@ -38,11 +38,11 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property2'])]);
 
-        $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader();
-        $symfonyConstraintAnnotationReader->setSchema($schema);
+        $symfonyAnnotationReader = new SymfonyAnnotationReader();
+        $symfonyAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
-        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property2'), $schema->properties[1]);
+        $symfonyAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property2'), $schema->properties[1]);
 
         // expect required to be numeric array with sequential keys (not [0 => ..., 2 => ...])
         self::assertEquals($schema->required, ['property1', 'property2']);
@@ -58,11 +58,11 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property2'])]);
 
-        $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader();
-        $symfonyConstraintAnnotationReader->setSchema($schema);
+        $symfonyAnnotationReader = new SymfonyAnnotationReader();
+        $symfonyAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
-        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property2'), $schema->properties[1]);
+        $symfonyAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property2'), $schema->properties[1]);
 
         // expect required to be numeric array with sequential keys (not [0 => ..., 2 => ...])
         self::assertEquals($schema->required, ['property2']);
@@ -88,10 +88,10 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $schema = $this->createObj(OA\Schema::class, []);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
 
-        $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader();
-        $symfonyConstraintAnnotationReader->setSchema($schema);
+        $symfonyAnnotationReader = new SymfonyAnnotationReader();
+        $symfonyAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
 
         // expect enum to be numeric array with sequential keys (not [1 => "active", 2 => "active"])
         self::assertEquals($schema->properties[0]->enum, ['active', 'blocked']);
@@ -120,10 +120,10 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $schema = $this->createObj(OA\Schema::class, []);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
 
-        $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader();
-        $symfonyConstraintAnnotationReader->setSchema($schema);
+        $symfonyAnnotationReader = new SymfonyAnnotationReader();
+        $symfonyAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
 
         self::assertInstanceOf(OA\Items::class, $schema->properties[0]->items);
         self::assertEquals($schema->properties[0]->items->enum, ['one', 'two']);
@@ -146,10 +146,10 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $schema = $this->createObj(OA\Schema::class, []);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
 
-        $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader();
-        $symfonyConstraintAnnotationReader->setSchema($schema);
+        $symfonyAnnotationReader = new SymfonyAnnotationReader();
+        $symfonyAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
 
         self::assertSame(Generator::UNDEFINED, $schema->properties[0]->maxLength);
         self::assertSame(1, $schema->properties[0]->minLength);
@@ -172,10 +172,10 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $schema = $this->createObj(OA\Schema::class, []);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
 
-        $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader();
-        $symfonyConstraintAnnotationReader->setSchema($schema);
+        $symfonyAnnotationReader = new SymfonyAnnotationReader();
+        $symfonyAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
 
         self::assertSame(Generator::UNDEFINED, $schema->properties[0]->minLength);
         self::assertSame(100, $schema->properties[0]->maxLength);
@@ -200,10 +200,10 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $schema = $this->createObj(OA\Schema::class, []);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => $propertyName])]);
 
-        $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader();
-        $symfonyConstraintAnnotationReader->setSchema($schema);
+        $symfonyAnnotationReader = new SymfonyAnnotationReader();
+        $symfonyAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, $propertyName), $schema->properties[0]);
+        $symfonyAnnotationReader->updateProperty(new \ReflectionProperty($entity, $propertyName), $schema->properties[0]);
 
         self::assertSame([$propertyName], $schema->required);
         self::assertSame(0, $schema->properties[0]->minimum);
@@ -221,10 +221,10 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $schema = $this->createObj(OA\Schema::class, []);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
 
-        $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader();
-        $symfonyConstraintAnnotationReader->setSchema($schema);
+        $symfonyAnnotationReader = new SymfonyAnnotationReader();
+        $symfonyAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
 
         self::assertSame(Generator::UNDEFINED, $schema->properties[0]->minItems);
         self::assertSame(10, $schema->properties[0]->maxItems);
@@ -247,10 +247,10 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $schema = $this->createObj(OA\Schema::class, []);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
 
-        $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader();
-        $symfonyConstraintAnnotationReader->setSchema($schema);
+        $symfonyAnnotationReader = new SymfonyAnnotationReader();
+        $symfonyAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
 
         self::assertSame(Generator::UNDEFINED, $schema->properties[0]->maxItems);
         self::assertSame(10, $schema->properties[0]->minItems);
@@ -273,10 +273,10 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $schema = $this->createObj(OA\Schema::class, []);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
 
-        $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader();
-        $symfonyConstraintAnnotationReader->setSchema($schema);
+        $symfonyAnnotationReader = new SymfonyAnnotationReader();
+        $symfonyAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
 
         self::assertSame(Generator::UNDEFINED, $schema->properties[0]->maximum);
         self::assertSame(10, $schema->properties[0]->minimum);
@@ -299,10 +299,10 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $schema = $this->createObj(OA\Schema::class, []);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
 
-        $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader();
-        $symfonyConstraintAnnotationReader->setSchema($schema);
+        $symfonyAnnotationReader = new SymfonyAnnotationReader();
+        $symfonyAnnotationReader->setSchema($schema);
 
-        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+        $symfonyAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
 
         self::assertSame(Generator::UNDEFINED, $schema->properties[0]->minimum);
         self::assertSame(10, $schema->properties[0]->maximum);
@@ -325,7 +325,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
     {
         $schema = $this->createObj(OA\Schema::class, []);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
-        $reader = new SymfonyConstraintAnnotationReader(true);
+        $reader = new SymfonyAnnotationReader(true);
         $reader->setSchema($schema);
 
         // no serialization groups passed here
@@ -344,7 +344,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $schema->merge([
             $this->createObj(OA\Property::class, ['property' => 'property1']),
         ]);
-        $reader = new SymfonyConstraintAnnotationReader(true);
+        $reader = new SymfonyAnnotationReader(true);
         $reader->setSchema($schema);
 
         // no serialization groups passed here
@@ -364,7 +364,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $schema->merge([
             $this->createObj(OA\Property::class, ['property' => 'property1']),
         ]);
-        $reader = new SymfonyConstraintAnnotationReader(true);
+        $reader = new SymfonyAnnotationReader(true);
         $reader->setSchema($schema);
 
         // no serialization groups passed here
@@ -385,7 +385,7 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         $schema->merge([
             $this->createObj(OA\Property::class, ['property' => 'property1']),
         ]);
-        $reader = new SymfonyConstraintAnnotationReader(true);
+        $reader = new SymfonyAnnotationReader(true);
         $reader->setSchema($schema);
 
         // no serialization groups passed here

--- a/tests/ModelDescriber/Annotations/SymfonyAnnotationReaderTest.php
+++ b/tests/ModelDescriber/Annotations/SymfonyAnnotationReaderTest.php
@@ -367,10 +367,12 @@ class SymfonyAnnotationReaderTest extends TestCase
         $reader = new SymfonyAnnotationReader(true);
         $reader->setSchema($schema);
 
+        $context = [];
         // no serialization groups passed here
         $reader->updateProperty(
             new \ReflectionProperty($entity, 'property1'),
             $schema->properties[0],
+            $context,
             ['other']
         );
 
@@ -388,10 +390,12 @@ class SymfonyAnnotationReaderTest extends TestCase
         $reader = new SymfonyAnnotationReader(true);
         $reader->setSchema($schema);
 
+        $context = [];
         // no serialization groups passed here
         $reader->updateProperty(
             new \ReflectionProperty($entity, 'property1'),
             $schema->properties[0],
+            $context,
             ['other', Constraint::DEFAULT_GROUP]
         );
 


### PR DESCRIPTION
## Description
Symfony serializer supports a `Context` attribute which can provide details for how to normalize a property. Specifically, a `datetime_format` key can be provided to specify how to format a `DateTime` field. This PR handles a `datetime_format` value of `Y-m-d` and sets the `format` to `date`, rather than the current incorrect value of `date-time`.

I don't believe there are any issues this PR will close, though this was brought up in a comment at https://github.com/nelmio/NelmioApiDocBundle/issues/2145#issuecomment-1932547474

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [ ] Feature
- [x] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [x] I have made corresponding changes to the documentation (`docs/`)
- [] I have made corresponding changes to the changelog (`CHANGELOG.md`)

## Uncertainties
- The most suitable place I could find to place this was alongside the Symfony constraint annotation readers (`SymfonyConstraintAnnotationReader`), and making this a more generic `SymfonyAnnotationReader` class. The class was documented as `@internal` so I don't believe this would be a breaking change. If you'd rather I go down a different route, please give me some pointers of where/how you'd like this implemented.
- I'm torn whether this should be classed as a feature (from the bundle perspective, functionality to parse this field doesn't yet exist) or bug (because from a user perspective, the bundle is generating the wrong format) - and as such, haven't updated the changelog yet.
- I don't think any documentation changes should be required for this, so have checked this off on the checklist.