### PR TITLE
refactor: add `symfony/type-info: ^7.2` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "symfony/deprecation-contracts": "^2.1 || ^3",
         "symfony/framework-bundle": "^6.4 || ^7.2",
         "symfony/http-foundation": "^6.4 || ^7.2",
+        "symfony/type-info": "^7.2",
         "symfony/http-kernel": "^6.4 || ^7.2",
         "symfony/options-resolver": "^6.4 || ^7.2",
         "symfony/property-info": "^6.4 || ^7.2",
@@ -80,7 +81,6 @@
         "symfony/security-csrf": "For using csrf protection tokens in forms.",
         "symfony/serializer": "For describing your models.",
         "symfony/twig-bundle": "For using the Swagger UI.",
-        "symfony/type-info": "For extracting type information from PHP elements like properties, arguments and return types.",
         "symfony/validator": "For describing the validation constraints in your models.",
         "willdurand/hateoas-bundle": "For extracting HATEOAS metadata."
     },

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -89,9 +89,7 @@ final class Model
 
     public function getHash(): string
     {
-        $type = class_exists(Type::class)
-            ? $this->getTypeInfo()->__toString()
-            : $this->getType();
+        $type = $this->getTypeInfo()->__toString();
 
         return md5(serialize([$type, $this->getSerializationContext(), $this->name]));
     }

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -172,12 +172,10 @@ final class ModelRegistry
                 $schema = $this->describeSchema($model, $name);
 
                 if (null === $schema) {
-                    $type = class_exists(Type::class)
-                        ? $model->getTypeInfo()
-                        : $model->getType();
+                    $type = $model->getTypeInfo();
 
                     $errorMessage = \sprintf('Schema of type "%s" can\'t be generated, no describer supports it.', $this->typeToString($type));
-                    if (method_exists($type, 'getClassName') && null !== $type->getClassName() && !class_exists($className = $type->getClassName())) {
+                    if ($type instanceof Type\ObjectType && !class_exists($className = $type->getClassName())) {
                         $errorMessage .= \sprintf(' Class "%s" does not exist, did you forget a use statement, or typed it wrong?', $className);
                     }
                     throw new \LogicException($errorMessage);
@@ -200,9 +198,7 @@ final class ModelRegistry
             return $model->name;
         }
 
-        $type = class_exists(Type::class)
-            ? $model->getTypeInfo()
-            : $model->getType();
+        $type = $model->getTypeInfo();
 
         // 3. Generate from the type
         return $this->getTypeShortName($type);
@@ -235,9 +231,7 @@ final class ModelRegistry
      */
     private function modelToArray(Model $model): array
     {
-        $type = class_exists(Type::class)
-            ? $model->getTypeInfo()
-            : $model->getType();
+        $type = $model->getTypeInfo();
 
         $dataType = $this->typeToString($type);
 

--- a/src/ModelDescriber/BazingaHateoasModelDescriber.php
+++ b/src/ModelDescriber/BazingaHateoasModelDescriber.php
@@ -21,7 +21,6 @@ use Nelmio\ApiDocBundle\Model\Model;
 use Nelmio\ApiDocBundle\Model\ModelRegistry;
 use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 use OpenApi\Annotations as OA;
-use Symfony\Component\PropertyInfo\Type as LegacyType;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 
 class BazingaHateoasModelDescriber implements ModelDescriberInterface, ModelRegistryAwareInterface
@@ -89,10 +88,10 @@ class BazingaHateoasModelDescriber implements ModelDescriberInterface, ModelRegi
 
     private function getHateoasMetadata(Model $model): ?object
     {
-        /** @var ObjectType|LegacyType $type */
-        $type = class_exists(\Symfony\Component\TypeInfo\Type::class)
-            ? $model->getTypeInfo()
-            : $model->getType();
+        $type = $model->getTypeInfo();
+        if (!$type instanceof ObjectType) {
+            return null;
+        }
 
         try {
             return $this->factory->getMetadataForClass($type->getClassName());

--- a/src/ModelDescriber/EnumModelDescriber.php
+++ b/src/ModelDescriber/EnumModelDescriber.php
@@ -13,7 +13,6 @@ namespace Nelmio\ApiDocBundle\ModelDescriber;
 
 use Nelmio\ApiDocBundle\Model\Model;
 use OpenApi\Annotations\Schema;
-use Symfony\Component\PropertyInfo\Type as LegacyType;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 
 class EnumModelDescriber implements ModelDescriberInterface
@@ -22,10 +21,11 @@ class EnumModelDescriber implements ModelDescriberInterface
 
     public function describe(Model $model, Schema $schema): void
     {
-        /** @var ObjectType|LegacyType $type */
-        $type = class_exists(\Symfony\Component\TypeInfo\Type::class)
-            ? $model->getTypeInfo()
-            : $model->getType();
+        $type = $model->getTypeInfo();
+        if (!$type instanceof ObjectType) {
+            return;
+        }
+
         $enumClass = $type->getClassName();
         $forceName = isset($model->getSerializationContext()[self::FORCE_NAMES]) && true === $model->getSerializationContext()[self::FORCE_NAMES];
 
@@ -45,14 +45,8 @@ class EnumModelDescriber implements ModelDescriberInterface
 
     public function supports(Model $model): bool
     {
-        if (class_exists(\Symfony\Component\TypeInfo\Type::class)) {
-            return $model->getTypeInfo() instanceof ObjectType
-                && enum_exists($model->getTypeInfo()->getClassName())
-                && is_subclass_of($model->getTypeInfo()->getClassName(), \BackedEnum::class);
-        }
-
-        return LegacyType::BUILTIN_TYPE_OBJECT === $model->getType()->getBuiltinType()
-            && enum_exists($model->getType()->getClassName())
-            && is_subclass_of($model->getType()->getClassName(), \BackedEnum::class);
+        return $model->getTypeInfo() instanceof ObjectType
+            && enum_exists($model->getTypeInfo()->getClassName())
+            && is_subclass_of($model->getTypeInfo()->getClassName(), \BackedEnum::class);
     }
 }

--- a/src/ModelDescriber/FallbackObjectModelDescriber.php
+++ b/src/ModelDescriber/FallbackObjectModelDescriber.php
@@ -13,7 +13,6 @@ namespace Nelmio\ApiDocBundle\ModelDescriber;
 
 use Nelmio\ApiDocBundle\Model\Model;
 use OpenApi\Annotations as OA;
-use Symfony\Component\PropertyInfo\Type as LegacyType;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 
 class FallbackObjectModelDescriber implements ModelDescriberInterface
@@ -24,10 +23,6 @@ class FallbackObjectModelDescriber implements ModelDescriberInterface
 
     public function supports(Model $model): bool
     {
-        if (class_exists(\Symfony\Component\TypeInfo\Type::class)) {
-            return $model->getTypeInfo() instanceof ObjectType;
-        }
-
-        return LegacyType::BUILTIN_TYPE_OBJECT === $model->getType()->getBuiltinType();
+        return $model->getTypeInfo() instanceof ObjectType;
     }
 }

--- a/src/ModelDescriber/FormModelDescriber.php
+++ b/src/ModelDescriber/FormModelDescriber.php
@@ -28,8 +28,6 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\ResolvedFormTypeInterface;
-use Symfony\Component\PropertyInfo\Type as LegacyType;
-use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 
 /**
@@ -66,10 +64,11 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
 
     public function describe(Model $model, OA\Schema $schema): void
     {
-        /** @var ObjectType|LegacyType $type */
-        $type = class_exists(Type::class)
-            ? $model->getTypeInfo()
-            : $model->getType();
+        $type = $model->getTypeInfo();
+        if (!$type instanceof ObjectType) {
+            return;
+        }
+
         $class = $type->getClassName();
 
         $annotationsReader = new AnnotationsReader(
@@ -95,12 +94,8 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
 
     public function supports(Model $model): bool
     {
-        if (class_exists(Type::class)) {
-            return $model->getTypeInfo() instanceof ObjectType
-                && is_a($model->getTypeInfo()->getClassName(), FormTypeInterface::class, true);
-        }
-
-        return is_a($model->getType()->getClassName(), FormTypeInterface::class, true);
+        return $model->getTypeInfo() instanceof ObjectType
+            && is_a($model->getTypeInfo()->getClassName(), FormTypeInterface::class, true);
     }
 
     private function parseForm(OA\Schema $schema, FormInterface $form): void

--- a/src/ModelDescriber/JMSModelDescriber.php
+++ b/src/ModelDescriber/JMSModelDescriber.php
@@ -26,8 +26,6 @@ use Nelmio\ApiDocBundle\OpenApiPhp\Util;
 use Nelmio\ApiDocBundle\Util\LegacyTypeConverter;
 use OpenApi\Annotations as OA;
 use OpenApi\Generator;
-use Symfony\Component\PropertyInfo\Type as LegacyType;
-use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 
 /**
@@ -85,10 +83,11 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
 
     public function describe(Model $model, OA\Schema $schema): void
     {
-        /** @var ObjectType|LegacyType $type */
-        $type = class_exists(Type::class)
-            ? $model->getTypeInfo()
-            : $model->getType();
+        $type = $model->getTypeInfo();
+        if (!$type instanceof ObjectType) {
+            return;
+        }
+
         $className = $type->getClassName();
         $metadata = $this->factory->getMetadataForClass($className);
         if (!$metadata instanceof ClassMetadata) {
@@ -269,10 +268,11 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
             return false;
         }
 
-        /** @var ObjectType|LegacyType $type */
-        $type = class_exists(Type::class)
-            ? $model->getTypeInfo()
-            : $model->getType();
+        $type = $model->getTypeInfo();
+        if (!$type instanceof ObjectType) {
+            return false;
+        }
+
         $className = $type->getClassName();
 
         try {

--- a/src/ModelDescriber/ObjectModelDescriber.php
+++ b/src/ModelDescriber/ObjectModelDescriber.php
@@ -64,10 +64,11 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
 
     public function describe(Model $model, OA\Schema $schema): void
     {
-        /** @var ObjectType|LegacyType $type */
-        $type = class_exists(Type::class)
-            ? $model->getTypeInfo()
-            : $model->getType();
+        $type = $model->getTypeInfo();
+        if (!$type instanceof ObjectType) {
+            return;
+        }
+
         $class = $type->getClassName();
         $schema->_context->class = $class;
 
@@ -205,9 +206,7 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
             return;
         }
 
-        $modelType = class_exists(Type::class) ? $model->getTypeInfo() : $model->getType()->getClassName();
-
-        throw new \Exception(\sprintf('Type "%s" is not supported in %s::$%s. You may need to use the `#[OA\Property(type="")]` attribute to specify it manually.', \is_array($types) ? $types[0]->getBuiltinType() : $types, $modelType, $propertyName));
+        throw new \Exception(\sprintf('Type "%s" is not supported in %s::$%s. You may need to use the `#[OA\Property(type="")]` attribute to specify it manually.', \is_array($types) ? $types[0]->getBuiltinType() : $types, $model->getTypeInfo(), $propertyName));
     }
 
     /**
@@ -242,12 +241,7 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
 
     public function supports(Model $model): bool
     {
-        if (class_exists(Type::class)) {
-            return $model->getTypeInfo() instanceof ObjectType
-                && (class_exists($model->getTypeInfo()->getClassName()) || interface_exists($model->getTypeInfo()->getClassName()));
-        }
-
-        return LegacyType::BUILTIN_TYPE_OBJECT === $model->getType()->getBuiltinType()
-            && (class_exists($model->getType()->getClassName()) || interface_exists($model->getType()->getClassName()));
+        return $model->getTypeInfo() instanceof ObjectType
+            && (class_exists($model->getTypeInfo()->getClassName()) || interface_exists($model->getTypeInfo()->getClassName()));
     }
 }

--- a/src/ModelDescriber/SelfDescribingModelDescriber.php
+++ b/src/ModelDescriber/SelfDescribingModelDescriber.php
@@ -13,31 +13,24 @@ namespace Nelmio\ApiDocBundle\ModelDescriber;
 
 use Nelmio\ApiDocBundle\Model\Model;
 use OpenApi\Annotations as OA;
-use Symfony\Component\PropertyInfo\Type as LegacyType;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 
 class SelfDescribingModelDescriber implements ModelDescriberInterface
 {
     public function describe(Model $model, OA\Schema $schema): void
     {
-        /** @var ObjectType|LegacyType $type */
-        $type = class_exists(\Symfony\Component\TypeInfo\Type::class)
-            ? $model->getTypeInfo()
-            : $model->getType();
+        $type = $model->getTypeInfo();
+        if (!$type instanceof ObjectType) {
+            return;
+        }
 
         \call_user_func([$type->getClassName(), 'describe'], $schema, $model);
     }
 
     public function supports(Model $model): bool
     {
-        if (class_exists(\Symfony\Component\TypeInfo\Type::class)) {
-            return $model->getTypeInfo() instanceof ObjectType
-                && class_exists($model->getTypeInfo()->getClassName())
-                && is_a($model->getTypeInfo()->getClassName(), SelfDescribingModelInterface::class, true);
-        }
-
-        return null !== $model->getType()->getClassName()
-            && class_exists($model->getType()->getClassName())
-            && is_a($model->getType()->getClassName(), SelfDescribingModelInterface::class, true);
+        return $model->getTypeInfo() instanceof ObjectType
+            && class_exists($model->getTypeInfo()->getClassName())
+            && is_a($model->getTypeInfo()->getClassName(), SelfDescribingModelInterface::class, true);
     }
 }

--- a/src/Util/LegacyTypeConverter.php
+++ b/src/Util/LegacyTypeConverter.php
@@ -103,16 +103,8 @@ final class LegacyTypeConverter
         throw new \LogicException('Unsupported TypeInfo type: '.$type->__toString().'.');
     }
 
-    public static function createType(string $type): LegacyType|Type
+    public static function createType(string $type): Type
     {
-        if (!class_exists(Type::class)) {
-            if (str_ends_with($type, '[]')) {
-                return new LegacyType('array', false, null, true, null, self::createType(substr($type, 0, -2)));
-            }
-
-            return new LegacyType('object', false, $type);
-        }
-
         if (str_ends_with($type, '[]')) {
             return Type::list(self::createType(substr($type, 0, -2)));
         }

--- a/tests/Model/ModelRegistryTest.php
+++ b/tests/Model/ModelRegistryTest.php
@@ -35,7 +35,7 @@ class ModelRegistryTest extends TestCase
         $type = new LegacyType(LegacyType::BUILTIN_TYPE_ARRAY, false, null, true);
 
         self::assertEquals(
-            class_exists(Type::class) ? '#/components/schemas/mixed[]' : '#/components/schemas/array',
+            '#/components/schemas/mixed[]',
             $registry->register(new Model($type, ['group1']))
         );
     }
@@ -86,20 +86,18 @@ class ModelRegistryTest extends TestCase
 
         yield 'nullable class (LegacyType)' => [
             new LegacyType(LegacyType::BUILTIN_TYPE_OBJECT, true, self::class),
-            class_exists(Type::class) ? 'Nelmio\\ApiDocBundle\\Tests\\Model\\ModelRegistryTest|null' : 'Nelmio\\ApiDocBundle\\Tests\\Model\\ModelRegistryTest',
+            'Nelmio\\ApiDocBundle\\Tests\\Model\\ModelRegistryTest|null',
         ];
 
-        if (class_exists(Type::class)) {
-            yield 'class' => [
-                Type::object(self::class),
-                'Nelmio\\ApiDocBundle\\Tests\\Model\\ModelRegistryTest',
-            ];
+        yield 'class' => [
+            Type::object(self::class),
+            'Nelmio\\ApiDocBundle\\Tests\\Model\\ModelRegistryTest',
+        ];
 
-            yield 'nullable class' => [
-                Type::nullable(Type::object(self::class)),
-                'Nelmio\\ApiDocBundle\\Tests\\Model\\ModelRegistryTest|null',
-            ];
-        }
+        yield 'nullable class' => [
+            Type::nullable(Type::object(self::class)),
+            'Nelmio\\ApiDocBundle\\Tests\\Model\\ModelRegistryTest|null',
+        ];
     }
 
     public function testNameCollisionsAreLoggedWithAlternativeNames(): void
