### PR TITLE
docs(pr-template): remove mention of `CHANGELOG.md`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,4 +15,3 @@ Closes #...
 
 ## Checklist
 - [ ] I have made corresponding changes to the documentation (`docs/`)
-- [ ] I have made corresponding changes to the changelog (`CHANGELOG.md`)


### PR DESCRIPTION
## Description

release-please handles this now

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [x] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)