### PR TITLE
feat: Add support for the query http method

### DIFF
--- a/src/OpenApiPhp/Util.php
+++ b/src/OpenApiPhp/Util.php
@@ -56,7 +56,7 @@ final class Util
      *
      * @var string[]
      */
-    public const OPERATIONS = ['get', 'post', 'put', 'patch', 'delete', 'options', 'head', 'trace'];
+    public const OPERATIONS = ['get', 'post', 'put', 'patch', 'delete', 'options', 'head', 'trace', 'query'];
 
     /**
      * Return an existing PathItem object from $api->paths[] having its member path set to $path.


### PR DESCRIPTION
## Description
I added the QUERY http method to list of allowed operations. query is already supported in swagger.

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [x] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)