### PR TITLE
feat: add support for zircote/swagger-php 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "symfony/property-info": "^6.4 || ^7.2 || ^8.0",
         "symfony/routing": "^6.4 || ^7.2 || ^8.0",
         "symfony/type-info": "^7.2 || ^8.0",
-        "zircote/swagger-php": "^4.11.1 || ^5.0"
+        "zircote/swagger-php": "^4.11.1 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "api-platform/core": "^3.2 || ^4.0",


### PR DESCRIPTION
## Summary

- Add `^6.0` to the `zircote/swagger-php` version constraint in `composer.json`

swagger-php 6.0 has been released with OpenAPI 3.2 support. The APIs removed in 6.0 (`Generator::scan()`, `getProcessors()`, `setProcessors()`, `Utils::finder()`) are **not** used by this bundle. The APIs we rely on (`Generator::UNDEFINED`, `Generator::isDefault()`, `Generator::$context`, `getProcessorPipeline()`) are all preserved in 6.x.

This is a one-line change — no source code modifications needed.

Closes #2673