### PR TITLE
docs: fix some minor issues

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -46,3 +46,4 @@ or configure UI configuration, use the ``--html-config`` option.
 
 .. _`configure Swagger UI`: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
 .. _`configure Redocly`: https://redocly.com/docs/redoc/config/
+.. _`configure Stoplight`: https://docs.stoplight.io/

--- a/docs/configuration_reference.rst
+++ b/docs/configuration_reference.rst
@@ -298,7 +298,7 @@ security
 **default**: ``[]``
 
 Defines the security scheme(s) to use for the area. See `authentication schemes`_ for more information and possible values.
-See the :ref:`security page <area-security-configuration>` for more information on how to configure security for your areas.
+See the :doc:`security page </security>` for more information on how to configure security for your areas.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Description

This is similar to #2735, but fixes another issue that only happens in 5.x branch:

```
Found invalid reference "area-security-configuration" in file "configuration_reference"
Found invalid reference "configure Stoplight" in file "commands"
```

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [x] Documentation Update
- [ ] CI

## Checklist
- [x] I have made corresponding changes to the documentation (`docs/`)