### PR TITLE
style(tests): add missing `void` return types

### DIFF
--- a/tests/Functional/Controller/ApiController.php
+++ b/tests/Functional/Controller/ApiController.php
@@ -62,7 +62,7 @@ class ApiController
     #[Route('/article/{id}', methods: ['GET'])]
     #[OA\Parameter(name: 'Accept-Version', in: 'header', schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'Application-Name', in: 'header', schema: new OA\Schema(type: 'string'))]
-    public function fetchArticleAction()
+    public function fetchArticleAction(): void
     {
     }
 
@@ -81,7 +81,7 @@ class ApiController
     #[Route('/article-interface/{id}', methods: ['GET'])]
     #[OA\Parameter(name: 'Accept-Version', in: 'header', schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'Application-Name', in: 'header', schema: new OA\Schema(type: 'string'))]
-    public function fetchArticleInterfaceAction()
+    public function fetchArticleInterfaceAction(): void
     {
     }
 
@@ -110,7 +110,7 @@ class ApiController
             ),
         ],
     )]
-    public function swaggerAction()
+    public function swaggerAction(): void
     {
     }
 
@@ -130,7 +130,7 @@ class ApiController
         ),
     )]
     #[OA\Tag(name: 'implicit')]
-    public function implicitSwaggerAction()
+    public function implicitSwaggerAction(): void
     {
     }
 
@@ -146,7 +146,7 @@ class ApiController
         description: 'This is a request body',
         content: new Model(type: UserType::class, options: ['bar' => 'baz']),
     )]
-    public function submitUserTypeAction()
+    public function submitUserTypeAction(): void
     {
     }
 
@@ -182,7 +182,7 @@ class ApiController
             new OA\Response(response: '201', description: ''),
         ],
     )]
-    public function filteredAction()
+    public function filteredAction(): void
     {
     }
 
@@ -192,7 +192,7 @@ class ApiController
         content: new Model(type: DummyType::class),
     )]
     #[OA\Response(response: 201, description: '')]
-    public function formAction()
+    public function formAction(): void
     {
     }
 
@@ -202,7 +202,7 @@ class ApiController
         content: new Model(type: FormWithModel::class),
     )]
     #[OA\Response(response: 201, description: '')]
-    public function formWithModelAction()
+    public function formWithModelAction(): void
     {
     }
 
@@ -212,7 +212,7 @@ class ApiController
         content: new Model(type: FormWithModel::class, name: 'RenamedFormWithModel'),
     )]
     #[OA\Response(response: 201, description: '')]
-    public function formWithModelRenamed()
+    public function formWithModelRenamed(): void
     {
     }
 
@@ -239,7 +239,7 @@ class ApiController
         description: 'Used for symfony constraints test',
         content: new Model(type: SymfonyConstraints::class),
     )]
-    public function symfonyConstraintsAction()
+    public function symfonyConstraintsAction(): void
     {
     }
 
@@ -261,7 +261,7 @@ class ApiController
     #[OA\Get(description: 'This is the get operation')]
     #[OA\Post(description: 'This is post')]
     #[OA\Response(response: 200, description: 'Worked well!', attachables: [new Model(type: DummyType::class)])]
-    public function operationsWithOtherAnnotations()
+    public function operationsWithOtherAnnotations(): void
     {
     }
 
@@ -273,19 +273,19 @@ class ApiController
 
     #[Route('/compound', methods: ['GET', 'POST'])]
     #[OA\Response(response: 200, description: 'Worked well!', attachables: [new Model(type: CompoundEntity::class)])]
-    public function compoundEntityAction()
+    public function compoundEntityAction(): void
     {
     }
 
     #[Route('/discriminator-mapping', methods: ['GET', 'POST'])]
     #[OA\Response(response: 200, description: 'Worked well!', attachables: [new Model(type: SymfonyDiscriminator::class)])]
-    public function discriminatorMappingAction()
+    public function discriminatorMappingAction(): void
     {
     }
 
     #[Route('/discriminator-mapping-configured-with-file', methods: ['GET', 'POST'])]
     #[OA\Response(response: 200, description: 'Worked well!', attachables: [new Model(type: SymfonyDiscriminatorFileMapping::class)])]
-    public function discriminatorMappingConfiguredWithFileAction()
+    public function discriminatorMappingConfiguredWithFileAction(): void
     {
     }
 
