### PR TITLE
chore(phpdocumentor): bump support for reflection-docblock & type-resolver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": ">=8.2",
-        "phpdocumentor/reflection-docblock": "^5.0",
-        "phpdocumentor/type-resolver": "^1.8.2",
+        "phpdocumentor/reflection-docblock": "^5.0 || ^6.0",
+        "phpdocumentor/type-resolver": "^1.8.2 || ^2.0",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/container": "^1.0 || ^2.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",


### PR DESCRIPTION
## Description

- Bump `phpdocumentor/reflection-docblock` to allow [`6.*`](https://github.com/phpDocumentor/ReflectionDocBlock/releases/tag/6.0.0)
- Bump `phpdocumentor/ type-resolver` to allow [`2.x`](https://github.com/phpDocumentor/TypeResolver/releases/tag/2.0.0)

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)