### PR TITLE
fix: serializer extractor logic 

### DIFF
--- a/src/ModelDescriber/Annotations/AnnotationsReader.php
+++ b/src/ModelDescriber/Annotations/AnnotationsReader.php
@@ -70,17 +70,28 @@ class AnnotationsReader
     }
 
     /**
-     * @param \ReflectionProperty[]|\ReflectionMethod[] $reflections
+     * @param list<\ReflectionProperty|\ReflectionMethod> $reflections
      */
-    public function shouldDescribeProperty(array $reflections): bool
+    public function shouldDescribeProperty(array $reflections, bool $isJms): bool
     {
+        $isPublic = $isJms;
         foreach ($reflections as $reflection) {
+            // If the property has #[Ignore] attribute, always ignore it
             if ([] !== $reflection->getAttributes(Ignore::class)) {
                 return false;
             }
+
+            if ($isJms) {
+                continue;
+            }
+
+            if ($reflection->isPublic()) {
+                $isPublic = true;
+            }
         }
 
-        return true;
+        // Describe if it's a public property or has a public getter
+        return $isPublic;
     }
 
     /**

--- a/src/ModelDescriber/Annotations/AnnotationsReader.php
+++ b/src/ModelDescriber/Annotations/AnnotationsReader.php
@@ -74,24 +74,19 @@ class AnnotationsReader
      */
     public function shouldDescribeProperty(array $reflections, bool $isJms): bool
     {
-        $isPublic = $isJms;
         foreach ($reflections as $reflection) {
             // If the property has #[Ignore] attribute, always ignore it
             if ([] !== $reflection->getAttributes(Ignore::class)) {
                 return false;
             }
-
-            if ($isJms) {
-                continue;
-            }
-
-            if ($reflection->isPublic()) {
-                $isPublic = true;
-            }
         }
 
-        // Describe if it's a public property or has a public getter
-        return $isPublic;
+        // The first reflection result determines if the property is visible
+        if (!$isJms && !$reflections[0]?->isPublic()) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/ModelDescriber/JMSModelDescriber.php
+++ b/src/ModelDescriber/JMSModelDescriber.php
@@ -156,7 +156,7 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
                 }
             }
 