@@ -309,7 +309,7 @@ class ApiController
         description: 'Used for symfony constraints with validation groups test',
         content: new Model(type: SymfonyConstraintsWithValidationGroups::class, groups: ['test']),
     )]
-    public function symfonyConstraintsWithGroupsAction()
+    public function symfonyConstraintsWithGroupsAction(): void
     {
     }
 
@@ -322,7 +322,7 @@ class ApiController
             ref: new Model(type: EntityWithAlternateType::class),
         ),
     )]
-    public function alternateEntityType()
+    public function alternateEntityType(): void
     {
     }
 
@@ -335,7 +335,7 @@ class ApiController
             ref: new Model(type: EntityWithRef::class),
         ),
     )]
-    public function entityWithRef()
+    public function entityWithRef(): void
     {
     }
 
@@ -348,7 +348,7 @@ class ApiController
             ref: new Model(type: EntityWithObjectType::class),
         ),
     )]
-    public function entityWithObjectType()
+    public function entityWithObjectType(): void
     {
     }
 
@@ -360,7 +360,7 @@ class ApiController
             ref: new Model(type: EntityWithUuid::class),
         ),
     )]
-    public function entityWithUuid()
+    public function entityWithUuid(): void
     {
     }
 
@@ -372,7 +372,7 @@ class ApiController
             ref: new Model(type: EntityWithUlid::class),
         ),
     )]
-    public function entityWithUlid()
+    public function entityWithUlid(): void
     {
     }
 
@@ -384,7 +384,7 @@ class ApiController
             ref: new Model(type: EntityWithTranslatable::class),
         ),
     )]
-    public function entityWithTranslatable()
+    public function entityWithTranslatable(): void
     {
     }
 
@@ -396,7 +396,7 @@ class ApiController
     #[OA\RequestBody(
         content: new Model(type: FormWithAlternateSchemaType::class),
     )]
-    public function formWithAlternateSchemaType()
+    public function formWithAlternateSchemaType(): void
     {
     }
 
@@ -408,7 +408,7 @@ class ApiController
     #[OA\RequestBody(
         content: new Model(type: FormWithRefType::class),
     )]
-    public function formWithRefSchemaType()
+    public function formWithRefSchemaType(): void
     {
     }
 
@@ -420,7 +420,7 @@ class ApiController
     #[OA\RequestBody(
         content: new Model(type: FormWithCsrfProtectionEnabledType::class),
     )]
-    public function formWithCsrfProtectionEnabledType()
+    public function formWithCsrfProtectionEnabledType(): void
     {
     }
 
@@ -432,7 +432,7 @@ class ApiController
     #[OA\RequestBody(
         content: new Model(type: FormWithCsrfProtectionDisabledType::class),
     )]
-    public function formWithCsrfProtectionDisabledType()
+    public function formWithCsrfProtectionDisabledType(): void
     {
     }
 
@@ -444,7 +444,7 @@ class ApiController
             new Model(type: EntityWithNullableSchemaSet::class),
         ],
     )]
-    public function entityWithNullableSchemaSet()
+    public function entityWithNullableSchemaSet(): void
     {
     }
 
@@ -456,7 +456,7 @@ class ApiController
     #[OA\RequestBody(
         content: new Model(type: EntityWithFalsyDefaults::class),
     )]
-    public function entityWithFalsyDefaults()
+    public function entityWithFalsyDefaults(): void
     {
     }
 
@@ -472,7 +472,7 @@ class ApiController
     #[OA\Parameter(ref: '#/components/parameters/test')]
     #[Route('/article_attributes/{id}', methods: ['GET'])]
     #[OA\Parameter(name: 'Accept-Version', in: 'header', schema: new OA\Schema(type: 'string'))]
-    public function fetchArticleActionWithAttributes()
+    public function fetchArticleActionWithAttributes(): void
     {
     }
 
@@ -509,19 +509,19 @@ class ApiController
 
     #[Route('/enum')]
     #[OA\Response(response: '201', description: '', attachables: [new Model(type: Article81::class)])]
-    public function enum()
+    public function enum(): void
     {
     }
 
     #[Route('/range_integer', methods: ['GET'])]
     #[OA\Response(response: '200', description: '', attachables: [new Model(type: RangeInteger::class)])]
