### PR TITLE
chore(php): bump minimum to php 8.2

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ Follow these mandatory guidelines when contributing code, documentation, and tra
 
 * **Project Scope:** This is a **standalone third-party Symfony bundle**.
 * **Compatibility:** Code **must** be compatible with **Symfony 6.4, and 7.x** versions.
-* **Target PHP:** Use **modern PHP 8.1** syntax and features.
+* **Target PHP:** Use **modern PHP 8.2** syntax and features.
 * **Deprecations:** **Avoid** using deprecated Symfony or PHP features. Consult the [Symfony Backward Compatibility Promise](https://symfony.com/doc/current/contributing/code/bc.html#working-on-symfony-code) for accepted changes during review.
 * **Readability:** Break text lines in documentation at **~72–78 characters** for optimal readability.
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,11 +25,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php-version: 8.1
+          - php-version: 8.2
             symfony-require: "6.4"
             composer-flags: "--prefer-lowest"
-          - php-version: 8.1
-            symfony-require: "6.4"
           - php-version: 8.2
             symfony-require: "6.4"
           - php-version: 8.3

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "phpdocumentor/reflection-docblock": "^5.0",
         "phpdocumentor/type-resolver": "^1.8.2",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ This bundle supports *Symfony* route requirements, *Symfony* request mapping (:d
 For models, it supports the `Symfony serializer`_ , the `JMS serializer`_ and the `willdurand/Hateoas`_ library.
 It does also support `Symfony form`_ types.
 
-Attributes are supported from version 4.7 and PHP 8.1.
+Attributes are supported from version 4.7 and PHP 8.1 onward.
 
 Migrate from 4.x to 5.0
 -----------------------


### PR DESCRIPTION
## Description

Requirement for https://github.com/nelmio/NelmioApiDocBundle/pull/2610 to work, because `symfony/type-info` only support a minimum version of PHP `8.2`.

I am fairly convinced that a bump from `8.1` to `8.2` can be done in a minor version bump (compared to `7.4` to `8.1` which I did in a major from `4.x` to `5.x` previously):
1. I have seen other packages do this (One example being [Symfony 6.1](https://symfony.com/blog/symfony-6-1-will-require-php-8-1))
2. I asked gemini:
   | Environment Change	| Package Version Bump | SemVer Rationale |
   | ------------------ | -------------------- | ---------------- |
   | PHP 8.1 to 8.2	| Minor (e.g., 1.3.0)  | Backward-Compatible Language Bump: No new major incompatibilities were introduced between 8.1 and 8.2. |
   | PHP 7.4 to 8.1     | Major (e.g., 2.0.0)  | Backward-Incompatible Language Bump: PHP 8.x introduced fundamental, breaking changes that cause 7.x code to fail. |

Additionally PHP `8.1` will stop being supported in 1 month (security support until 31 dec 2025) https://www.php.net/supported-versions.php

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)