### PR TITLE
fix: ArrayDescriber splitting arrayKey() union into anyOf [array, object]

### DIFF
--- a/src/TypeDescriber/ArrayDescriber.php
+++ b/src/TypeDescriber/ArrayDescriber.php
@@ -14,6 +14,7 @@ namespace Nelmio\ApiDocBundle\TypeDescriber;
 use OpenApi\Annotations\Schema;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\Type\CollectionType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
 
 /**
  * @implements TypeDescriberInterface<CollectionType>
@@ -28,6 +29,31 @@ final class ArrayDescriber implements TypeDescriberInterface, TypeDescriberAware
     {
         if (!$type->getCollectionKeyType() instanceof Type\UnionType) {
             throw new \LogicException('This describer only supports '.CollectionType::class.' with '.Type\UnionType::class.' as key type.');
+        }
+
+        // When the key type is arrayKey() (int|string union), the collection has
+        // no explicit key type (e.g. `array<T>` in PHPDoc). Treat as a JSON array
+        // rather than splitting into anyOf: [array, object].
+        $keyTypes = $type->getCollectionKeyType()->getTypes();
+        if (2 === \count($keyTypes)
+            && $keyTypes[0] instanceof Type\BuiltinType
+            && $keyTypes[1] instanceof Type\BuiltinType
+            && self::isArrayKeyUnion($keyTypes[0]->getTypeIdentifier(), $keyTypes[1]->getTypeIdentifier())
+        ) {
+            // When a Traversable object is used as a generic parameter
+            // (e.g. `list<MyTraversableClass>`), StringTypeResolver wraps it in
+            // CollectionType(ObjectType) with no key/value type info. Unwrap it
+            // so ClassDescriber can create a proper $ref.
+            $wrappedType = $type->getWrappedType();
+            if ($wrappedType instanceof Type\ObjectType) {
+                $this->describer->describe($wrappedType, $schema, $context);
+
+                return;
+            }
+
+            $this->describer->describe(Type::list($type->getCollectionValueType()), $schema, $context);
+
+            return;
         }
 
         $arrayTypes = array_map(
@@ -46,5 +72,15 @@ final class ArrayDescriber implements TypeDescriberInterface, TypeDescriberAware
     {
         return $type instanceof CollectionType
             && $type->getCollectionKeyType() instanceof Type\UnionType;
+    }
+
+    /**
+     * Checks whether two type identifiers form an arrayKey() union (int|string),
+     * regardless of which order TypeInfo emits them.
+     */
+    private static function isArrayKeyUnion(TypeIdentifier $a, TypeIdentifier $b): bool
+    {
+        return (TypeIdentifier::INT === $a && TypeIdentifier::STRING === $b)
+            || (TypeIdentifier::STRING === $a && TypeIdentifier::INT === $b);
     }
 }

--- a/tests/Functional/Controller/JMSController.php
+++ b/tests/Functional/Controller/JMSController.php
@@ -132,8 +132,7 @@ class JMSController
         response: 200,
         description: 'Success',
         content: new Model(type: Article81::class)
-    )
-    ]
+    )]
     public function enum(): void
     {
     }
@@ -143,8 +142,7 @@ class JMSController
         response: 200,
         description: 'Success',
         content: new Model(type: JMSAbstractUser::class)
-    )
-    ]
+    )]
     public function discriminatorMapAction(): void
     {
     }
@@ -154,8 +152,7 @@ class JMSController
         response: 200,
         description: 'Success',
         content: new Model(type: JMSEnum::class)
-    )
-    ]
+    )]
     public function enumArrayAction(): void
     {
     }
@@ -165,8 +162,7 @@ class JMSController
         response: 200,
         description: 'Success',
         content: new Model(type: JMSIgnoredProperty::class)
-    )
-    ]
+    )]
     public function ignoredProperty(): void
     {
     }

