### PR TITLE
fix: collect alternative names before registering models to prevent a…

### DIFF
--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -74,7 +74,7 @@ final class ModelRegistry
         $this->api = $api;
         $this->logger = new NullLogger();
 
-        // Collect all alternative names to prevent first to prevent registering models
+        // Collect all alternative names to prevent first registering models
         // finding nested refererences before having a potential defined alternative name
         $models = [];
         foreach ($alternativeNames as $alternativeName => $criteria) {

--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -74,6 +74,9 @@ final class ModelRegistry
         $this->api = $api;
         $this->logger = new NullLogger();
 
+        // Collect all alternative names to prevent first to prevent registering models
+        // finding nested refererences before having a potential defined alternative name
+        $models = [];
         foreach ($alternativeNames as $alternativeName => $criteria) {
             $model = new Model(
                 LegacyTypeConverter::createType($criteria['type']),
@@ -81,9 +84,12 @@ final class ModelRegistry
                 $criteria['options'] ?? [],
                 $criteria['serializationContext'] ?? [],
             );
+            $models[] = $model;
 
             $this->alternativeNames[$model->getHash()] = $alternativeName;
+        }
 
+        foreach ($models as $model) {
             $this->register($model);
         }
     }


### PR DESCRIPTION
…uto-generated names when discovering nested models

## Description

Collect all alternativeName entries before actually registering their models, preventing early searches for nested Models.

Closes #2757

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)