### PR TITLE
Replace deprecated LegacyTypeConverter::createType() with Type::fromString()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/deprecation-contracts": "^2.1 || ^3",
         "symfony/framework-bundle": "^6.4 || ^7.2",
         "symfony/http-foundation": "^6.4 || ^7.2",
-        "symfony/type-info": "^7.2",
+        "symfony/type-info": "^7.3",
         "symfony/http-kernel": "^6.4 || ^7.2",
         "symfony/options-resolver": "^6.4 || ^7.2",
         "symfony/property-info": "^6.4 || ^7.2",

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -14,7 +14,6 @@ namespace Nelmio\ApiDocBundle\Model;
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
 use Nelmio\ApiDocBundle\ModelDescriber\ModelDescriberInterface;
 use Nelmio\ApiDocBundle\OpenApiPhp\Util;
-use Nelmio\ApiDocBundle\Util\LegacyTypeConverter;
 use OpenApi\Annotations as OA;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
@@ -76,7 +75,7 @@ final class ModelRegistry
 
         foreach ($alternativeNames as $alternativeName => $criteria) {
             $model = new Model(
-                LegacyTypeConverter::createType($criteria['type']),
+                Type::fromString($criteria['type']),
                 $criteria['groups'],
                 $criteria['options'] ?? [],
                 $criteria['serializationContext'] ?? [],

--- a/src/ModelDescriber/ApplyOpenApiDiscriminatorTrait.php
+++ b/src/ModelDescriber/ApplyOpenApiDiscriminatorTrait.php
@@ -14,7 +14,7 @@ namespace Nelmio\ApiDocBundle\ModelDescriber;
 use Nelmio\ApiDocBundle\Model\Model;
 use Nelmio\ApiDocBundle\Model\ModelRegistry;
 use Nelmio\ApiDocBundle\OpenApiPhp\Util;
-use Nelmio\ApiDocBundle\Util\LegacyTypeConverter;
+use Symfony\Component\TypeInfo\Type;
 use OpenApi\Annotations as OA;
 
 /**
@@ -52,7 +52,7 @@ trait ApplyOpenApiDiscriminatorTrait
         foreach ($typeMap as $propertyValue => $className) {
             $oneOfSchema = new OA\Schema(['_context' => $weakContext]);
             $oneOfSchema->ref = $modelRegistry->register(new Model(
-                LegacyTypeConverter::createType($className),
+                Type::fromString($className),
                 $model->getGroups(),
                 $model->getOptions(),
                 $model->getSerializationContext()

--- a/src/ModelDescriber/FormModelDescriber.php
+++ b/src/ModelDescriber/FormModelDescriber.php
@@ -17,7 +17,7 @@ use Nelmio\ApiDocBundle\Model\Model;
 use Nelmio\ApiDocBundle\ModelDescriber\Annotations\AnnotationsReader;
 use Nelmio\ApiDocBundle\OpenApiPhp\ModelRegister;
 use Nelmio\ApiDocBundle\OpenApiPhp\Util;
-use Nelmio\ApiDocBundle\Util\LegacyTypeConverter;
+use Symfony\Component\TypeInfo\Type;
 use Nelmio\ApiDocBundle\Util\SetsContextTrait;
 use OpenApi\Analysis;
 use OpenApi\Annotations as OA;
@@ -156,7 +156,7 @@ final class FormModelDescriber implements ModelDescriberInterface, ModelRegistry
         if (null === $builtinFormType = $this->getBuiltinFormType($type)) {
             // if form type is not builtin in Form component.
             $model = new Model(
-                LegacyTypeConverter::createType(\get_class($type->getInnerType())),
+                Type::fromString(\get_class($type->getInnerType())),
                 null,
                 $config->getOptions()
             );

--- a/src/ModelDescriber/JMSModelDescriber.php
+++ b/src/ModelDescriber/JMSModelDescriber.php
@@ -23,7 +23,7 @@ use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareTrait;
 use Nelmio\ApiDocBundle\Model\Model;
 use Nelmio\ApiDocBundle\ModelDescriber\Annotations\AnnotationsReader;
 use Nelmio\ApiDocBundle\OpenApiPhp\Util;
-use Nelmio\ApiDocBundle\Util\LegacyTypeConverter;
+use Symfony\Component\TypeInfo\Type;
 use OpenApi\Annotations as OA;
 use OpenApi\Generator;
 use Symfony\Component\TypeInfo\Type\ObjectType;
@@ -167,7 +167,8 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
             if (true === $item->inline && isset($item->type['name'])) {
                 // currently array types can not be documented :-/
                 if (!\in_array($item->type['name'], ['array', 'ArrayCollection'], true)) {
-                    $inlineModel = new Model(LegacyTypeConverter::createType($item->type['name']), $groups);
+
+                    $inlineModel = new Model(Type::fromString($item->type['name']), $groups);
                     $this->describe($inlineModel, $schema);
                 }
                 $context->popPropertyMetadata();
@@ -357,7 +358,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
             $groups = $this->computeGroups($context, $type);
             unset($serializationContext['groups']);
 
-            $model = new Model(LegacyTypeConverter::createType($type['name']), $groups, [], $serializationContext);
+            $model = new Model(Type::fromString($type['name']), $groups, [], $serializationContext);
             $modelRef = $this->modelRegistry->register($model);
 
             $customFields = (array) $property->jsonSerialize();

--- a/src/OpenApiPhp/ModelRegister.php
+++ b/src/OpenApiPhp/ModelRegister.php
@@ -14,7 +14,7 @@ namespace Nelmio\ApiDocBundle\OpenApiPhp;
 use Nelmio\ApiDocBundle\Attribute\Model as ModelAnnotation;
 use Nelmio\ApiDocBundle\Model\Model;
 use Nelmio\ApiDocBundle\Model\ModelRegistry;
-use Nelmio\ApiDocBundle\Util\LegacyTypeConverter;
+use Symfony\Component\TypeInfo\Type;
 use OpenApi\Analysis;
 use OpenApi\Annotations as OA;
 use OpenApi\Generator;
@@ -50,7 +50,7 @@ final class ModelRegister
             if ($annotation instanceof OA\Schema && $annotation->ref instanceof ModelAnnotation) {
                 $model = $annotation->ref;
 
-                $annotation->ref = $this->modelRegistry->register(new Model(LegacyTypeConverter::createType($model->type), $this->getGroups($model, $parentGroups), $model->options, $model->serializationContext, $model->name));
+                $annotation->ref = $this->modelRegistry->register(new Model(Type::fromString($model->type), $this->getGroups($model, $parentGroups), $model->options, $model->serializationContext, $model->name));
 
                 // It is no longer an unmerged annotation
                 $this->detach($model, $annotation, $analysis);
@@ -76,7 +76,7 @@ final class ModelRegister
             if ($annotation instanceof OA\Response || $annotation instanceof OA\RequestBody) {
                 $properties = [
                     '_context' => Util::createContext(['nested' => $annotation], $annotation->_context),
-                    'ref' => $this->modelRegistry->register(new Model(LegacyTypeConverter::createType($model->type), $this->getGroups($model, $parentGroups), $model->options, $model->serializationContext, $model->name)),
+                    'ref' => $this->modelRegistry->register(new Model(Type::fromString($model->type), $this->getGroups($model, $parentGroups), $model->options, $model->serializationContext, $model->name)),
                 ];
 
                 foreach ($this->mediaTypes as $mediaType) {
@@ -98,7 +98,7 @@ final class ModelRegister
             }
 
             $annotation->merge([new $annotationClass([
-                'ref' => $this->modelRegistry->register(new Model(LegacyTypeConverter::createType($model->type), $this->getGroups($model, $parentGroups), $model->options, $model->serializationContext, $model->name)),
+                'ref' => $this->modelRegistry->register(new Model(Type::fromString($model->type), $this->getGroups($model, $parentGroups), $model->options, $model->serializationContext, $model->name)),
             ])]);
 
             // It is no longer an unmerged annotation

--- a/src/RouteDescriber/RouteArgumentDescriber/SymfonyMapQueryStringDescriber.php
+++ b/src/RouteDescriber/RouteArgumentDescriber/SymfonyMapQueryStringDescriber.php
@@ -16,7 +16,7 @@ namespace Nelmio\ApiDocBundle\RouteDescriber\RouteArgumentDescriber;
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareTrait;
 use Nelmio\ApiDocBundle\Model\Model;
-use Nelmio\ApiDocBundle\Util\LegacyTypeConverter;
+use Symfony\Component\TypeInfo\Type;
 use OpenApi\Annotations as OA;
 use Symfony\Component\HttpKernel\Attribute\MapQueryString;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
@@ -37,7 +37,7 @@ final class SymfonyMapQueryStringDescriber implements RouteArgumentDescriberInte
         }
 
         $modelRef = $this->modelRegistry->register(new Model(
-            LegacyTypeConverter::createType($argumentMetadata->getType()),
+            Type::fromString($argumentMetadata->getType()),
             groups: $this->getGroups($attribute),
             serializationContext: $attribute->serializationContext,
         ));

--- a/src/RouteDescriber/RouteArgumentDescriber/SymfonyMapRequestPayloadDescriber.php
+++ b/src/RouteDescriber/RouteArgumentDescriber/SymfonyMapRequestPayloadDescriber.php
@@ -16,7 +16,7 @@ namespace Nelmio\ApiDocBundle\RouteDescriber\RouteArgumentDescriber;
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
 use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareTrait;
 use Nelmio\ApiDocBundle\Model\Model;
-use Nelmio\ApiDocBundle\Util\LegacyTypeConverter;
+use Symfony\Component\TypeInfo\Type;
 use OpenApi\Annotations as OA;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
@@ -43,7 +43,7 @@ final class SymfonyMapRequestPayloadDescriber implements RouteArgumentDescriberI
         }
 
         $modelRef = $this->modelRegistry->register(new Model(
-            LegacyTypeConverter::createType($typeClass),
+            Type::fromString($typeClass),
             groups: $this->getGroups($attribute),
             serializationContext: $attribute->serializationContext,
         ));

--- a/tests/Util/LegacyTypeConverterTest.php
+++ b/tests/Util/LegacyTypeConverterTest.php
@@ -160,7 +160,7 @@ class LegacyTypeConverterTest extends TestCase
     #[DataProvider('provideCreateTypeCases')]
     public function testCreateType(Type $expected, string $typeString): void
     {
-        self::assertEquals($expected, LegacyTypeConverter::createType($typeString));
+        self::assertEquals($expected, Type::fromString($typeString));
     }
 
     public static function provideCreateTypeCases(): \Generator


### PR DESCRIPTION
This PR removes the deprecated LegacyTypeConverter::createType() usage and replaces it with Type::fromString(), which is the recommended API since Symfony 7.2.

Only the safe and forward-compatible part of the LegacyTypeConverter is removed toTypeInfoType() and toLegacyType() remain untouched, as they still provide conversions that have no public equivalent in Symfony.
Happy to adjust if needed.