--- a/tests/Functional/Fixtures/GenericTypesController.json
+++ b/tests/Functional/Fixtures/GenericTypesController.json
@@ -126,20 +126,10 @@
                         }
                     },
                     "array": {
-                        "oneOf": [
-                            {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            {
-                                "type": "object",
-                                "additionalProperties": {
-                                    "type": "string"
-                                }
-                            }
-                        ]
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "list": {
                         "type": "array",
@@ -164,20 +154,10 @@
                         }
                     },
                     "array": {
-                        "oneOf": [
-                            {
-                                "type": "array",
-                                "items": {
-                                    "type": "integer"
-                                }
-                            },
-                            {
-                                "type": "object",
-                                "additionalProperties": {
-                                    "type": "integer"
-                                }
-                            }
-                        ]
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
                     },
                     "list": {
                         "type": "array",
@@ -202,20 +182,10 @@
                         }
                     },
                     "array": {
-                        "oneOf": [
-                            {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/RegularClass"
-                                }
-                            },
-                            {
-                                "type": "object",
-                                "additionalProperties": {
-                                    "$ref": "#/components/schemas/RegularClass"
-                                }
-                            }
-                        ]
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RegularClass"
+                        }
                     },
                     "list": {
                         "type": "array",

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -1164,19 +1164,9 @@ class FunctionalTest extends WebTestCase
                     'type' => 'array',
                     'items' => [],
                 ] : [
-                    'oneOf' => [
-                        [
-                            'type' => 'array',
-                            'items' => [
-                                'nullable' => true,
-                            ],
-                        ],
-                        [
-                            'type' => 'object',
-                            'additionalProperties' => [
-                                'nullable' => true,
-                            ],
-                        ],
+                    'type' => 'array',
+                    'items' => [
+                        'nullable' => true,
                     ],
                 ],
                 'moreThings' => [

--- a/tests/Functional/ModelDescriber/Fixtures/TypeInfo/ArrayMixedKeys.json
+++ b/tests/Functional/ModelDescriber/Fixtures/TypeInfo/ArrayMixedKeys.json
@@ -4,20 +4,10 @@
     ],
     "properties": {
         "mixedArray": {
-            "oneOf": [
-                {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                },
-                {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "integer"
-                    }
-                }
-            ]
+            "type": "array",
+            "items": {
+                "type": "integer"
+            }
         }
     },
     "type": "object"

--- a/tests/Functional/ModelDescriber/Fixtures/TypeInfo/ArrayOfInt.json
+++ b/tests/Functional/ModelDescriber/Fixtures/TypeInfo/ArrayOfInt.json
@@ -6,36 +6,16 @@
     ],
     "properties": {
         "untypedArray": {
-            "oneOf": [
-                {
-                    "type": "array",
-                    "items": {
-                        "nullable": true
-                    }
-                },
-                {
-                    "type": "object",
-                    "additionalProperties": {
-                        "nullable": true
-                    }
-                }
-            ]
+            "type": "array",
+            "items": {
+                "nullable": true
+            }
         },
         "arrayOfIntegers": {
-            "oneOf": [
-                {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                },
-                {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "integer"
-                    }
-                }
-            ]
+            "type": "array",
+            "items": {
+                "type": "integer"
+            }
         },
         "listOfIntegers": {
             "type": "array",

--- a/tests/Functional/ModelDescriber/Fixtures/TypeInfo/ArrayOfString.json
+++ b/tests/Functional/ModelDescriber/Fixtures/TypeInfo/ArrayOfString.json
@@ -6,36 +6,16 @@
     ],
     "properties": {
         "untypedArray": {
-            "oneOf": [
-                {
-                    "type": "array",
-                    "items": {
-                        "nullable": true
-                    }
-                },
-                {
-                    "type": "object",
-                    "additionalProperties": {
-                        "nullable": true
-                    }
-                }
-            ]
+            "type": "array",
+            "items": {
+                "nullable": true
+            }
         },
         "arrayOfStrings": {
-            "oneOf": [
-                {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                }
-            ]
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
         },
         "listOfStrings": {
             "type": "array",

--- a/tests/TypeDescriber/ArrayDescriberTest.php
+++ b/tests/TypeDescriber/ArrayDescriberTest.php
@@ -12,6 +12,7 @@
 namespace Nelmio\ApiDocBundle\Tests\TypeDescriber;
 
 use Nelmio\ApiDocBundle\TypeDescriber\ArrayDescriber;
+use Nelmio\ApiDocBundle\TypeDescriber\TypeDescriberInterface;
 use OpenApi\Annotations\Schema;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\TypeInfo\Type;
@@ -46,5 +47,47 @@ class ArrayDescriberTest extends TestCase
         yield [Type::array(Type::int(), Type::string())];
         yield [Type::list()];
         yield [Type::dict()];
+    }
+
+    /**
+     * When the key type is arrayKey() (int|string union), the describer should
+     * treat the collection as a list rather than splitting into anyOf [array, object].
+     */
+    public function testArrayKeyUnionIsTreatedAsList(): void
+    {
+        $innerDescriber = $this->createMock(TypeDescriberInterface::class);
+        $innerDescriber->expects(self::once())
+            ->method('describe')
+            ->with(self::callback(static function (Type $type): bool {
+                // Should delegate a list(string) — i.e. CollectionType with int key and string value
+                return $type instanceof CollectionType
+                    && $type->isList()
+                    && 'string' === (string) $type->getCollectionValueType();
+            }));
+
+        $this->describer->setDescriber($innerDescriber);
+
+        // array<string> is resolved by TypeInfo as CollectionType with arrayKey() union key
+        $type = Type::array(Type::string());
+        $this->describer->describe($type, new Schema([]));
+    }
+
+    /**
+     * When a Traversable object is auto-wrapped in CollectionType(ObjectType),
+     * the describer should unwrap it and delegate the ObjectType directly.
+     */
+    public function testTraversableObjectIsUnwrapped(): void
+    {
+        $objectType = Type::object(\ArrayObject::class);
+        // Simulate what StringTypeResolver does: wrap in CollectionType(ObjectType)
+        $collectionType = new CollectionType($objectType);
+
+        $innerDescriber = $this->createMock(TypeDescriberInterface::class);
+        $innerDescriber->expects(self::once())
+            ->method('describe')
+            ->with(self::identicalTo($objectType));
+
+        $this->describer->setDescriber($innerDescriber);
+        $this->describer->describe($collectionType, new Schema([]));
     }
 }