-    public function rangeInteger()
+    public function rangeInteger(): void
     {
     }
 
     #[Route('/serializename', methods: ['GET'])]
     #[OA\Response(response: 200, description: 'success', content: new Model(type: SerializedNameEntity::class))]
-    public function serializedNameAction()
+    public function serializedNameAction(): void
     {
     }
 
@@ -536,19 +536,19 @@ class ApiController
         description: 'Same class without context',
         content: new Model(type: EntityThroughNameConverter::class)
     )]
-    public function nameConverterContext()
+    public function nameConverterContext(): void
     {
     }
 
     #[Route('/arbitrary_array', methods: ['GET'])]
     #[OA\Response(response: 200, description: 'Success', content: new Model(type: Foo::class))]
-    public function arbitraryArray()
+    public function arbitraryArray(): void
     {
     }
 
     #[Route('/dictionary', methods: ['GET'])]
     #[OA\Response(response: 200, description: 'Success', content: new Model(type: Dictionary::class))]
-    public function dictionary()
+    public function dictionary(): void
     {
     }
 
@@ -560,7 +560,7 @@ class ApiController
             ref: new Model(type: EntityWithIgnoredProperty::class),
         ),
     )]
-    public function entityWithIgnoredProperty()
+    public function entityWithIgnoredProperty(): void
     {
     }
 

--- a/tests/Functional/Controller/ApiController81Collisions.php
+++ b/tests/Functional/Controller/ApiController81Collisions.php
@@ -20,25 +20,25 @@ class ApiController81Collisions
 {
     #[Route('/article_81_group_full', methods: ['GET'])]
     #[OA\Response(response: 200, description: 'Success', content: new Model(type: Article81WithGroups::class, groups: ['full']))]
-    public function article81GroupFull()
+    public function article81GroupFull(): void
     {
     }
 
     #[Route('/article_81_group_default', methods: ['GET'])]
     #[OA\Response(response: 200, description: 'Success', content: new Model(type: Article81WithGroups::class, groups: ['default']))]
-    public function article81GroupDefault()
+    public function article81GroupDefault(): void
     {
     }
 
     #[Route('/article_81_group_default_and_full', methods: ['GET'])]
     #[OA\Response(response: 200, description: 'Success', content: new Model(type: Article81WithGroups::class, groups: ['default', 'full']))]
-    public function article81GroupDefaultAndFull()
+    public function article81GroupDefaultAndFull(): void
     {
     }
 
     #[Route('/article_81_group_empty', methods: ['GET'])]
     #[OA\Response(response: 200, description: 'Success', content: new Model(type: Article81WithGroups::class, groups: []))]
-    public function article81GroupEmpty()
+    public function article81GroupEmpty(): void
     {
     }
 }

--- a/tests/Functional/Controller/BazingaController.php
+++ b/tests/Functional/Controller/BazingaController.php
@@ -25,7 +25,7 @@ class BazingaController
         description: 'Success',
         content: new Model(type: BazingaUser::class)
     )]
-    public function userAction()
+    public function userAction(): void
     {
     }
 
@@ -35,7 +35,7 @@ class BazingaController
         description: 'Success',
         content: new Model(type: BazingaUser::class, groups: ['foo'])
     )]
-    public function userGroupAction()
+    public function userGroupAction(): void
     {
     }
 }

--- a/tests/Functional/Controller/BazingaTypedController.php
+++ b/tests/Functional/Controller/BazingaTypedController.php
@@ -25,7 +25,7 @@ class BazingaTypedController
         description: 'Success',
         content: new Model(type: BazingaUserTyped::class)
     )]
-    public function userTypedAction()
+    public function userTypedAction(): void
     {
     }
 }

--- a/tests/Functional/Controller/FOSRestController.php
+++ b/tests/Functional/Controller/FOSRestController.php
@@ -30,7 +30,7 @@ class FOSRestController
     #[RequestParam(name: 'datetimeAlt', requirements: new DateTime('c'))]
     #[RequestParam(name: 'datetimeNoFormat', requirements: new DateTime())]
     #[RequestParam(name: 'date', requirements: new DateTime('Y-m-d'))]
-    public function fosrestAction()
+    public function fosrestAction(): void
     {
     }
 
@@ -43,7 +43,7 @@ class FOSRestController
     #[RequestParam(name: 'datetimeAlt', requirements: new DateTime('c'))]
     #[RequestParam(name: 'datetimeNoFormat', requirements: new DateTime())]
     #[RequestParam(name: 'date', requirements: new DateTime('Y-m-d'))]
