### PR TITLE
fix(composer): conflict for symfony/property-info versions

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 $finder = (new PhpCsFixer\Finder())
     ->in(__DIR__)
     ->exclude('var')
+    ->notName('reference.php')
     ->exclude('tests/Functional/cache')
     ->exclude('tests/Functional/ModelDescriber/Fixtures')
     ->notContains('ChoiceConstraintsWithPHP85StaticCallbackEntity');

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,8 @@
         "willdurand/negotiation": "^3.0"
     },
     "conflict": {
-        "zircote/swagger-php": "4.8.7 || 5.5.0"
+        "zircote/swagger-php": "4.8.7 || 5.5.0",
+        "symfony/property-info": "6.4.32 || 7.3.10 || 7.4.4 || 8.0.4"
     },
     "suggest": {
         "api-platform/core": "For using an API oriented framework.",

--- a/tests/Functional/ModelDescriber/ObjectModelDescriberTypeInfoTest.php
+++ b/tests/Functional/ModelDescriber/ObjectModelDescriberTypeInfoTest.php
@@ -90,46 +90,6 @@ final class ObjectModelDescriberTypeInfoTest extends ObjectModelDescriberTest
     }
 
     /**
-     * @dataProvider provideInvalidTypes
-     */
-    public function testInvalidType(object $class, string $expectedType, string $propertyName): void
-    {
-        $model = new Model(Type::object($class::class));
-        $schema = new OA\Schema([
-            'type' => 'object',
-        ]);
-
-        self::expectException(\Exception::class);
-        self::expectExceptionMessage(\sprintf('Type "%s" is not supported in %s::%s. You may need to use the `#[OA\Property(type="")]` attribute to specify it manually.', $expectedType, $class::class, $propertyName));
-
-        $this->modelDescriber->describe($model, $schema);
-    }
-
-    public static function provideInvalidTypes(): \Generator
-    {
-        yield 'never' => [
-            new class {
-                public function getNever(): never
-                {
-                    throw new \Exception('This method should never be called');
-                }
-            },
-            'never',
-            '$never',
-        ];
-
-        yield 'void' => [
-            new class {
-                public function getVoid(): void
-                {
-                }
-            },
-            'void',
-            '$void',
-        ];
-    }
-
-    /**
      * `symfony/type-info 7.3.3` changed the string representation of list from `array<int, T>` to `list<T>`.
      *
      * This causes a change in the order of the types in a union type, which in turn changes the generated schema.


### PR DESCRIPTION
## Description

See issue in https://github.com/symfony/symfony/issues/63179

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)