### PR DESCRIPTION
## Problem

When Symfony's TypeInfo resolves `array<T>` (single generic parameter, no explicit key type), the key defaults to `arrayKey()` — a `union(int, string)`. `ArrayDescriber` splits this into separate `array<int, T>` and `array<string, T>` types, producing an incorrect OpenAPI schema:

```json
{
  "anyOf": [
    { "type": "array", "items": { "$ref": "#/components/schemas/MyDto" } },
    { "type": "object", "additionalProperties": { "$ref": "#/components/schemas/MyDto" } }
  ]
}
```

The correct output should be just `{ "type": "array", "items": { "$ref": "#/components/schemas/MyDto" } }`, since `array<T>` in PHP — especially in the context of JSON API responses — means a sequential array (JSON array), not "either array or object".

### Traversable objects as generic parameters

When a `Traversable` object is used as a generic parameter (e.g. `list<MyIterableClass>`), `StringTypeResolver` wraps it in `CollectionType(ObjectType)` with no key/value type info. `ArrayDescriber` then describes this as `array<unknown>` (because `getCollectionValueType()` returns `mixed()`), losing the type reference entirely.

The fix detects when the wrapped type is an `ObjectType` (meaning `StringTypeResolver` auto-wrapped a Traversable class) and delegates to the chain so `ClassDescriber` can create a proper `$ref`.

## Reproduction

```php
final class EventDTO
{
    /** @var RefereeDTO[] */
    public array $referees;
}
```

With `type_info: true` (Symfony ≥ 7.3), the `referees` property schema includes both `array` and `object` types instead of just `array`.

## Relation to #2508

Issue #2508 reported two symptoms:

1. **`type_info: false`**: `"items": {}` (empty, no type info) — this was caused by `ConstructorExtractor` not reading `@var` on promoted constructor properties, and was fixed upstream in Symfony 7.4 (symfony/symfony#60795).
2. **`type_info: true`**: `"oneOf": [{ "type": "array" }, { "type": "object" }]` — this is the `ArrayDescriber` issue fixed by this PR. Even with Symfony 7.4, once TypeInfo correctly reads the type, `ArrayDescriber` still splits the `arrayKey()` union into `anyOf: [array, object]`.

This PR fixes the remaining symptom 2 from #2508.