-    public function fosrestAttributesAction()
+    public function fosrestAttributesAction(): void
     {
     }
 }

--- a/tests/Functional/Controller/GenericTypesController.php
+++ b/tests/Functional/Controller/GenericTypesController.php
@@ -26,7 +26,7 @@ class GenericTypesController
         content: new Model(type: GenericTypes::class),
     )]
     #[Route('/generic-types', methods: ['GET'])]
-    public function genericTypesAction()
+    public function genericTypesAction(): void
     {
     }
 }

--- a/tests/Functional/Controller/JMSController.php
+++ b/tests/Functional/Controller/JMSController.php
@@ -37,7 +37,7 @@ class JMSController
         description: 'Success',
         content: new Model(type: JMSUser::class)
     )]
-    public function userAction()
+    public function userAction(): void
     {
     }
 
@@ -47,7 +47,7 @@ class JMSController
         description: 'Success',
         content: new Model(type: VirtualProperty::class)
     )]
-    public function yamlAction()
+    public function yamlAction(): void
     {
     }
 
@@ -60,7 +60,7 @@ class JMSController
             groups: ['list', 'details', 'User' => ['list']]
         )
     )]
-    public function complexAction()
+    public function complexAction(): void
     {
     }
 
@@ -73,7 +73,7 @@ class JMSController
             groups: ['Default', 'complex' => ['User' => ['details']]]
         )
     )]
-    public function complexDualAction()
+    public function complexDualAction(): void
     {
     }
 
@@ -83,7 +83,7 @@ class JMSController
         description: 'Success',
         content: new Model(type: JMSNamingStrategyConstraints::class, groups: ['Default'])
     )]
-    public function namingStrategyConstraintsAction()
+    public function namingStrategyConstraintsAction(): void
     {
     }
 
@@ -93,7 +93,7 @@ class JMSController
         description: 'Success',
         content: new Model(type: JMSChat::class, groups: ['Default', 'members' => ['mini']])
     )]
-    public function chatAction()
+    public function chatAction(): void
     {
     }
 
@@ -103,7 +103,7 @@ class JMSController
         description: 'Success',
         content: new Model(type: JMSPicture::class, groups: ['mini'])
     )]
-    public function pictureAction()
+    public function pictureAction(): void
     {
     }
 
@@ -113,7 +113,7 @@ class JMSController
         description: 'Success',
         content: new Model(type: JMSChatUser::class, groups: ['mini'])
     )]
-    public function minUserAction()
+    public function minUserAction(): void
     {
     }
 
@@ -123,7 +123,7 @@ class JMSController
         description: 'Success',
         content: new Model(type: JMSChatRoomUser::class, groups: ['mini', 'friend' => ['living' => ['Default']]])
     )]
-    public function minUserNestedAction()
+    public function minUserNestedAction(): void
     {
     }
 
@@ -134,7 +134,7 @@ class JMSController
         content: new Model(type: Article81::class)
     )
     ]
-    public function enum()
+    public function enum(): void
     {
     }
 
@@ -145,7 +145,7 @@ class JMSController
         content: new Model(type: JMSAbstractUser::class)
     )
     ]
-    public function discriminatorMapAction()
+    public function discriminatorMapAction(): void
     {
     }
 
@@ -156,7 +156,7 @@ class JMSController
         content: new Model(type: JMSEnum::class)
     )
     ]
-    public function enumArrayAction()
+    public function enumArrayAction(): void
     {
     }
 
@@ -167,7 +167,7 @@ class JMSController
         content: new Model(type: JMSIgnoredProperty::class)
     )
     ]
-    public function ignoredProperty()
+    public function ignoredProperty(): void
     {
     }
 }

--- a/tests/Functional/Controller/JmsOptOutController.php
+++ b/tests/Functional/Controller/JmsOptOutController.php
@@ -25,7 +25,7 @@ final class JmsOptOutController
         description: 'Success',
         content: new Model(type: JMSUser::class)
     )]
-    public function jms()
+    public function jms(): void
     {
     }
 
@@ -35,7 +35,7 @@ final class JmsOptOutController
         description: 'Success',
         content: new Model(type: JMSUser::class, serializationContext: ['useJms' => false])
     )]
