### PR TITLE
fix: `#[MapRequestPayload]` & `#[MapUploadedFile]` combined on same route

### DIFF
--- a/src/Processor/MapRequestPayloadProcessor.php
+++ b/src/Processor/MapRequestPayloadProcessor.php
@@ -65,6 +65,29 @@ final class MapRequestPayloadProcessor
 
             foreach ($formats as $format) {
                 if (!Generator::isDefault($requestBody->content)) {
+                    $multipartMediaType = $this->findMultipartFormData($requestBody);
+
+                    if (null !== $multipartMediaType) {
+                        $existingSchema = Util::getChild($multipartMediaType, OA\Schema::class);
+
+                        if (!Generator::isDefault($existingSchema->properties)) {
+                            $fileSchema = new OA\Schema([
+                                '_context' => Util::createWeakContext($existingSchema->_context),
+                                'type' => 'object',
+                                'properties' => $existingSchema->properties,
+                            ]);
+
+                            $refSchema = new OA\Schema([
+                                '_context' => Util::createWeakContext($existingSchema->_context),
+                                'ref' => $modelRef,
+                            ]);
+
+                            $existingSchema->properties = Generator::UNDEFINED; /* @phpstan-ignore-line */
+                            $existingSchema->type = Generator::UNDEFINED;
+                            $existingSchema->allOf = [$refSchema, $fileSchema];
+                        }
+                    }
+
                     continue;
                 }
 
@@ -86,6 +109,21 @@ final class MapRequestPayloadProcessor
                 }
             }
         }
+    }
+
+    private function findMultipartFormData(OA\RequestBody $requestBody): ?OA\MediaType
+    {
+        if (Generator::isDefault($requestBody->content)) {
+            return null;
+        }
+
+        foreach ($requestBody->content as $mediaType) {
+            if ($mediaType instanceof OA\MediaType && 'multipart/form-data' === $mediaType->mediaType) {
+                return $mediaType;
+            }
+        }
+
+        return null;
     }
 
     private function getContentSchemaForType(OA\RequestBody $requestBody, string $type): OA\Schema

--- a/tests/Functional/Controller/MapUploadedFileWithRequestPayloadController.php
+++ b/tests/Functional/Controller/MapUploadedFileWithRequestPayloadController.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
+
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\Article81;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+use Symfony\Component\HttpKernel\Attribute\MapUploadedFile;
+use Symfony\Component\Routing\Attribute\Route;
+
+class MapUploadedFileWithRequestPayloadController
+{
+    #[Route('/article_upload_with_payload', methods: ['POST'])]
+    #[OA\Response(response: '200', description: '')]
+    public function uploadWithPayload(
+        #[MapRequestPayload(acceptFormat: 'json')]
+        Article81 $article81,
+        #[MapUploadedFile]
+        UploadedFile $upload,
+    ): void {
+    }
+}

--- a/tests/Functional/ControllerTest.php
+++ b/tests/Functional/ControllerTest.php
@@ -329,6 +329,40 @@ final class ControllerTest extends WebTestCase
             yield 'Symfony 7.1 MapUploadedFile attribute' => [
                 'MapUploadedFileController',
             ];
+
+            yield 'MapUploadedFile combined with MapRequestPayload' => [
+                'MapUploadedFileWithRequestPayloadController',
+                null,
+                [],
+                [
+                    'framework' => [
+                        'property_info' => [
+                            'enabled' => true,
+                        ],
+                        'serializer' => [
+                            'enabled' => true,
+                            'enable_attributes' => true,
+                        ],
+                        'validation' => [
+                            'enabled' => true,
+                            'enable_attributes' => true,
+                            'static_method' => [
+                                'loadValidatorMetadata',
+                            ],
+                            'translation_domain' => 'validators',
+                            'email_validation_mode' => 'html5',
+                            'mapping' => [
+                                'paths' => [],
+                            ],
+                            'not_compromised_password' => [
+                                'enabled' => true,
+                                'endpoint' => null,
+                            ],
+                            'auto_mapping' => [],
+                        ],
+                    ],
+                ],
+            ];
         }
 
         yield 'https://github.com/nelmio/NelmioApiDocBundle/issues/2224' => [

--- a/tests/Functional/Fixtures/MapUploadedFileWithRequestPayloadController.json
+++ b/tests/Functional/Fixtures/MapUploadedFileWithRequestPayloadController.json
@@ -1,0 +1,102 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "",
+        "version": "0.0.0"
+    },
+    "paths": {
+        "/article_upload_with_payload": {
+            "post": {
+                "operationId": "post_nelmio_apidoc_tests_functional_mapuploadedfilewithrequestpayload_uploadwithpayload",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Article81"
+                                    },
+                                    {
+                                        "properties": {
+                                            "upload": {
+                                                "type": "string",
+                                                "format": "binary"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "ArticleType81": {
+                "type": "string",
+                "enum": [
+                    "draft",
+                    "final"
+                ]
+            },
+            "ArticleType81IntBacked": {
+                "type": "integer",
+                "enum": [
+                    0,
+                    1
+                ]
+            },
+            "ArticleType81NotBacked": {
+                "required": [
+                    "name"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "Article81": {
+                "required": [
+                    "id",
+                    "type",
+                    "intBackedType",
+                    "notBackedType"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ArticleType81"
+                    },
+                    "intBackedType": {
+                        "$ref": "#/components/schemas/ArticleType81IntBacked"
+                    },
+                    "notBackedType": {
+                        "$ref": "#/components/schemas/ArticleType81NotBacked"
+                    },
+                    "nullableType": {
+                        "nullable": true,
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/ArticleType81"
+                            }
+                        ]
+                    }
+                },
+                "type": "object"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2672

When a controller uses both `#[MapRequestPayload]` and `#[MapUploadedFile]` on the same action, only the file upload properties appeared in the OpenAPI documentation — the DTO properties from `MapRequestPayload` were lost.

**Root cause**: In `MapRequestPayloadProcessor::__invoke()`, when `$requestBody->content` is already set (by `SymfonyMapUploadedFileDescriber` which creates the `multipart/form-data` schema), the processor does `continue` and never adds the model ref for the DTO.

**Fix**: Instead of skipping entirely when content exists, detect if a `multipart/form-data` media type with file properties is present. If so, merge the DTO reference via `allOf`:

```json
{
  "multipart/form-data": {
    "schema": {
      "allOf": [
        { "$ref": "#/components/schemas/MyDto" },
        {
          "type": "object",
          "properties": {
            "upload": { "type": "string", "format": "binary" }
          }
        }
      ]
    }
  }
}
```