### PR TITLE
fix(swagger-php): conflict with broken version 5.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "willdurand/negotiation": "^3.0"
     },
     "conflict": {
-        "zircote/swagger-php": "4.8.7"
+        "zircote/swagger-php": "4.8.7 || 5.5.0"
     },
     "suggest": {
         "api-platform/core": "For using an API oriented framework.",


### PR DESCRIPTION
## Description

It seems that version [`5.5.0`](https://github.com/zircote/swagger-php/releases/tag/5.5.0) introduced a bug. Reported in https://github.com/zircote/swagger-php/issues/1823 

https://github.com/zircote/swagger-php/issues/1823

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [x] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)