### PR TITLE
fix(deps): require zircote/swagger-php >= 5.7.8 for the query method

### DIFF
--- a/.github/workflows/common/composer-install/action.yaml
+++ b/.github/workflows/common/composer-install/action.yaml
@@ -56,5 +56,5 @@ runs:
     - name: Install dependencies with Composer
       env:
         SYMFONY_REQUIRE: "${{ inputs.symfony-version }}.*"
-      run: composer update --no-interaction --no-progress ${{ inputs.composer-flags }}
+      run: composer update --no-interaction --no-progress --no-security-blocking ${{ inputs.composer-flags }}
       shell: bash

--- a/.github/workflows/common/composer-install/action.yaml
+++ b/.github/workflows/common/composer-install/action.yaml
@@ -56,5 +56,5 @@ runs:
     - name: Install dependencies with Composer
       env:
         SYMFONY_REQUIRE: "${{ inputs.symfony-version }}.*"
-      run: composer update --no-interaction --no-progress --no-security-blocking ${{ inputs.composer-flags }}
+      run: composer update --no-interaction --no-progress ${{ inputs.composer-flags }}
       shell: bash

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "symfony/property-info": "^6.4 || ^7.2 || ^8.0",
         "symfony/routing": "^6.4 || ^7.2 || ^8.0",
         "symfony/type-info": "^7.2 || ^8.0",
-        "zircote/swagger-php": "^4.11.1 || ^5.0 || ^6.0"
+        "zircote/swagger-php": "^5.7.8 || ^6.0"
     },
     "require-dev": {
         "api-platform/core": "^3.2 || ^4.0",
@@ -66,7 +66,6 @@
         "willdurand/negotiation": "^3.0"
     },
     "conflict": {
-        "zircote/swagger-php": "4.8.7 || 5.5.0",
         "symfony/property-info": "6.4.32 || 7.3.10 || 7.4.4 || 8.0.4"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/http-foundation": "^6.4 || ^7.2 || ^8.0",
         "symfony/http-kernel": "^6.4 || ^7.2 || ^8.0",
         "symfony/options-resolver": "^6.4 || ^7.2 || ^8.0",
-        "symfony/property-info": "^6.4 || ^7.2 || ^8.0",
+        "symfony/property-info": "^6.4.15 || ^7.2 || ^8.0",
         "symfony/routing": "^6.4 || ^7.2 || ^8.0",
         "symfony/type-info": "^7.2 || ^8.0",
         "zircote/swagger-php": "^5.7.8 || ^6.0"

--- a/composer.json
+++ b/composer.json
@@ -94,12 +94,7 @@
     },
     "config": {
         "lock": false,
-        "sort-packages": true,
-        "audit": {
-            "ignore": [
-                "PKSA-365x-2zjk-pt47"
-            ]
-        }
+        "sort-packages": true
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "zircote/swagger-php": "^5.7.8 || ^6.0"
     },
     "require-dev": {
-        "api-platform/core": "^3.2 || ^4.0",
+        "api-platform/core": "^3.4.6 || ^4.0.9",
         "doctrine/inflector": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.52",
         "friendsofsymfony/rest-bundle": "^3.2.0",
@@ -94,7 +94,12 @@
     },
     "config": {
         "lock": false,
-        "sort-packages": true
+        "sort-packages": true,
+        "policy": {
+            "advisories": {
+                "block": false
+            }
+        }
     },
     "extra": {
         "branch-alias": {

--- a/src/Describer/OpenApiPhpDescriber.php
+++ b/src/Describer/OpenApiPhpDescriber.php
@@ -138,7 +138,7 @@ final class OpenApiPhpDescriber
                     continue;
                 }
 
-                if ($annotation instanceof OA\Parameter && Generator::UNDEFINED === $annotation->name && null !== $annotation->_context?->property) {
+                if ($annotation instanceof OA\Parameter && Generator::UNDEFINED === $annotation->name && null !== $annotation->_context->property) {
                     $annotation->name = $annotation->_context->property;
                 }
 

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -1377,7 +1377,6 @@ class FunctionalTest extends WebTestCase
         self::assertCount(2, $securitySchemes);
 
         $basicAuthScheme = $securitySchemes[0];
-        self::assertInstanceOf(OAAnnotations\SecurityScheme::class, $basicAuthScheme);
         self::assertSame([
             'securityScheme' => 'basicAuth',
             'type' => 'http',
@@ -1385,7 +1384,6 @@ class FunctionalTest extends WebTestCase
         ], json_decode($basicAuthScheme->toJson(), true));
 
         $apiKeyAuthScheme = $securitySchemes[1];
-        self::assertInstanceOf(OAAnnotations\SecurityScheme::class, $apiKeyAuthScheme);
         self::assertSame([
             'securityScheme' => 'apiKeyAuth',
             'type' => 'apiKey',

--- a/tests/SwaggerPhp/UtilTest.php
+++ b/tests/SwaggerPhp/UtilTest.php
@@ -1041,17 +1041,6 @@ class UtilTest extends TestCase
         self::assertSame('NoContextModel', $schema->schema);
     }
 
-    public function testGetSchemaCreatesComponentsWhenOpenApiContextIsNull(): void
-    {
-        $api = self::createObj(OA\OpenApi::class, []);
-        $api->_context = null;
-
-        $schema = Util::getSchema($api, 'NullContextModel');
-
-        self::assertInstanceOf(OA\Components::class, $api->components);
-        self::assertSame('NullContextModel', $schema->schema);
-    }
-
     public function testGetSchemaCreatesComponentsUsingExistingOpenApiContext(): void
     {
         $existingContext = new Context(['fromExisting' => true]);

--- a/tests/SwaggerPhp/UtilTest.php
+++ b/tests/SwaggerPhp/UtilTest.php
@@ -99,7 +99,7 @@ class UtilTest extends TestCase
     {
         $info = Util::createChild($this->rootAnnotation, OA\Info::class);
 
-        self::assertInstanceOf(Context::class, $info->_context);
+        self::assertSame($this->rootAnnotation, $info->_context->nested);
     }
 
     public function testCreateChildHasNestedContext(): void


### PR DESCRIPTION
## Description

`Util::OPERATIONS` gained `'query'` in #2732, but PathItem only wires the Query operation as of swagger-php 5.7.8 / 6.0.0.

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)