### PR TITLE
fix: version number in triggered deprecation

### DIFF
--- a/config/routing/swaggerui.php
+++ b/config/routing/swaggerui.php
@@ -16,7 +16,7 @@ return function (RoutingConfigurator $routes): void {
     foreach (debug_backtrace(\DEBUG_BACKTRACE_PROVIDE_OBJECT) as $trace) {
         if (isset($trace['object']) && $trace['object'] instanceof XmlFileLoader && 'doImport' === $trace['function']) {
             if (__DIR__ === dirname(realpath($trace['args'][3]))) {
-                trigger_deprecation('nelmio/api-doc-bundle', '7.3', 'The "swaggerui.xml" routing configuration file is deprecated, import "swaggerui.php" instead.');
+                trigger_deprecation('nelmio/api-doc-bundle', '5.6.4', 'The "swaggerui.xml" routing configuration file is deprecated, import "swaggerui.php" instead.');
 
                 break;
             }


### PR DESCRIPTION
## Description

Fixes incorrect deprecate version added in https://github.com/nelmio/NelmioApiDocBundle/pull/2566

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)