### PR TITLE
refactor: update ObjectModelDescriber to handle symfony 8

### DIFF
--- a/src/ModelDescriber/ObjectModelDescriber.php
+++ b/src/ModelDescriber/ObjectModelDescriber.php
@@ -23,7 +23,6 @@ use OpenApi\Generator;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\Type as LegacyType;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
-use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\Type\ObjectType;
@@ -38,12 +37,12 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
     private PropertyDescriberInterface|TypeDescriberInterface $propertyDescriber;
     /** @var string[] */
     private array $mediaTypes;
-    /** @var (NameConverterInterface&AdvancedNameConverterInterface)|null */
+    /** @var NameConverterInterface|null */
     private ?NameConverterInterface $nameConverter;
     private bool $useValidationGroups;
 
     /**
-     * @param (NameConverterInterface&AdvancedNameConverterInterface)|null $nameConverter
+     * @param NameConverterInterface|null $nameConverter
      * @param string[]                                                     $mediaTypes
      */
     public function __construct(

--- a/src/ModelDescriber/ObjectModelDescriber.php
+++ b/src/ModelDescriber/ObjectModelDescriber.php
@@ -150,7 +150,11 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
             if ($this->propertyDescriber instanceof TypeDescriberInterface) {
                 $types = $this->propertyInfo->getType($class, $propertyName);
             } else {
-                $types = $this->propertyInfo->getTypes($class, $propertyName);
+                if (method_exists($this->propertyInfo, 'getTypes')) {
+                    $types = $this->propertyInfo->getTypes($class, $propertyName);
+                } else {
+                    $types = $this->propertyInfo->getType($class, $propertyName);
+                }
             }
 
             if (null === $types) {
@@ -175,8 +179,8 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
 
         $camelProp = $this->camelize($propertyName);
         foreach (['', 'get', 'is', 'has', 'can', 'add', 'remove', 'set'] as $prefix) {
-            if ($reflClass->hasMethod($prefix.$camelProp)) {
-                $reflections[] = $reflClass->getMethod($prefix.$camelProp);
+            if ($reflClass->hasMethod($prefix . $camelProp)) {
+                $reflections[] = $reflClass->getMethod($prefix . $camelProp);
             }
         }
 
@@ -240,7 +244,9 @@ class ObjectModelDescriber implements ModelDescriberInterface, ModelRegistryAwar
 
     public function supports(Model $model): bool
     {
-        return $model->getTypeInfo() instanceof ObjectType
-            && (class_exists($model->getTypeInfo()->getClassName()) || interface_exists($model->getTypeInfo()->getClassName()));
+        $type = $model->getTypeInfo();
+
+        return $type instanceof ObjectType
+            && (class_exists($type->getClassName()) || interface_exists($type->getClassName()));
     }
 }


### PR DESCRIPTION
## Description

Removed `AdvancedNameConverterInterface` reference. This class was removed in Symfony 8 (see [upgrade guide](https://github.com/symfony/symfony/blob/8.1/UPGRADE-8.0.md))
Refactor usage of `getTypes` to `getType`.
## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [x] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI