### PR TITLE
fix: LegacyType deprecation warning in Configuration

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3,14 +3,20 @@ parameters:
 		-
 			message: '#^Call to function method_exists\(\) with ''Symfony\\\\Component\\\\PropertyInfo\\\\PropertyInfoExtractor'' and ''getType'' will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
-			count: 1
+			count: 2
 			path: src/DependencyInjection/Configuration.php
 
 		-
 			message: '#^Call to function method_exists\(\) with ''Symfony\\\\Component\\\\PropertyInfo\\\\PropertyInfoExtractor'' and ''getType'' will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
-			count: 1
+			count: 2
 			path: tests/DependencyInjection/ConfigurationTest.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''Symfony\\\\Component\\\\PropertyInfo\\\\PropertyInfoExtractor'' and ''getType'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: tests/Functional/ControllerTest.php
 
 		-
 			message: '#^Only booleans are allowed in an if condition, mixed given\.$#'

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -16,7 +16,7 @@ use Nelmio\ApiDocBundle\Render\Html\AssetsMode;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
-use Symfony\Component\PropertyInfo\Type as LegacyType;
+use Symfony\Component\TypeInfo\Type as TypeInfoType;
 
 final class Configuration implements ConfigurationInterface
 {
@@ -30,13 +30,13 @@ final class Configuration implements ConfigurationInterface
             ->children()
                 ->booleanNode('type_info')
                     ->info('Use the symfony/type-info component for determining types.')
-                    ->defaultValue(static fn (): bool => !class_exists(LegacyType::class))
+                    ->defaultValue(static fn (): bool => class_exists(TypeInfoType::class) && method_exists(PropertyInfoExtractor::class, 'getType'))
                     ->validate()
                         ->ifTrue(static fn ($v) => true === $v && !method_exists(PropertyInfoExtractor::class, 'getType'))
                         ->thenInvalid('The type_info option requires Symfony 7 or higher. Please upgrade Symfony or set type_info to false.')
                     ->end()
                     ->validate()
-                        ->ifTrue(static fn ($v) => false === $v && !class_exists(LegacyType::class))
+                        ->ifTrue(static fn ($v) => false === $v && !class_exists('Symfony\Component\PropertyInfo\Type'))
                         ->thenInvalid('The type_info option cannot be set to false on Symfony 8 or higher. Please set type_info to true.')
                     ->end()
                 ->end()

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\PropertyInfo\Type as LegacyType;
 use Symfony\Component\TypeInfo\Type as TypeInfoType;
 
 class ConfigurationTest extends TestCase
@@ -263,7 +264,7 @@ class ConfigurationTest extends TestCase
             ];
         }
 
-        if (!class_exists('Symfony\Component\PropertyInfo\Type')) {
+        if (!class_exists(LegacyType::class)) {
             yield 'type_info cannot be false with Symfony 8 or higher' => [
                 [
                     'type_info' => false,

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
-use Symfony\Component\PropertyInfo\Type as LegacyType;
+use Symfony\Component\TypeInfo\Type as TypeInfoType;
 
 class ConfigurationTest extends TestCase
 {
@@ -263,7 +263,7 @@ class ConfigurationTest extends TestCase
             ];
         }
 
-        if (!class_exists(LegacyType::class)) {
+        if (!class_exists('Symfony\Component\PropertyInfo\Type')) {
             yield 'type_info cannot be false with Symfony 8 or higher' => [
                 [
                     'type_info' => false,
@@ -381,7 +381,7 @@ class ConfigurationTest extends TestCase
         $config = $this->processor->processConfiguration(new Configuration(), []);
 
         self::assertSame(
-            !class_exists(LegacyType::class),
+            class_exists(TypeInfoType::class) && method_exists(PropertyInfoExtractor::class, 'getType'),
             $config['type_info']
         );
     }

--- a/tests/Functional/ControllerTest.php
+++ b/tests/Functional/ControllerTest.php
@@ -22,8 +22,9 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Kernel;
-use Symfony\Component\PropertyInfo\Type as LegacyType;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+use Symfony\Component\TypeInfo\Type as TypeInfoType;
 
 /**
  * Fairly intensive functional tests because the Kernel is recreated for each test.
@@ -120,7 +121,7 @@ final class ControllerTest extends WebTestCase
 
         yield 'MapQueryString' => [
             'MapQueryStringController',
-            class_exists(LegacyType::class) ? 'MapQueryStringController' : 'MapQueryStringController-type_info',
+            class_exists(TypeInfoType::class) && method_exists(PropertyInfoExtractor::class, 'getType') ? 'MapQueryStringController-type_info' : 'MapQueryStringController',
             [],
             [
                 // Enable serializer
@@ -155,7 +156,7 @@ final class ControllerTest extends WebTestCase
 
         yield 'https://github.com/nelmio/NelmioApiDocBundle/issues/2191' => [
             'MapQueryStringController',
-            class_exists(LegacyType::class) ? 'cleanup-components' : 'cleanup-components-type_info',
+            class_exists(TypeInfoType::class) && method_exists(PropertyInfoExtractor::class, 'getType') ? 'cleanup-components-type_info' : 'cleanup-components',
             [],
             [
                 // Enable serializer


### PR DESCRIPTION
## Summary

- Check for the presence of `Symfony\Component\TypeInfo\Type` instead of the absence of the deprecated `Symfony\Component\PropertyInfo\Type` to avoid triggering a deprecation warning on Symfony 7.x
- Use `!method_exists(PropertyInfoExtractor::class, 'getTypes')` to reliably detect Symfony 8+ for the validation that prevents setting `type_info: false`

Fixes #2677