### PR TITLE
fix(SplObjectStorage): `SplObjectStorage::detach()` is deprecated since `8.5`, use method `SplObjectStorage::offsetUnset()` instead

### DIFF
--- a/src/OpenApiPhp/ModelRegister.php
+++ b/src/OpenApiPhp/ModelRegister.php
@@ -132,7 +132,7 @@ final class ModelRegister
             }
         }
 
-        $analysis->annotations->detach($model);
+        $analysis->annotations->offsetUnset($model);
     }
 
     private function getModel(OA\AbstractAnnotation $annotation): ?ModelAnnotation


### PR DESCRIPTION
## Description

Fixes deprecation in PHP 8.5
> `SplObjectStorage::detach()`` is deprecated since `8.5`, use method `SplObjectStorage::offsetUnset()`` instead

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)

```
BEGIN_COMMIT_OVERRIDE
fix(SplObjectStorage): `SplObjectStorage::detach()` is deprecated since `8.5`, use method `SplObjectStorage::offsetUnset()` instead
END_COMMIT_OVERRIDE