### PR TITLE
fix(swagger-ui): dark mode ui background color

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -11,7 +11,6 @@ html {
 
 body {
     margin:70px 0 0;
-    background: #f0f0f0;
 }
 
 
@@ -58,7 +57,6 @@ header #logo img {
   padding:10px 0 0;
   width:100%;
   max-width:100%;
-  background-color:white;
   border-bottom:1px solid #ccc;
   margin-bottom:30px;
 }
@@ -156,7 +154,6 @@ header #logo img {
 
 #swagger-ui.api-platform .opblock {
   border-radius:0;
-  background-color:white;
   box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
   margin:0 0 10px;
   padding:0;
@@ -215,7 +212,6 @@ text-align:center;
 #swagger-ui.api-platform .btn {
   transition:all ease 0.2s;
   box-shadow:none;
-  background-color: #f7f7f7
 }
 
 #swagger-ui.api-platform .btn:hover {


### PR DESCRIPTION
## Description

Remove background color definitions to make dark mode looks OK

Closes #2663

## What type of PR is this?
- [x] Bug Fix

## Result

dark mode:
<img width="1256" height="759" alt="image" src="https://github.com/user-attachments/assets/263cfbf2-4cd3-4c9d-9c71-328071e34da2" />

light mode:
<img width="1256" height="759" alt="image" src="https://github.com/user-attachments/assets/b16b18e5-5426-49e3-aeb9-ecd5c2685b46" />
