### PR TITLE
ci(composer): ignore symfony cve

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,12 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "audit": {
+            "ignore": [
+                "PKSA-365x-2zjk-pt47"
+            ]
+        }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
## Description

Ignore insecure dependency, this is currently causing CI to fail https://symfony.com/blog/cve-2025-64500-incorrect-parsing-of-path-info-can-lead-to-limited-authorization-bypass

> Problem 1
    - Root composer.json requires symfony/http-foundation ^6.4 || ^7.1, found symfony/http-foundation[v6.4.0, ..., v6.4.29, v7.1.0, ..., v7.3.7] but these were not loaded, because they are affected by security advisories. To ignore the advisories, add ("PKSA-365x-2zjk-pt47") to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [x] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)