### PR TITLE
fix: Count constraint uses minProperties/maxProperties for maps

### DIFF
--- a/src/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
+++ b/src/ModelDescriber/Annotations/SymfonyConstraintAnnotationReader.php
@@ -97,11 +97,20 @@ class SymfonyConstraintAnnotationReader
             } elseif ($attribute instanceof Assert\Regex) {
                 $this->appendPattern($property, $attribute->getHtmlPattern());
             } elseif ($attribute instanceof Assert\Count) {
-                if (isset($attribute->min)) {
-                    $property->minItems = $attribute->min;
-                }
-                if (isset($attribute->max)) {
-                    $property->maxItems = $attribute->max;
+                if ('object' === $property->type) {
+                    if (isset($attribute->min)) {
+                        $property->minProperties = $attribute->min;
+                    }
+                    if (isset($attribute->max)) {
+                        $property->maxProperties = $attribute->max;
+                    }
+                } else {
+                    if (isset($attribute->min)) {
+                        $property->minItems = $attribute->min;
+                    }
+                    if (isset($attribute->max)) {
+                        $property->maxItems = $attribute->max;
+                    }
                 }
             } elseif ($attribute instanceof Assert\Choice) {
                 $this->applyEnumFromChoiceConstraint($property, $attribute, $reflection);

--- a/tests/ModelDescriber/Annotations/AnnotationReaderTest.php
+++ b/tests/ModelDescriber/Annotations/AnnotationReaderTest.php
@@ -25,11 +25,8 @@ class AnnotationReaderTest extends TestCase
 {
     use SetsContextTrait;
 
-    /**
-     * @param object $entity
-     */
     #[DataProvider('provideProperty')]
-    public function testProperty($entity): void
+    public function testProperty(object $entity): void
     {
         $baseProps = ['_context' => new Context()];
 

--- a/tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
+++ b/tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
@@ -267,6 +267,35 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
     /**
      * @param object $entity
      */
+    #[DataProvider('provideCountConstraintSetsMinMaxPropertiesForObjectType')]
+    public function testCountConstraintSetsMinMaxPropertiesForObjectType($entity): void
+    {
+        $schema = $this->createObj(OA\Schema::class, []);
+        $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
+        $schema->properties[0]->type = 'object';
+
+        $symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader();
+        $symfonyConstraintAnnotationReader->setSchema($schema);
+
+        $symfonyConstraintAnnotationReader->updateProperty(new \ReflectionProperty($entity, 'property1'), $schema->properties[0]);
+
+        self::assertSame(1, $schema->properties[0]->minProperties);
+        self::assertSame(10, $schema->properties[0]->maxProperties);
+        self::assertSame(Generator::UNDEFINED, $schema->properties[0]->minItems);
+        self::assertSame(Generator::UNDEFINED, $schema->properties[0]->maxItems);
+    }
+
+    public static function provideCountConstraintSetsMinMaxPropertiesForObjectType(): \Generator
+    {
+        yield 'Attributes' => [new class {
+            #[Assert\Count(min: 1, max: 10)]
+            public $property1;
+        }];
+    }
+
+    /**
+     * @param object $entity
+     */
     #[DataProvider('provideRangeConstraintDoesNotSetMaximumIfMaxIsNotSet')]
     public function testRangeConstraintDoesNotSetMaximumIfMaxIsNotSet($entity): void
     {

--- a/tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
+++ b/tests/ModelDescriber/Annotations/SymfonyConstraintAnnotationReaderTest.php
@@ -48,11 +48,8 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         self::assertEquals($schema->required, ['property1', 'property2']);
     }
 
-    /**
-     * @param object $entity
-     */
     #[DataProvider('provideOptionalProperty')]
-    public function testOptionalProperty($entity): void
+    public function testOptionalProperty(object $entity): void
     {
         $schema = $this->createObj(OA\Schema::class, []);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
@@ -79,11 +76,8 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         }];
     }
 
-    /**
-     * @param object $entity
-     */
     #[DataProvider('provideAssertChoiceResultsInNumericArray')]
-    public function testAssertChoiceResultsInNumericArray($entity): void
+    public function testAssertChoiceResultsInNumericArray(object $entity): void
     {
         $schema = $this->createObj(OA\Schema::class, []);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
@@ -111,11 +105,8 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         }];
     }
 
