### PR TITLE
fix(config): root vendor extensions get ignored

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -67,6 +67,7 @@ final class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('documentation')
                     ->useAttributeAsKey('key')
+                    ->normalizeKeys(false)
                     ->info('The documentation used as base')
                     ->example(['info' => ['title' => 'My App']])
                     ->prototype('variable')->end()

--- a/tests/Functional/ControllerTest.php
+++ b/tests/Functional/ControllerTest.php
@@ -369,7 +369,7 @@ final class ControllerTest extends WebTestCase
             ];
         }
 
-        yield 'https://github.com/nelmio/NelmioApiDocBundle/issues/2224' => [
+        yield 'VendorExtension' => [
             null,
             'VendorExtension',
             [],
@@ -383,6 +383,20 @@ final class ControllerTest extends WebTestCase
                                 'test' => 'Test vendor extension',
                             ],
                             'x-build' => '#SomeCommitHash',
+                        ],
+                        'x-metadata' => [
+                            'test' => 'Test metadata vendor extension',
+                            'buildHash' => '#SomeCommitHash',
+                        ],
+                        'x-tagGroups' => [
+                            [
+                                'name' => 'Group 1',
+                                'tags' => ['tag1', 'tag2'],
+                            ],
+                            [
+                                'name' => 'Group 2',
+                                'tags' => ['tag3', 'tag4'],
+                            ],
                         ],
                         'components' => [
                             'schemas' => [

--- a/tests/Functional/Fixtures/.VendorExtension.json
+++ b/tests/Functional/Fixtures/.VendorExtension.json
@@ -9,6 +9,20 @@
             "test": "Test vendor extension"
         }
     },
+    "x-metadata": {
+        "test": "Test metadata vendor extension",
+        "buildHash": "#SomeCommitHash"
+    },
+    "x-tagGroups": [
+        {
+            "name": "Group 1",
+            "tags": ["tag1", "tag2"]
+        },
+        {
+            "name": "Group 2",
+            "tags": ["tag3", "tag4"]
+        }
+    ],
     "paths": {},
     "components": {
         "schemas": {


### PR DESCRIPTION
## Description

Fixes root extensions like `x-tagGroup` being normalized during config parsing to `x_tagGroup` causing it to be removed from the generated documentation.

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)