### PR TITLE
feat: Implement Ulid type description in ClassDescriber

### DIFF
--- a/src/PropertyDescriber/UuidPropertyDescriber.php
+++ b/src/PropertyDescriber/UuidPropertyDescriber.php
@@ -14,6 +14,7 @@ namespace Nelmio\ApiDocBundle\PropertyDescriber;
 use OpenApi\Annotations as OA;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\Ulid;
 
 final class UuidPropertyDescriber implements PropertyDescriberInterface
 {
@@ -23,7 +24,9 @@ final class UuidPropertyDescriber implements PropertyDescriberInterface
     public function describe(array $types, OA\Schema $property, array $context = []): void
     {
         $property->type = 'string';
-        $property->format = 'uuid';
+
+        $isUlid = is_a($types[0]->getClassName(), Ulid::class, true);
+        $property->format = $isUlid ? 'ulid' : 'uuid';
     }
 
     public function supports(array $types, array $context = []): bool

--- a/src/TypeDescriber/ClassDescriber.php
+++ b/src/TypeDescriber/ClassDescriber.php
@@ -21,6 +21,7 @@ use Symfony\Component\PropertyInfo\Type as LegacyType;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\Ulid;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
@@ -34,6 +35,13 @@ final class ClassDescriber implements TypeDescriberInterface, ModelRegistryAware
 
     public function describe(Type $type, Schema $schema, array $context = []): void
     {
+        if (is_a($type->getClassName(), Ulid::class, true)) {
+            $schema->type = 'string';
+            $schema->format = 'ulid';
+
+            return;
+        }
+
         if (is_a($type->getClassName(), AbstractUid::class, true)) {
             $schema->type = 'string';
             $schema->format = 'uuid';

--- a/tests/Functional/Controller/ApiController.php
+++ b/tests/Functional/Controller/ApiController.php
@@ -29,6 +29,7 @@ use Nelmio\ApiDocBundle\Tests\Functional\Entity\EntityWithNullableSchemaSet;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\EntityWithObjectType;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\EntityWithRef;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\EntityWithTranslatable;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\EntityWithUlid;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\EntityWithUuid;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\RangeInteger;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\SymfonyConstraints;
@@ -360,6 +361,18 @@ class ApiController
         ),
     )]
     public function entityWithUuid()
+    {
+    }
+
+    #[Route('/entity-with-ulid', methods: ['GET', 'POST'])]
+    #[OA\Response(
+        response: 200,
+        description: 'success',
+        content: new OA\JsonContent(
+            ref: new Model(type: EntityWithUlid::class),
+        ),
+    )]
+    public function entityWithUlid()
     {
     }
 

--- a/tests/Functional/Entity/EntityWithUlid.php
+++ b/tests/Functional/Entity/EntityWithUlid.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
+
+use Symfony\Component\Uid\Ulid;
+
+class EntityWithUlid
+{
+    public Ulid $id;
+    public string $name;
+
+    public function __construct(string $name)
+    {
+        $this->id = new Ulid();
+        $this->name = $name;
+    }
+}

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -893,6 +893,24 @@ class FunctionalTest extends WebTestCase
         ], json_decode($this->getModel('EntityWithUuid')->toJson(), true));
     }
 
+    public function testEntityWithUlid(): void
+    {
+        self::assertEquals([
+            'schema' => 'EntityWithUlid',
+            'type' => 'object',
+            'required' => ['id', 'name'],
+            'properties' => [
+                'id' => [
+                    'type' => 'string',
+                    'format' => 'ulid',
+                ],
+                'name' => [
+                    'type' => 'string',
+                ],
+            ],
+        ], json_decode($this->getModel('EntityWithUlid')->toJson(), true));
+    }
+
     public function testEntityWithTranslatable(): void
     {
         self::assertEquals([

--- a/tests/Functional/ModelDescriber/Fixtures/UuidClass.json
+++ b/tests/Functional/ModelDescriber/Fixtures/UuidClass.json
@@ -15,7 +15,7 @@
         },
         "ulid": {
             "type": "string",
-            "format": "uuid"
+            "format": "ulid"
         },
         "uuidV1": {
             "type": "string",

--- a/tests/Functional/ModelDescriber/Fixtures/UuidClass7And8.json
+++ b/tests/Functional/ModelDescriber/Fixtures/UuidClass7And8.json
@@ -17,7 +17,7 @@
         },
         "ulid": {
             "type": "string",
-            "format": "uuid"
+            "format": "ulid"
         },
         "uuidV1": {
             "type": "string",

--- a/tests/PropertyDescriber/UuidPropertyDescriberTest.php
+++ b/tests/PropertyDescriber/UuidPropertyDescriberTest.php
@@ -14,6 +14,7 @@ namespace Nelmio\ApiDocBundle\Tests\PropertyDescriber;
 use Nelmio\ApiDocBundle\PropertyDescriber\UuidPropertyDescriber;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Uid\Uuid;
 
 class UuidPropertyDescriberTest extends TestCase
@@ -21,6 +22,15 @@ class UuidPropertyDescriberTest extends TestCase
     public function testSupportsUuidPropertyType(): void
     {
         $type = new Type(Type::BUILTIN_TYPE_OBJECT, false, Uuid::class);
+
+        $describer = new UuidPropertyDescriber();
+
+        self::assertTrue($describer->supports([$type]));
+    }
+
+    public function testSupportsUlidPropertyType(): void
+    {
+        $type = new Type(Type::BUILTIN_TYPE_OBJECT, false, Ulid::class);
 
         $describer = new UuidPropertyDescriber();
 
@@ -50,10 +60,25 @@ class UuidPropertyDescriberTest extends TestCase
         $property = $this->initProperty();
 
         $describer = new UuidPropertyDescriber();
-        $describer->describe([], $property, []);
+
+        $type = new Type(Type::BUILTIN_TYPE_OBJECT, false, Uuid::class);
+        $describer->describe([$type], $property, []);
 
         self::assertSame('string', $property->type);
         self::assertSame('uuid', $property->format);
+    }
+
+    public function testDescribeUlidPropertyType(): void
+    {
+        $property = $this->initProperty();
+
+        $describer = new UuidPropertyDescriber();
+
+        $type = new Type(Type::BUILTIN_TYPE_OBJECT, false, Ulid::class);
+        $describer->describe([$type], $property, []);
+
+        self::assertSame('string', $property->type);
+        self::assertSame('ulid', $property->format);
     }
 
     private function initProperty(): \OpenApi\Annotations\Property


### PR DESCRIPTION
Add support for Ulid type in ClassDescriber.

As the schema format is not bounded to any list, we use `ulid` for Ulid types here.

## Description

This allows Ulid properties to be properly labbelled as `type: string, format: ulid` in the schema definition.

In turns, this allows data to be passed using one of the (short) forms of ULIDs too

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [x] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)