### PR TITLE
[Docs] Add a missing reference link

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -46,3 +46,4 @@ or configure UI configuration, use the ``--html-config`` option.
 
 .. _`configure Swagger UI`: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
 .. _`configure Redocly`: https://redocly.com/docs/redoc/config/
+.. _`configure Stoplight`: https://docs.stoplight.io/


### PR DESCRIPTION
## Description

Fixes this:

```
Found invalid reference "configure Stoplight" in file "commands"
```

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [x] Documentation Update
- [ ] CI

## Checklist
- [x] I have made corresponding changes to the documentation (`docs/`)