### PR TITLE
ci(release-please): make it possible to create backport releases

### DIFF
--- a/.github/workflows/release.backport.yml
+++ b/.github/workflows/release.backport.yml
@@ -1,0 +1,25 @@
+name: Release Backport
+on:
+  push:
+    branches:
+      - 4.x
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4.4.0
+        with:
+          # this assumes that you have created a personal access token
+          # (PAT) and configured it as a GitHub action secret named
+          # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # this is a built-in strategy in release-please, see "Action Inputs"
+          # for more options
+          release-type: php
+          versioning-strategy: always-bump-patch
+          release-as: 4.0.0


### PR DESCRIPTION
## Description

Should make it possible to atleast automate versioning for older versions (4.x) 👀 

https://github.com/nelmio/NelmioApiDocBundle/issues/2591#issuecomment-3522457589

Uses new feature from https://github.com/googleapis/release-please-action/pull/1121

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [x] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)