-            if (!$annotationsReader->shouldDescribeProperty($reflections)) {
+            if (!$annotationsReader->shouldDescribeProperty($reflections, true)) {
                 $context->popPropertyMetadata();
 
                 continue;

--- a/src/ModelDescriber/ObjectModelDescriber.php
+++ b/src/ModelDescriber/ObjectModelDescriber.php
@@ -114,16 +114,12 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
             return;
         }
 
-        // Fix for https://github.com/nelmio/NelmioApiDocBundle/issues/1756
-        // The SerializerExtractor does expose private/protected properties for some reason, so we eliminate them here
-        $propertyInfoProperties = array_intersect($propertyInfoProperties, $this->propertyInfo->getProperties($class, []) ?? []);
-
         foreach ($propertyInfoProperties as $propertyName) {
             $serializedName = null !== $this->nameConverter ? $this->nameConverter->normalize($propertyName, $class, null, $model->getSerializationContext()) : $propertyName;
 
             $reflections = $this->getReflections($reflClass, $propertyName);
 
-            if (!$annotationsReader->shouldDescribeProperty($reflections)) {
+            if (!$annotationsReader->shouldDescribeProperty($reflections, false)) {
                 continue;
             }
 
@@ -165,7 +161,7 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
     }
 
     /**
-     * @return \ReflectionProperty[]|\ReflectionMethod[]
+     * @return list<\ReflectionProperty|\ReflectionMethod>
      */
     private function getReflections(\ReflectionClass $reflClass, string $propertyName): array
     {

--- a/src/ModelDescriber/ObjectModelDescriber.php
+++ b/src/ModelDescriber/ObjectModelDescriber.php
@@ -33,6 +33,8 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
     use ApplyOpenApiDiscriminatorTrait;
     use ModelRegistryAwareTrait;
 
+    private const ACCESSOR_PREFIXES = ['get', 'is', 'has', 'can', 'add', 'remove', 'set'];
+
     private PropertyInfoExtractorInterface $propertyInfo;
     private ?ClassMetadataFactoryInterface $classMetadataFactory;
     private PropertyDescriberInterface|TypeDescriberInterface $propertyDescriber;
@@ -166,15 +168,20 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
     private function getReflections(\ReflectionClass $reflClass, string $propertyName): array
     {
         $reflections = [];
-        if ($reflClass->hasProperty($propertyName)) {
-            $reflections[] = $reflClass->getProperty($propertyName);
-        }
 
         $camelProp = $this->camelize($propertyName);
-        foreach (['', 'get', 'is', 'has', 'can', 'add', 'remove', 'set'] as $prefix) {
-            if ($reflClass->hasMethod($prefix.$camelProp)) {
-                $reflections[] = $reflClass->getMethod($prefix.$camelProp);
+        foreach (self::ACCESSOR_PREFIXES as $prefix) {
+            if ($reflClass->hasMethod($methodName = $prefix.$camelProp)) {
+                $reflections[] = $reflClass->getMethod($methodName);
             }
+        }
+
+        if ($reflClass->hasMethod($getsetter = lcfirst($camelProp))) {
+            $reflections[] = $reflClass->getMethod($getsetter);
+        }
+
+        if ($reflClass->hasProperty($propertyName)) {
+            $reflections[] = $reflClass->getProperty($propertyName);
         }
 
         return $reflections;
@@ -185,7 +192,7 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
      */
     private function camelize(string $string): string
     {
-        return str_replace(' ', '', ucwords(str_replace('_', ' ', $string)));
+        return str_replace(' ', '', ucwords($string));
     }
 
     /**

--- a/tests/Functional/Entity/PrivateProtectedExposure.php
+++ b/tests/Functional/Entity/PrivateProtectedExposure.php
@@ -26,6 +26,15 @@ class PrivateProtectedExposure
 
     private bool $isVisible;
 
+    public int $campaign_id;
+
+    private bool $is_active;
+
+    public function isActive(): bool
+    {
+        return $this->is_active;
+    }
+
     public function isVisible(): bool
     {
         return $this->isVisible;

--- a/tests/Functional/Entity/PrivateProtectedExposure.php
+++ b/tests/Functional/Entity/PrivateProtectedExposure.php
@@ -24,6 +24,13 @@ class PrivateProtectedExposure
      */
     public $publicField;
 
+    private bool $isVisible;
+
+    public function isVisible(): bool
+    {
+        return $this->isVisible;
+    }
+
     protected function setProtected(string $thing)
     {
     }

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -786,10 +786,24 @@ class FunctionalTest extends WebTestCase
      */
     public function testPrivateProtectedExposure(): void
     {
+        self::assertEquals([
+            'schema' => 'PrivateProtectedExposure',
+            'type' => 'object',
+            'required' => [
+                'publicField',
+                'isVisible',
+            ],
+            'properties' => [
+                'isVisible' => [
+                    'type' => 'boolean',
+                ],
+                'publicField' => [
+                    'type' => 'string',
+                ],
+            ],
+        ], json_decode(($model = $this->getModel('PrivateProtectedExposure'))->toJson(), true));
+
         // Ensure that groups are supported
-        $model = $this->getModel('PrivateProtectedExposure');
-        self::assertCount(1, $model->properties);
-        $this->assertHasProperty('publicField', $model);
         $this->assertNotHasProperty('privateField', $model);
         $this->assertNotHasProperty('protectedField', $model);
         $this->assertNotHasProperty('protected', $model);

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -792,6 +792,8 @@ class FunctionalTest extends WebTestCase
             'required' => [
                 'publicField',
                 'isVisible',
+                'campaign_id',
+                'active',
             ],
             'properties' => [
                 'isVisible' => [
@@ -799,6 +801,12 @@ class FunctionalTest extends WebTestCase
                 ],
                 'publicField' => [
                     'type' => 'string',
+                ],
+                'campaign_id' => [
+                    'type' => 'integer',
+                ],
+                'active' => [
+                    'type' => 'boolean',
                 ],
             ],
         ], json_decode(($model = $this->getModel('PrivateProtectedExposure'))->toJson(), true));


### PR DESCRIPTION
## Description

Fixes the bug introduced in https://github.com/nelmio/NelmioApiDocBundle/issues/1756 to properly handle private/protected properties. 

This fix should now also ensure that snake_case properties are properly described & ensures that any properties that is named like an accessor (e.g. `$isActive`) gets described.

```php
// Property `isMyDtoSupported` named like an accessor would not be described
class MyDto {
    public bool $isMyDtoSupported;
  
    public function isMyDtoSupported(): bool
    {
        return $this->isMyDtoSupported;
    }
}
```

Closes https://github.com/nelmio/NelmioApiDocBundle/issues/2361, Closes https://github.com/nelmio/NelmioApiDocBundle/issues/1843, Closes https://github.com/nelmio/NelmioApiDocBundle/issues/1592

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)