-    public function jmsOptOut()
+    public function jmsOptOut(): void
     {
     }
 }

--- a/tests/Functional/Controller/MapQueryParameterController.php
+++ b/tests/Functional/Controller/MapQueryParameterController.php
@@ -54,8 +54,7 @@ class MapQueryParameterController
         string $regexp,
         #[MapQueryParameter(filter: \FILTER_VALIDATE_URL)]
         string $url,
-    ): void
-    {
+    ): void {
     }
 
     #[Route('/article_map_query_parameter_nullable', methods: ['GET'])]
@@ -94,8 +93,7 @@ class MapQueryParameterController
         ?int $id,
         #[MapQueryParameter]
         ?string $changedType,
-    ): void
-    {
+    ): void {
     }
 
     #[Route('/article_map_query_parameter_invalid_regexp', methods: ['GET'])]
@@ -103,8 +101,7 @@ class MapQueryParameterController
     public function fetchArticleWithInvalidRegexp(
         #[MapQueryParameter(filter: \FILTER_VALIDATE_REGEXP, options: ['regexp' => 'This is not a valid regexp'])]
         string $regexp,
-    ): void
-    {
+    ): void {
     }
 
     #[Route('/article_map_query_parameter_unsupported_flag', methods: ['GET'])]
@@ -112,8 +109,7 @@ class MapQueryParameterController
     public function fetchArticleWithUnsupportedRegexpFlag(
         #[MapQueryParameter(filter: \FILTER_VALIDATE_REGEXP, options: ['regexp' => '/\ZUnsupportedFlag/'])]
         string $regexp,
-    ): void
-    {
+    ): void {
     }
 
     #[Route('/article_map_query_parameter_replaced_flag', methods: ['GET'])]
@@ -121,7 +117,6 @@ class MapQueryParameterController
     public function fetchArticleWithReplacedRegexpFlag(
         #[MapQueryParameter(filter: \FILTER_VALIDATE_REGEXP, options: ['regexp' => '/\ADifferentFlag/'])]
         string $regexp,
-    ): void
-    {
+    ): void {
     }
 }

--- a/tests/Functional/Controller/MapQueryParameterController.php
+++ b/tests/Functional/Controller/MapQueryParameterController.php
@@ -54,7 +54,8 @@ class MapQueryParameterController
         string $regexp,
         #[MapQueryParameter(filter: \FILTER_VALIDATE_URL)]
         string $url,
-    ) {
+    ): void
+    {
     }
 
     #[Route('/article_map_query_parameter_nullable', methods: ['GET'])]
@@ -93,7 +94,8 @@ class MapQueryParameterController
         ?int $id,
         #[MapQueryParameter]
         ?string $changedType,
-    ) {
+    ): void
+    {
     }
 
     #[Route('/article_map_query_parameter_invalid_regexp', methods: ['GET'])]
@@ -101,7 +103,8 @@ class MapQueryParameterController
     public function fetchArticleWithInvalidRegexp(
         #[MapQueryParameter(filter: \FILTER_VALIDATE_REGEXP, options: ['regexp' => 'This is not a valid regexp'])]
         string $regexp,
-    ) {
+    ): void
+    {
     }
 
     #[Route('/article_map_query_parameter_unsupported_flag', methods: ['GET'])]
@@ -109,7 +112,8 @@ class MapQueryParameterController
     public function fetchArticleWithUnsupportedRegexpFlag(
         #[MapQueryParameter(filter: \FILTER_VALIDATE_REGEXP, options: ['regexp' => '/\ZUnsupportedFlag/'])]
         string $regexp,
-    ) {
+    ): void
+    {
     }
 
     #[Route('/article_map_query_parameter_replaced_flag', methods: ['GET'])]
@@ -117,6 +121,7 @@ class MapQueryParameterController
     public function fetchArticleWithReplacedRegexpFlag(
         #[MapQueryParameter(filter: \FILTER_VALIDATE_REGEXP, options: ['regexp' => '/\ADifferentFlag/'])]
         string $regexp,
-    ) {
+    ): void
+    {
     }
 }

