### PR TITLE
fix(#2790): ReflectionReader only substitutes prefixes on methods

### DIFF
--- a/src/ModelDescriber/Annotations/ReflectionReader.php
+++ b/src/ModelDescriber/Annotations/ReflectionReader.php
@@ -45,13 +45,14 @@ final class ReflectionReader
         }
 
         $serializedName = $reflection->getName();
-        foreach (['get', 'is', 'has', 'can', 'add', 'remove', 'set'] as $prefix) {
-            if (str_starts_with($serializedName, $prefix)) {
-                $serializedName = substr($serializedName, \strlen($prefix));
-            }
-        }
 
         if ($reflection instanceof \ReflectionMethod) {
+            foreach (['get', 'is', 'has', 'can', 'add', 'remove', 'set'] as $prefix) {
+                if (str_starts_with($serializedName, $prefix)) {
+                    $serializedName = substr($serializedName, \strlen($prefix));
+                }
+            }
+
             $methodDefault = $this->getDefaultFromMethodReflection($reflection);
             if (Generator::UNDEFINED !== $methodDefault) {
                 if (null === $methodDefault) {

--- a/tests/Functional/Entity/EntityWithPromotedPropertiesWithDefaults.php
+++ b/tests/Functional/Entity/EntityWithPromotedPropertiesWithDefaults.php
@@ -25,6 +25,7 @@ class EntityWithPromotedPropertiesWithDefaults
         ?int $nullableNonPromotedPropertyWithDefault = null,
         public readonly int $nonNullablePromotedPropertyWithDefault = 4711,
         public readonly ?string $nullablePromotedPropertyWithDefault = null,
+        public readonly ?string $additionalNullablePromotedPropertyWithDefaultAndPrefix = null,
     ) {
         $this->nonNullableNonPromotedPropertyWithDefault = $nonNullableNonPromotedPropertyWithDefault;
     }

--- a/tests/Functional/Fixtures/PromotedPropertiesController81.defaults.json
+++ b/tests/Functional/Fixtures/PromotedPropertiesController81.defaults.json
@@ -41,6 +41,11 @@
                         "type": "string",
                         "nullable": true,
                         "default": null
+                    },
+                    "additionalNullablePromotedPropertyWithDefaultAndPrefix": {
+                        "type": "string",
+                        "nullable": true,
+                        "default": null
                     }
                 },
                 "type": "object"


### PR DESCRIPTION
## Description

`ReflectionReader` should not substitute prefixes on properties, only on methods.

Closes #2790

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [x] I have made corresponding changes to the documentation (`docs/`)