### PR TITLE
ci(ui): file generation on node 22

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -21,7 +21,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
       - uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
+          node-version: '22.x'
       - run: yarn install
       - name: Swagger UI
         run: yarn run swagger


### PR DESCRIPTION
## Description

dependabot PR's are currently failing to update the files in CI:

```
Run yarn install
yarn install v1.22.22
info No lockfile found.
[1/4] Resolving packages...
warning @stoplight/elements > react-query > match-sorter@6.4.0: This was arguably a breaking change. Not in API, but more results can be returned. Upgrade to the next major when you are ready for that
warning @stoplight/elements > react-query > broadcast-channel > rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
warning @stoplight/elements > @stoplight/http-spec > postman-collection > @faker-js/faker@5.5.3: Please update to a newer version.
warning @stoplight/elements > @stoplight/mosaic > @fortawesome/react-fontawesome@0.2.6: v0.2.x is no longer supported. Unless you are still using FontAwesome 5, please update to v3.1.1 or greater.
warning @stoplight/elements > @stoplight/elements-core > @stoplight/mosaic-code-editor > @fortawesome/react-fontawesome@0.2.6: v0.2.x is no longer supported. Unless you are still using FontAwesome 5, please update to v3.1.1 or greater.
warning @stoplight/elements > @stoplight/elements-core > @stoplight/mosaic-code-viewer > @fortawesome/react-fontawesome@0.2.6: v0.2.x is no longer supported. Unless you are still using FontAwesome 5, please update to v3.1.1 or greater.
warning @stoplight/elements > @stoplight/mosaic > lodash.get@4.4.2: This package is deprecated. Use the optional chaining (?.) operator instead.
warning @stoplight/elements > @stoplight/elements-core > @stoplight/mosaic-code-editor > lodash.get@4.4.2: This package is deprecated. Use the optional chaining (?.) operator instead.
warning @stoplight/elements > @stoplight/elements-core > @stoplight/mosaic-code-viewer > lodash.get@4.4.2: This package is deprecated. Use the optional chaining (?.) operator instead.
warning @stoplight/elements > react-query > broadcast-channel > rimraf > glob@7.2.3: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
warning @stoplight/elements > @stoplight/elements-core > httpsnippet-lite > formdata-node > node-domexception@1.0.0: Use your platform's native DOMException instead
warning @stoplight/elements > react-query > broadcast-channel > rimraf > glob > inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
[2/4] Fetching packages...
error @scalar/api-reference@1.52.0: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.20.2"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: Process completed with exit code 1.
```

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [x] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)