--- a/tests/Functional/Controller/MapQueryStringController.php
+++ b/tests/Functional/Controller/MapQueryStringController.php
@@ -80,8 +80,7 @@ class MapQueryStringController
     public function fetchArticleFromMapQueryStringOverwriteParameters(
         #[MapQueryString]
         SymfonyMapQueryString $article81Query,
-    ): void
-    {
+    ): void {
     }
 
     #[Route('/article_map_query_string_many_parameters', methods: ['GET'])]

--- a/tests/Functional/Controller/MapQueryStringController.php
+++ b/tests/Functional/Controller/MapQueryStringController.php
@@ -80,7 +80,8 @@ class MapQueryStringController
     public function fetchArticleFromMapQueryStringOverwriteParameters(
         #[MapQueryString]
         SymfonyMapQueryString $article81Query,
-    ) {
+    ): void
+    {
     }
 
     #[Route('/article_map_query_string_many_parameters', methods: ['GET'])]

--- a/tests/Functional/Controller/MapRequestPayloadArray.php
+++ b/tests/Functional/Controller/MapRequestPayloadArray.php
@@ -23,7 +23,8 @@ class MapRequestPayloadArray
     public function createArticleFromMapRequestPayloadArray(
         #[MapRequestPayload(type: Article81::class)]
         array $articles,
-    ) {
+    ): void
+    {
     }
 
     #[Route('/article_map_request_payload_nullable_array', methods: ['POST'])]
@@ -31,6 +32,7 @@ class MapRequestPayloadArray
     public function createArticleFromMapRequestPayloadNullableArray(
         #[MapRequestPayload(type: Article81::class)]
         ?array $nullableArticles,
-    ) {
+    ): void
+    {
     }
 }

--- a/tests/Functional/Controller/MapRequestPayloadArray.php
+++ b/tests/Functional/Controller/MapRequestPayloadArray.php
@@ -23,8 +23,7 @@ class MapRequestPayloadArray
     public function createArticleFromMapRequestPayloadArray(
         #[MapRequestPayload(type: Article81::class)]
         array $articles,
-    ): void
-    {
+    ): void {
     }
 
     #[Route('/article_map_request_payload_nullable_array', methods: ['POST'])]
@@ -32,7 +31,6 @@ class MapRequestPayloadArray
     public function createArticleFromMapRequestPayloadNullableArray(
         #[MapRequestPayload(type: Article81::class)]
         ?array $nullableArticles,
-    ): void
-    {
+    ): void {
     }
 }

--- a/tests/Functional/Controller/MapRequestPayloadController.php
+++ b/tests/Functional/Controller/MapRequestPayloadController.php
@@ -46,8 +46,7 @@ class MapRequestPayloadController
     public function createArticleFromMapRequestPayloadOverwrite(
         #[MapRequestPayload]
         Article81 $article81,
-    ): void
-    {
+    ): void {
     }
 
     #[Route('/article_map_request_payload_handles_already_set_content', methods: ['POST'])]
@@ -61,8 +60,7 @@ class MapRequestPayloadController
     public function createArticleFromMapRequestPayloadHandlesAlreadySetContent(
         #[MapRequestPayload]
         Article81 $article81,
-    ): void
-    {
+    ): void {
     }
 
     #[Route('/article_map_request_payload_validation_groups', methods: ['POST'])]

--- a/tests/Functional/Controller/MapRequestPayloadController.php
+++ b/tests/Functional/Controller/MapRequestPayloadController.php
@@ -46,7 +46,8 @@ class MapRequestPayloadController
     public function createArticleFromMapRequestPayloadOverwrite(
         #[MapRequestPayload]
         Article81 $article81,
-    ) {
+    ): void
+    {
     }
 
     #[Route('/article_map_request_payload_handles_already_set_content', methods: ['POST'])]
@@ -60,7 +61,8 @@ class MapRequestPayloadController
     public function createArticleFromMapRequestPayloadHandlesAlreadySetContent(
         #[MapRequestPayload]
         Article81 $article81,
-    ) {
+    ): void
+    {
     }
 
     #[Route('/article_map_request_payload_validation_groups', methods: ['POST'])]

--- a/tests/Functional/Controller/MapUploadedFileController.php
+++ b/tests/Functional/Controller/MapUploadedFileController.php
@@ -55,8 +55,7 @@ class MapUploadedFileController
     public function createUploadFromMapUploadedFileAddToExisting(
         #[MapUploadedFile]
         ?UploadedFile $upload,
-    ): void
-    {
+    ): void {
     }
 
     #[Route('/article_map_uploaded_file_overwrite', methods: ['POST'])]