-    /**
-     * @param object $entity
-     */
     #[DataProvider('provideMultipleChoiceConstraintsApplyEnumToItems')]
-    public function testMultipleChoiceConstraintsApplyEnumToItems($entity): void
+    public function testMultipleChoiceConstraintsApplyEnumToItems(object $entity): void
     {
         $schema = $this->createObj(OA\Schema::class, []);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
@@ -137,11 +128,8 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         }];
     }
 
-    /**
-     * @param object $entity
-     */
     #[DataProvider('provideLengthConstraintDoesNotSetMaxLengthIfMaxIsNotSet')]
-    public function testLengthConstraintDoesNotSetMaxLengthIfMaxIsNotSet($entity): void
+    public function testLengthConstraintDoesNotSetMaxLengthIfMaxIsNotSet(object $entity): void
     {
         $schema = $this->createObj(OA\Schema::class, []);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
@@ -163,11 +151,8 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         }];
     }
 
-    /**
-     * @param object $entity
-     */
     #[DataProvider('provideLengthConstraintDoesNotSetMinLengthIfMinIsNotSet')]
-    public function testLengthConstraintDoesNotSetMinLengthIfMinIsNotSet($entity): void
+    public function testLengthConstraintDoesNotSetMinLengthIfMinIsNotSet(object $entity): void
     {
         $schema = $this->createObj(OA\Schema::class, []);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
@@ -212,11 +197,8 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         self::assertTrue($schema->properties[0]->exclusiveMaximum);
     }
 
-    /**
-     * @param object $entity
-     */
     #[DataProvider('provideCountConstraintDoesNotSetMinItemsIfMinIsNotSet')]
-    public function testCountConstraintDoesNotSetMinItemsIfMinIsNotSet($entity): void
+    public function testCountConstraintDoesNotSetMinItemsIfMinIsNotSet(object $entity): void
     {
         $schema = $this->createObj(OA\Schema::class, []);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
@@ -238,11 +220,8 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         }];
     }
 
-    /**
-     * @param object $entity
-     */
     #[DataProvider('provideCountConstraintDoesNotSetMaxItemsIfMaxIsNotSet')]
-    public function testCountConstraintDoesNotSetMaxItemsIfMaxIsNotSet($entity): void
+    public function testCountConstraintDoesNotSetMaxItemsIfMaxIsNotSet(object $entity): void
     {
         $schema = $this->createObj(OA\Schema::class, []);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
@@ -264,11 +243,8 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         }];
     }
 
-    /**
-     * @param object $entity
-     */
     #[DataProvider('provideCountConstraintSetsMinMaxPropertiesForObjectType')]
-    public function testCountConstraintSetsMinMaxPropertiesForObjectType($entity): void
+    public function testCountConstraintSetsMinMaxPropertiesForObjectType(object $entity): void
     {
         $schema = $this->createObj(OA\Schema::class, []);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
@@ -293,11 +269,8 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         }];
     }
 
-    /**
-     * @param object $entity
-     */
     #[DataProvider('provideRangeConstraintDoesNotSetMaximumIfMaxIsNotSet')]
-    public function testRangeConstraintDoesNotSetMaximumIfMaxIsNotSet($entity): void
+    public function testRangeConstraintDoesNotSetMaximumIfMaxIsNotSet(object $entity): void
     {
         $schema = $this->createObj(OA\Schema::class, []);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);
@@ -319,11 +292,8 @@ class SymfonyConstraintAnnotationReaderTest extends TestCase
         }];
     }
 
-    /**
-     * @param object $entity
-     */
     #[DataProvider('provideRangeConstraintDoesNotSetMinimumIfMinIsNotSet')]
-    public function testRangeConstraintDoesNotSetMinimumIfMinIsNotSet($entity): void
+    public function testRangeConstraintDoesNotSetMinimumIfMinIsNotSet(object $entity): void
     {
         $schema = $this->createObj(OA\Schema::class, []);
         $schema->merge([$this->createObj(OA\Property::class, ['property' => 'property1'])]);


### PR DESCRIPTION
## Summary

- When a schema has type `object` (e.g. `array<string, Y>` maps), the `Count` constraint now correctly sets `minProperties`/`maxProperties` instead of `minItems`/`maxItems`, per the OpenAPI specification
- Schemas with type `array` continue using `minItems`/`maxItems` as before

Fixes #2578