### PR TITLE
chore(gitattributes): exclude dev configs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,11 @@
 .* export-ignore
 *.md export-ignore
-tests export-ignore
+
+codecov.yml export-ignore
 docs export-ignore
-phpunit export-ignore
+phpstan.dist.neon export-ignore
+phpstan-baseline.neon export-ignore
+phpunit-ignore.txt export-ignore
 phpunit.xml.dist export-ignore
+tests export-ignore
 utils export-ignore


### PR DESCRIPTION
## Description

Add gitattributes to exclude files from the packaged version:
- phpstan.dist.neon
- phpstan-baseline.neon
- codecov.yml

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [x] I have made corresponding changes to the documentation (`docs/`):  not needed