@@ -76,8 +75,7 @@ class MapUploadedFileController
     public function createUploadFromMapUploadedFileOverwrite(
         #[MapUploadedFile]
         ?UploadedFile $upload,
-    ): void
-    {
+    ): void {
     }
 
     #[Route('/article_map_uploaded_file_array', methods: ['POST'])]

--- a/tests/Functional/Controller/MapUploadedFileController.php
+++ b/tests/Functional/Controller/MapUploadedFileController.php
@@ -55,7 +55,8 @@ class MapUploadedFileController
     public function createUploadFromMapUploadedFileAddToExisting(
         #[MapUploadedFile]
         ?UploadedFile $upload,
-    ) {
+    ): void
+    {
     }
 
     #[Route('/article_map_uploaded_file_overwrite', methods: ['POST'])]
@@ -75,7 +76,8 @@ class MapUploadedFileController
     public function createUploadFromMapUploadedFileOverwrite(
         #[MapUploadedFile]
         ?UploadedFile $upload,
-    ) {
+    ): void
+    {
     }
 
     #[Route('/article_map_uploaded_file_array', methods: ['POST'])]

--- a/tests/Functional/Controller/PromotedPropertiesController81.php
+++ b/tests/Functional/Controller/PromotedPropertiesController81.php
@@ -31,7 +31,7 @@ class PromotedPropertiesController81
     #[OA\RequestBody(
         content: new Model(type: EntityWithPromotedPropertiesWithDefaults::class),
     )]
-    public function entityWithPromotedPropertiesWithDefaults()
+    public function entityWithPromotedPropertiesWithDefaults(): void
     {
     }
 }

--- a/tests/Functional/Entity/JMSComplex.php
+++ b/tests/Functional/Entity/JMSComplex.php
@@ -47,7 +47,7 @@ class JMSComplex
     #[Serializer\Expose]
     #[Serializer\Groups(['list'])]
     #[OA\Property(ref: new Model(type: JMSUser::class))]
-    public function getVirtualFriend()
+    public function getVirtualFriend(): void
     {
     }
 }

--- a/tests/Functional/Entity/JMSNamingStrategyConstraints.php
+++ b/tests/Functional/Entity/JMSNamingStrategyConstraints.php
@@ -31,7 +31,7 @@ class JMSNamingStrategyConstraints
         return $this->some_weird_named_property;
     }
 
-    public function setSomeWeirdNamedProperty(string $some_weird_named_property)
+    public function setSomeWeirdNamedProperty(string $some_weird_named_property): void
     {
         $this->some_weird_named_property = $some_weird_named_property;
     }

--- a/tests/Functional/Entity/User.php
+++ b/tests/Functional/Entity/User.php
@@ -85,18 +85,18 @@ class User
      */
     private $dateAsInterface;
 
-    public function setMoney(float $money)
+    public function setMoney(float $money): void
     {
         $this->money = $money;
     }
 
     #[OA\Property(example: 1)]
-    public function setId(int $id)
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
 
-    public function setEmail($email)
+    public function setEmail($email): void
     {
         $this->email = $email;
     }
@@ -104,7 +104,7 @@ class User
     /**
      * @param string[] $roles
      */
-    public function setRoles(array $roles)
+    public function setRoles(array $roles): void
     {
         $this->roles = $roles;
     }
@@ -113,7 +113,7 @@ class User
     {
     }
 
-    public function setFriendsNumber(int $friendsNumber)
+    public function setFriendsNumber(int $friendsNumber): void
     {
         $this->friendsNumber = $friendsNumber;
     }
@@ -147,7 +147,7 @@ class User
         return $this->dateAsInterface;
     }
 
-    public function setDateAsInterface(\DateTimeInterface $dateAsInterface)
+    public function setDateAsInterface(\DateTimeInterface $dateAsInterface): void
     {
         $this->dateAsInterface = $dateAsInterface;
     }

--- a/tests/Functional/EntityExcluded/ApiPlatform3/Dummy.php
+++ b/tests/Functional/EntityExcluded/ApiPlatform3/Dummy.php
@@ -48,7 +48,7 @@ class Dummy
         return $this->id;
     }
 
-    public function setName(string $name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }


### PR DESCRIPTION
This PR adds explicit void return types to methods that don't return any value.