@@ -160,10 +158,6 @@ class ModelRegistryTest extends TestCase
     #[DataProvider('getNameAlternatives')]
     public function testNameAliasingForObjects(string $expected, ?array $groups, ?string $name, array $alternativeNames): void
     {
-        if (!class_exists(Type::class)) {
-            self::markTestSkipped('symfony/type-info is not installed.');
-        }
-
         $registry = new ModelRegistry([], $this->createOpenApi(), $alternativeNames);
         $type = Type::object(self::class);
 
@@ -310,13 +304,11 @@ class ModelRegistryTest extends TestCase
 
     public static function unsupportedTypesProvider(): \Generator
     {
-        yield [new LegacyType(LegacyType::BUILTIN_TYPE_ARRAY, false, null, true), class_exists(Type::class) ? 'array' : 'mixed[]'];
+        yield [new LegacyType(LegacyType::BUILTIN_TYPE_ARRAY, false, null, true), 'array'];
         yield [new LegacyType(LegacyType::BUILTIN_TYPE_OBJECT, false, self::class), self::class];
 
-        if (class_exists(Type::class)) {
-            yield [Type::array(), 'array'];
-            yield [Type::object(self::class), self::class];
-        }
+        yield [Type::array(), 'array'];
+        yield [Type::object(self::class), self::class];
     }
 
     public function testUnsupportedTypeExceptionWithNonExistentClass(): void

--- a/tests/Util/LegacyTypeConverterTest.php
+++ b/tests/Util/LegacyTypeConverterTest.php
@@ -19,13 +19,6 @@ use Symfony\Component\TypeInfo\Type;
 
 class LegacyTypeConverterTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        if (!class_exists(Type::class)) {
-            self::markTestSkipped('Symfony TypeInfo component is not available.');
-        }
-    }
-
     /**
      * @param LegacyType[] $legacyTypes
      */
