### PR TITLE
fix: prevent nullable from triggering oneOf wrapping in JMSModelDescriber

### DIFF
--- a/src/ModelDescriber/JMSModelDescriber.php
+++ b/src/ModelDescriber/JMSModelDescriber.php
@@ -361,7 +361,10 @@ class JMSModelDescriber implements ModelDescriberInterface, ModelRegistryAwareIn
             $modelRef = $this->modelRegistry->register($model);
 
             $customFields = (array) $property->jsonSerialize();
-            unset($customFields['property']);
+            unset(
+                $customFields['property'],
+                $customFields['nullable'],
+            );
             if ([] === $customFields) { // no custom fields
                 $property->ref = $modelRef;
             } else {

--- a/tests/Functional/Entity/JMSUser.php
+++ b/tests/Functional/Entity/JMSUser.php
@@ -13,6 +13,7 @@ namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
 
 use JMS\Serializer\Annotation as Serializer;
 use OpenApi\Attributes as OA;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * User.
@@ -94,6 +95,11 @@ class JMSUser
     #[Serializer\Type(User::class)]
     #[Serializer\Expose]
     private $bestFriend;
+
+    #[Serializer\Type(User::class)]
+    #[Serializer\Expose]
+    #[Assert\NotNull]
+    private ?User $notNullFriend = null;
 
     /**
      * Whether this user is enabled or disabled.

--- a/tests/Functional/Fixtures/JmsOptOutController.json
+++ b/tests/Functional/Fixtures/JmsOptOutController.json
@@ -130,6 +130,9 @@
                     "best_friend": {
                         "$ref": "#/components/schemas/User"
                     },
+                    "not_null_friend": {
+                        "$ref": "#/components/schemas/User"
+                    },
                     "status": {
                         "title": "Whether this user is enabled or disabled.",
                         "description": "Only enabled users may be used in actions.",

--- a/tests/Functional/Fixtures/JmsOptOutController.json
+++ b/tests/Functional/Fixtures/JmsOptOutController.json
@@ -61,6 +61,9 @@
             "VirtualTypeClassDoesNotExistsHandlerDefined": {},
             "VirtualTypeClassDoesNotExistsHandlerNotDefined": {},
             "JMSUser": {
+                "required": [
+                    "not_null_friend"
+                ],
                 "properties": {
                     "id": {
                         "title": "userid",

--- a/tests/Functional/JMSFunctionalTest.php
+++ b/tests/Functional/JMSFunctionalTest.php
@@ -218,6 +218,7 @@ class JMSFunctionalTest extends WebTestCase
                     'type' => 'integer',
                 ],
             ],
+            'required' => ['not_null_friend'],
             'schema' => 'JMSUser',
         ], json_decode($this->getModel('JMSUser')->toJson(), true));
 

--- a/tests/Functional/JMSFunctionalTest.php
+++ b/tests/Functional/JMSFunctionalTest.php
@@ -143,6 +143,9 @@ class JMSFunctionalTest extends WebTestCase
                 'best_friend' => [
                     '$ref' => '#/components/schemas/User',
                 ],
+                'not_null_friend' => [
+                    '$ref' => '#/components/schemas/User',
+                ],
                 'status' => [
                     'type' => 'string',
                     'title' => 'Whether this user is enabled or disabled.',


### PR DESCRIPTION
## Summary

- When a JMS property has a `#[Assert\NotNull]` constraint, `SymfonyConstraintAnnotationReader` sets `nullable=false` on the OA property. This caused `jsonSerialize()` to return a non-empty `$customFields` array, which triggered unnecessary `oneOf` wrapping instead of a simple `$ref`
- Exclude `nullable` from the custom fields check (like `property` is already excluded), restoring the correct `$ref` output
- Added a test with a `#[Assert\NotNull]` property on `JMSUser` to prevent regression

Fixes #2565