### PR TITLE
fix(trigger_deprecation): incorrect & missing trigger_deprecation in `Model` class

### DIFF
--- a/phpunit-ignore.txt
+++ b/phpunit-ignore.txt
@@ -1,3 +1,3 @@
-# Ignoring deprecations from Nelmio\ApiDocBundle 5.6.0, Deprecation of Symfony PropertyInfo\Type
-/^Since nelmio\/api-doc-bundle 5\.7\.0\: Using Symfony\\Component\\PropertyInfo\\Type as type in Nelmio\\ApiDocBundle\\Model\\Model\:\:\_\_construct is deprecated, use Symfony\\Component\\TypeInfo\\Type instead\./
+# Ignoring deprecations from Nelmio\ApiDocBundle 5.8.0, Deprecation of Symfony PropertyInfo\Type
+/^Since nelmio\/api-doc-bundle 5\.8\.0\: Using Symfony\\Component\\PropertyInfo\\Type as type in Nelmio\\ApiDocBundle\\Model\\Model\:\:\_\_construct is deprecated, use Symfony\\Component\\TypeInfo\\Type instead\./
 /^Since nelmio\/api-doc-bundle 5\.8\.0\: The Nelmio\\ApiDocBundle\\Model\\Model\:\:Nelmio\\ApiDocBundle\\Model\\Model\:\:getType method is deprecated, use Nelmio\\ApiDocBundle\\Model\\Model\:\:getTypeInfo\(\) instead\./

--- a/phpunit-ignore.txt
+++ b/phpunit-ignore.txt
@@ -1,3 +1,3 @@
 # Ignoring deprecations from Nelmio\ApiDocBundle 5.8.0, Deprecation of Symfony PropertyInfo\Type
 /^Since nelmio\/api-doc-bundle 5\.8\.0\: Using Symfony\\Component\\PropertyInfo\\Type as type in Nelmio\\ApiDocBundle\\Model\\Model\:\:\_\_construct is deprecated, use Symfony\\Component\\TypeInfo\\Type instead\./
-/^Since nelmio\/api-doc-bundle 5\.8\.0\: The Nelmio\\ApiDocBundle\\Model\\Model\:\:Nelmio\\ApiDocBundle\\Model\\Model\:\:getType method is deprecated, use Nelmio\\ApiDocBundle\\Model\\Model\:\:getTypeInfo\(\) instead\./
+/^Since nelmio\/api-doc-bundle 5\.8\.0\: The Nelmio\\ApiDocBundle\\Model\\Model\:\:getType method is deprecated, use Nelmio\\ApiDocBundle\\Model\\Model\:\:getTypeInfo\(\) instead\./

--- a/phpunit-ignore.txt
+++ b/phpunit-ignore.txt
@@ -1,2 +1,3 @@
 # Ignoring deprecations from Nelmio\ApiDocBundle 5.6.0, Deprecation of Symfony PropertyInfo\Type
 /^Since nelmio\/api-doc-bundle 5\.7\.0\: Using Symfony\\Component\\PropertyInfo\\Type as type in Nelmio\\ApiDocBundle\\Model\\Model\:\:\_\_construct is deprecated, use Symfony\\Component\\TypeInfo\\Type instead\./
+/^Since nelmio\/api-doc-bundle 5\.8\.0\: The Nelmio\\ApiDocBundle\\Model\\Model\:\:Nelmio\\ApiDocBundle\\Model\\Model\:\:getType method is deprecated, use Nelmio\\ApiDocBundle\\Model\\Model\:\:getTypeInfo\(\) instead\./

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -33,7 +33,7 @@ final class Model
         if ($type instanceof LegacyType) {
             trigger_deprecation(
                 'nelmio/api-doc-bundle',
-                '5.7.0',
+                '5.8.0',
                 'Using Symfony\Component\PropertyInfo\Type as type in %s is deprecated, use Symfony\Component\TypeInfo\Type instead.',
                 __METHOD__
             );
@@ -49,6 +49,15 @@ final class Model
      */
     public function getType(): LegacyType
     {
+        trigger_deprecation(
+            'nelmio/api-doc-bundle',
+            '5.8.0',
+            'The %s::%s method is deprecated, use %s::getTypeInfo() instead.',
+            self::class,
+            __METHOD__,
+            self::class
+        );
+
         if ($this->type instanceof Type) {
             return LegacyTypeConverter::toLegacyType($this->type);
         }

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -52,10 +52,9 @@ final class Model
         trigger_deprecation(
             'nelmio/api-doc-bundle',
             '5.8.0',
-            'The %s::%s method is deprecated, use %s::getTypeInfo() instead.',
-            self::class,
+            'The %s method is deprecated, use %s::getTypeInfo() instead.',
             __METHOD__,
-            self::class
+            self::class,
         );
 
         if ($this->type instanceof Type) {


### PR DESCRIPTION
## Description

Fixes incorrect version number in `trigger_deprecation` & missing `trigger_deprecation` in `Model::getType()`

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactor
- [x] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)