@@ -42,12 +35,6 @@ class LegacyTypeConverterTest extends TestCase
 
     public static function provideToTypeInfoTypeCases(): \Generator
     {
-        if (!class_exists(Type::class)) {
-            yield [null];
-
-            return;
-        }
-
         yield 'null' => [
             null,
             null,
@@ -140,12 +127,6 @@ class LegacyTypeConverterTest extends TestCase
 
     public static function provideToLegacyTypeCases(): \Generator
     {
-        if (!class_exists(Type::class)) {
-            yield [null];
-
-            return;
-        }
-
         yield 'object' => [
             new LegacyType(LegacyType::BUILTIN_TYPE_OBJECT, false, 'Foo\Bar'),
             Type::object('Foo\Bar'),
@@ -184,25 +165,6 @@ class LegacyTypeConverterTest extends TestCase
 
     public static function provideCreateTypeCases(): \Generator
     {
-        if (!class_exists(Type::class)) {
-            yield 'object legacy type' => [
-                new LegacyType('object', false, 'Foo\Bar'),
-                'Foo\Bar',
-            ];
-
-            yield 'array legacy type' => [
-                new LegacyType('array', false, null, true, null, new LegacyType('object', false, 'Foo\Bar')),
-                'Foo\Bar[]',
-            ];
-
-            yield 'nested array legacy type' => [
-                new LegacyType('array', false, null, true, null, new LegacyType('array', false, null, true, null, new LegacyType('object', false, 'Foo\Bar'))),
-                'Foo\Bar[][]',
-            ];
-
-            return;
-        }
-
         yield 'simple' => [
             Type::object('Foo\Bar'),
             'Foo\Bar',


### PR DESCRIPTION
## Description

Follow-up on https://github.com/nelmio/NelmioApiDocBundle/pull/2526

Symfony 8 is going to require that `symfony/type-info` is installed. So that make it easier for users (and the internal code-base) we now always require `symfony/type-info: ^7.2`.

This also allows users running on Symfony 6.4 to properly use the new deprecated methods without needing them to require `symfony/type-info` in their own composer file.

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [x] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)