### PR TITLE
fix(OpenApiPhpDescriber): Set annotation name from context, if empty

### DIFF
--- a/src/Describer/OpenApiPhpDescriber.php
+++ b/src/Describer/OpenApiPhpDescriber.php
@@ -138,6 +138,10 @@ final class OpenApiPhpDescriber
                     continue;
                 }
 
+                if ($annotation instanceof OA\Parameter && Generator::UNDEFINED === $annotation->name && null !== $annotation->_context?->property) {
+                    $annotation->name = $annotation->_context->property;
+                }
+
                 if (
                     !$annotation instanceof OA\Response
                     && !$annotation instanceof OA\RequestBody

--- a/tests/Functional/Controller/MapQueryParameterController.php
+++ b/tests/Functional/Controller/MapQueryParameterController.php
@@ -119,4 +119,28 @@ class MapQueryParameterController
         string $regexp,
     ): void {
     }
+
+    #[Route('/article_map_query_parameter_name_from_context', methods: ['GET'])]
+    #[OA\Response(response: '200', description: '')]
+    public function fetchArticleWithParameterNamesFromContext(
+        #[MapQueryParameter]
+        #[OA\QueryParameter(
+            description: 'User ID from parameter context',
+            schema: new OA\Schema(type: 'integer', minimum: 1)
+        )]
+        int $userId,
+        #[MapQueryParameter]
+        #[OA\QueryParameter(
+            description: 'Search query from parameter context',
+            schema: new OA\Schema(type: 'string', minLength: 3)
+        )]
+        string $searchQuery,
+        #[MapQueryParameter]
+        #[OA\QueryParameter(
+            description: 'Page number from parameter context',
+            schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100)
+        )]
+        int $pageNumber,
+    ): void {
+    }
 }

--- a/tests/Functional/Fixtures/MapQueryParameterController.json
+++ b/tests/Functional/Fixtures/MapQueryParameterController.json
@@ -291,6 +291,49 @@
                     }
                 }
             }
+        },
+        "/article_map_query_parameter_name_from_context": {
+            "get": {
+                "operationId": "get_nelmio_apidoc_tests_functional_mapqueryparameter_fetcharticlewithparameternamesfromcontext",
+                "parameters": [
+                    {
+                        "name": "userId",
+                        "in": "query",
+                        "description": "User ID from parameter context",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1
+                        }
+                    },
+                    {
+                        "name": "searchQuery",
+                        "in": "query",
+                        "description": "Search query from parameter context",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "minLength": 3
+                        }
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "description": "Page number from parameter context",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100,
+                            "minimum": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

Since swagger-php v5.6 the name is not inferred anymore for the context directly. 
The property name is still available in the context.

If the name is not given as attribute parameter, the merge of different annotation fails, due to the missing name.

This PR fill back the annotation name from the context, if the name attribute is not directly set in the annotation itself

Closes #2657 

Context:
https://github.com/zircote/swagger-php/issues/1875

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`) - no need