### PR TITLE
fix: exclude BackedEnum from TranslatablePropertyDescriber

### DIFF
--- a/src/PropertyDescriber/TranslatablePropertyDescriber.php
+++ b/src/PropertyDescriber/TranslatablePropertyDescriber.php
@@ -29,6 +29,7 @@ final class TranslatablePropertyDescriber implements PropertyDescriberInterface
     {
         return 1 === \count($types)
             && Type::BUILTIN_TYPE_OBJECT === $types[0]->getBuiltinType()
-            && is_a($types[0]->getClassName(), TranslatableInterface::class, true);
+            && is_a($types[0]->getClassName(), TranslatableInterface::class, true)
+            && !is_subclass_of($types[0]->getClassName(), \BackedEnum::class);
     }
 }

--- a/src/TypeDescriber/ClassDescriber.php
+++ b/src/TypeDescriber/ClassDescriber.php
@@ -55,7 +55,9 @@ final class ClassDescriber implements TypeDescriberInterface, ModelRegistryAware
             return;
         }
 
-        if (is_a($type->getClassName(), TranslatableInterface::class, true)) {
+        if (is_a($type->getClassName(), TranslatableInterface::class, true)
+            && !is_subclass_of($type->getClassName(), \BackedEnum::class)
+        ) {
             $schema->type = 'string';
 
             return;

--- a/tests/Functional/ModelDescriber/Fixtures/TranslatedInvoice.json
+++ b/tests/Functional/ModelDescriber/Fixtures/TranslatedInvoice.json
@@ -16,7 +16,7 @@
             "type": "string"
         },
         "type": {
-            "type": "string"
+            "$ref": "#/components/schemas/InvoiceType"
         }
     },
     "type": "object"

--- a/tests/PropertyDescriber/TranslatablePropertyDescriberTest.php
+++ b/tests/PropertyDescriber/TranslatablePropertyDescriberTest.php
@@ -15,6 +15,7 @@ use Nelmio\ApiDocBundle\PropertyDescriber\TranslatablePropertyDescriber;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Type as LegacyType;
 use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class TranslatablePropertyDescriberTest extends TestCase
 {
@@ -32,6 +33,15 @@ class TranslatablePropertyDescriberTest extends TestCase
         $describer = new TranslatablePropertyDescriber();
 
         self::assertTrue($describer->supports([$type]));
+    }
+
+    public function testDoesNotSupportBackedEnumImplementingTranslatable(): void
+    {
+        $type = new LegacyType(LegacyType::BUILTIN_TYPE_OBJECT, false, TranslatableBackedEnum::class);
+
+        $describer = new TranslatablePropertyDescriber();
+
+        self::assertFalse($describer->supports([$type]));
     }
 
     public function testSupportsNoIntPropertyType(): void
@@ -65,5 +75,16 @@ class TranslatablePropertyDescriberTest extends TestCase
     private function initProperty(): \OpenApi\Annotations\Property
     {
         return new \OpenApi\Attributes\Property(); // union types, used in schema attribute require PHP >= 8.0.0
+    }
+}
+
+enum TranslatableBackedEnum: string implements TranslatableInterface
+{
+    case Foo = 'foo';
+    case Bar = 'bar';
+
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        return $translator->trans($this->value, locale: $locale);
     }
 }


### PR DESCRIPTION
## Summary

- When a `BackedEnum` implements `TranslatableInterface`, the `TranslatablePropertyDescriber` was matching first and forcing `type: string`, losing the enum values
- Added `!is_subclass_of(..., \BackedEnum::class)` check in `supports()` to let the enum describer handle these cases
- This is consistent with Symfony's serializer which prioritizes `BackedEnumNormalizer` (-915) over `TranslatableNormalizer` (-920)

Fixes #2507