### PR TITLE
docs: fix swagger examples broken link

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -473,7 +473,7 @@ If you need more complex features, take a look at:
     faq
     community
 
-.. _`SwaggerPHP examples`: https://github.com/zircote/swagger-php/tree/master/Examples
+.. _`SwaggerPHP examples`: https://github.com/zircote/swagger-php/tree/master/docs/examples
 .. _`Symfony PropertyInfo component`: https://symfony.com/doc/current/components/property_info.html
 .. _`TypeInfo component`: https://symfony.com/doc/current/components/type_info.html
 .. _`willdurand/Hateoas`: https://github.com/willdurand/Hateoas


### PR DESCRIPTION
## Description

Examples link in the [article](https://symfony.com/bundles/NelmioApiDocBundle/current/index.html) has been changed
so it is broken now

Closes #...

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [x] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)