### PR TITLE
feat: Add support for static callbacks in Symfony choice constraints

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,7 +15,8 @@ $finder = (new PhpCsFixer\Finder())
     ->in(__DIR__)
     ->exclude('var')
     ->exclude('tests/Functional/cache')
-    ->exclude('tests/Functional/ModelDescriber/Fixtures');
+    ->exclude('tests/Functional/ModelDescriber/Fixtures')
+    ->notContains('ChoiceConstraintsWithPHP85StaticCallbackEntity');
 
 return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)

--- a/src/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
+++ b/src/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
@@ -160,7 +160,9 @@ class SymfonyConstraintAnnotationReader
     private function applyEnumFromChoiceConstraint(OA\Schema $property, Assert\Choice $choice, $reflection): void
     {
         if (null !== $choice->callback) {
-            $enumValues = \call_user_func(\is_array($choice->callback) ? $choice->callback : [$reflection->class, $choice->callback]);
+            $enumValues = $choice->callback instanceof \Closure
+                ? ($choice->callback)()
+                : \call_user_func(\is_array($choice->callback) ? $choice->callback : [$reflection->class, $choice->callback]);
         } else {
             $enumValues = $choice->choices;
         }

--- a/tests/ModelDescriber/Annotations/ChoiceConstraintsWithPHP85StaticCallbackEntity.php
+++ b/tests/ModelDescriber/Annotations/ChoiceConstraintsWithPHP85StaticCallbackEntity.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\ModelDescriber\Annotations;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class ChoiceConstraintsWithPHP85StaticCallbackEntity
+{
+    #[Assert\Choice(callback: static function () {
+        return ['test1', 'test2'];
+    })]
+    public string $property1;
+}

--- a/tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
+++ b/tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
@@ -408,6 +408,31 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         }];
     }
 
+    public function testChoiceConstraintsWithStaticCallback(): void
+    {
+        if (PHP_VERSION_ID < 80500) {
+            self::markTestSkipped('This tests requires PHP >= 8.5.0');
+        }
+
+        $entity = new class {
+            #[Assert\Choice(callback: static function () {
+                return ['test1', 'test2'];
+            })]
+            public $property1;
+        };
+
+        $schema = $this->createObj(OA\Schema::class, []);
+        $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
+
+        $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader();
+        $symfonyConstraintAnnotationReader->setSchema($schema);
+
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+
+        self::assertEquals($schema->properties[0]->enum, ['test1', 'test2']);
+    }
+
+
     /**
      * @template T of OA\AbstractAnnotation
      *

--- a/tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
+++ b/tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
@@ -410,16 +410,11 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
 
     public function testChoiceConstraintsWithStaticCallback(): void
     {
-        if (PHP_VERSION_ID < 80500) {
+        if (\PHP_VERSION_ID < 80500) {
             self::markTestSkipped('This tests requires PHP >= 8.5.0');
         }
 
-        $entity = new class {
-            #[Assert\Choice(callback: static function () {
-                return ['test1', 'test2'];
-            })]
-            public $property1;
-        };
+        $entity = new ChoiceConstraintsWithPHP85StaticCallbackEntity();
 
         $schema = $this->createObj(OA\Schema::class, []);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
@@ -431,7 +426,6 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
 
         self::assertEquals($schema->properties[0]->enum, ['test1', 'test2']);
     }
-
 
     /**
      * @template T of OA\AbstractAnnotation


### PR DESCRIPTION
## Description

This PR adds support for generating enums from Symfony Choice constraints when the constraint uses a PHP 8.5 static callback defined directly inside an attribute.

For example
```php
class TestDto
{
    #[Assert\Choice(callback: static function () {
        return ['test1', 'test2'];
    })]
    public $property1;
}
```

In this case, the generator will correctly infer the allowed values and produce the corresponding enum.

Notes
* This feature is only available on PHP 8.5+
* Existing behavior for method-based callbacks remains unchanged

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [x] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)