### PR TITLE
fix: OpenAPI attributes responses not being processed

### DIFF
--- a/src/Describer/DefaultDescriber.php
+++ b/src/Describer/DefaultDescriber.php
@@ -40,21 +40,22 @@ final class DefaultDescriber implements DescriberInterface
         }
         foreach ($api->paths as $path) {
             foreach (Util::OPERATIONS as $method) {
-                /** @var OA\Operation $operation */
                 $operation = $path->{$method};
-                if (Generator::UNDEFINED !== $operation && null !== $operation) {
-                    // Verificar si hay respuestas (cualquier tipo)
-                    $hasAnyResponses = false;
-                    if (Generator::UNDEFINED !== $operation->responses && [] !== $operation->responses && null !== $operation->responses) {
-                        $hasAnyResponses = true;
-                    }
+                if (!$operation instanceof OA\Operation) {
+                    continue;
+                }
 
-                    // Solo agregar respuesta "default" si NO hay respuestas definidas
-                    if (!$hasAnyResponses) {
-                        /** @var OA\Response $response */
-                        $response = Util::getIndexedCollectionItem($operation, OA\Response::class, 'default');
-                        $response->description = '';
-                    }
+                // Verificar si hay respuestas (cualquier tipo)
+                $hasAnyResponses = false;
+                if (Generator::UNDEFINED !== $operation->responses && [] !== $operation->responses && null !== $operation->responses) {
+                    $hasAnyResponses = true;
+                }
+
+                // Solo agregar respuesta "default" si NO hay respuestas definidas
+                if (!$hasAnyResponses) {
+                    /** @var OA\Response $response */
+                    $response = Util::getIndexedCollectionItem($operation, OA\Response::class, 'default');
+                    $response->description = '';
                 }
             }
         }

--- a/src/Describer/DefaultDescriber.php
+++ b/src/Describer/DefaultDescriber.php
@@ -40,15 +40,21 @@ final class DefaultDescriber implements DescriberInterface
         }
         foreach ($api->paths as $path) {
             foreach (Util::OPERATIONS as $method) {
+                /** @var OA\Operation $operation */
                 $operation = $path->{$method};
-                if (!$operation instanceof OA\Operation) {
-                    continue;
-                }
+                if (Generator::UNDEFINED !== $operation && null !== $operation) {
+                    // Verificar si hay respuestas (cualquier tipo)
+                    $hasAnyResponses = false;
+                    if (Generator::UNDEFINED !== $operation->responses && [] !== $operation->responses && null !== $operation->responses) {
+                        $hasAnyResponses = true;
+                    }
 
-                if (Generator::UNDEFINED === $operation->responses || [] === $operation->responses) {
-                    /** @var OA\Response $response */
-                    $response = Util::getIndexedCollectionItem($operation, OA\Response::class, 'default');
-                    $response->description = '';
+                    // Solo agregar respuesta "default" si NO hay respuestas definidas
+                    if (!$hasAnyResponses) {
+                        /** @var OA\Response $response */
+                        $response = Util::getIndexedCollectionItem($operation, OA\Response::class, 'default');
+                        $response->description = '';
+                    }
                 }
             }
         }

--- a/src/Describer/OpenApiPhpDescriber.php
+++ b/src/Describer/OpenApiPhpDescriber.php
@@ -95,10 +95,10 @@ final class OpenApiPhpDescriber
                 // Procesar Attributes Post, Get, Put, Delete, etc.
                 $className = \get_class($annotation);
                 if (str_starts_with($className, 'OpenApi\\Attributes\\')) {
-                    $shortName = substr($className, strrpos($className, '\\') + 1);
+                    $shortName = \substr($className, \strrpos($className, '\\') + 1);
                     $httpMethodNames = ['Post', 'Get', 'Put', 'Delete', 'Patch'];
                     if (\in_array($shortName, $httpMethodNames, true)) {
-                        $methodName = strtolower($shortName);
+                        $methodName = \strtolower($shortName);
                         if (\in_array($methodName, $supportedHttpMethods, true)) {
                             $operation = Util::getOperation($path, $methodName);
                             $operation->mergeProperties($annotation);

--- a/src/Describer/OpenApiPhpDescriber.php
+++ b/src/Describer/OpenApiPhpDescriber.php
@@ -93,12 +93,12 @@ final class OpenApiPhpDescriber
                 }
 
                 // Procesar Attributes Post, Get, Put, Delete, etc.
-                $className = \get_class($annotation);
+                $className = $annotation::class;
                 if (str_starts_with($className, 'OpenApi\\Attributes\\')) {
-                    $shortName = \substr($className, \strrpos($className, '\\') + 1);
+                    $shortName = substr($className, strrpos($className, '\\') + 1);
                     $httpMethodNames = ['Post', 'Get', 'Put', 'Delete', 'Patch'];
                     if (\in_array($shortName, $httpMethodNames, true)) {
-                        $methodName = \strtolower($shortName);
+                        $methodName = strtolower($shortName);
                         if (\in_array($methodName, $supportedHttpMethods, true)) {
                             $operation = Util::getOperation($path, $methodName);
                             $operation->mergeProperties($annotation);

--- a/src/Describer/OpenApiPhpDescriber.php
+++ b/src/Describer/OpenApiPhpDescriber.php
@@ -92,6 +92,21 @@ final class OpenApiPhpDescriber
                     continue;
                 }
 
+                // Procesar Attributes Post, Get, Put, Delete, etc.
+                if ($annotation instanceof \OpenApi\Attributes\Post || 
+                    $annotation instanceof \OpenApi\Attributes\Get || 
+                    $annotation instanceof \OpenApi\Attributes\Put || 
+                    $annotation instanceof \OpenApi\Attributes\Delete || 
+                    $annotation instanceof \OpenApi\Attributes\Patch) {
+                    $className = get_class($annotation);
+                    $methodName = strtolower(substr($className, strrpos($className, "\\") + 1));
+                    if (in_array($methodName, $supportedHttpMethods, true)) {
+                        $operation = Util::getOperation($path, $methodName);
+                        $operation->mergeProperties($annotation);
+                    }
+                    continue;
+                }
+
                 if ($annotation instanceof OA\Operation) {
                     if (!\in_array($annotation->method, $supportedHttpMethods, true)) {
                         continue;

--- a/src/Describer/OpenApiPhpDescriber.php
+++ b/src/Describer/OpenApiPhpDescriber.php
@@ -93,18 +93,18 @@ final class OpenApiPhpDescriber
                 }
 
                 // Procesar Attributes Post, Get, Put, Delete, etc.
-                if ($annotation instanceof \OpenApi\Attributes\Post || 
-                    $annotation instanceof \OpenApi\Attributes\Get || 
-                    $annotation instanceof \OpenApi\Attributes\Put || 
-                    $annotation instanceof \OpenApi\Attributes\Delete || 
-                    $annotation instanceof \OpenApi\Attributes\Patch) {
-                    $className = get_class($annotation);
-                    $methodName = strtolower(substr($className, strrpos($className, "\\") + 1));
-                    if (in_array($methodName, $supportedHttpMethods, true)) {
-                        $operation = Util::getOperation($path, $methodName);
-                        $operation->mergeProperties($annotation);
+                $className = get_class($annotation);
+                if (str_starts_with($className, 'OpenApi\\Attributes\\')) {
+                    $shortName = substr($className, strrpos($className, "\\") + 1);
+                    $httpMethodNames = ['Post', 'Get', 'Put', 'Delete', 'Patch'];
+                    if (in_array($shortName, $httpMethodNames, true)) {
+                        $methodName = strtolower($shortName);
+                        if (in_array($methodName, $supportedHttpMethods, true)) {
+                            $operation = Util::getOperation($path, $methodName);
+                            $operation->mergeProperties($annotation);
+                        }
+                        continue;
                     }
-                    continue;
                 }
 
                 if ($annotation instanceof OA\Operation) {

--- a/src/Describer/OpenApiPhpDescriber.php
+++ b/src/Describer/OpenApiPhpDescriber.php
@@ -93,13 +93,13 @@ final class OpenApiPhpDescriber
                 }
 
                 // Procesar Attributes Post, Get, Put, Delete, etc.
-                $className = get_class($annotation);
+                $className = \get_class($annotation);
                 if (str_starts_with($className, 'OpenApi\\Attributes\\')) {
-                    $shortName = substr($className, strrpos($className, "\\") + 1);
+                    $shortName = substr($className, strrpos($className, '\\') + 1);
                     $httpMethodNames = ['Post', 'Get', 'Put', 'Delete', 'Patch'];
-                    if (in_array($shortName, $httpMethodNames, true)) {
+                    if (\in_array($shortName, $httpMethodNames, true)) {
                         $methodName = strtolower($shortName);
-                        if (in_array($methodName, $supportedHttpMethods, true)) {
+                        if (\in_array($methodName, $supportedHttpMethods, true)) {
                             $operation = Util::getOperation($path, $methodName);
                             $operation->mergeProperties($annotation);
                         }


### PR DESCRIPTION
This PR fixes an issue where OpenAPI attributes responses were not being processed correctly.

## Changes
- Fixed OpenAPI attributes responses processing in `OpenApiPhpDescriber`
- Improved response handling in `DefaultDescriber`

## Description
The OpenApiPhpDescriber wasn't handling Post/Get/Put/Delete/Patch attributes properly, so their responses weren't being merged into the spec. Also fixed DefaultDescriber adding default responses even when specific ones were already defined.

Now attributes like `#[OA\Post]` work correctly and we don't get default responses overriding the actual ones.