### PR TITLE
feat(type-describer): add stoppable type describer support

### DIFF
--- a/docs/customization/type_describer.rst
+++ b/docs/customization/type_describer.rst
@@ -1,7 +1,7 @@
 Type (Property) Customization
 =============================
 
-The bundle uses a various property describers to generate the OpenAPI
+The bundle uses various property describers to generate the OpenAPI
 schema for your properties. You can create your own property describer to
 customize how your properties are represented in the documentation.
 
@@ -17,7 +17,8 @@ your properties in a different way than the default describers do.
 
     Type describers are chained together and executed in order of their priority.
     If multiple describers support the same property type, they will combine their
-    generated schema.
+    generated schema. A describer can opt out of this and stop the chain; see
+    `Stopping the describer chain`_.
 
 .. important::
 
@@ -25,7 +26,7 @@ your properties in a different way than the default describers do.
     the bundle uses `Symfony's TypeInfo component <https://symfony.com/doc/current/components/type_info.html>`_
     for type detection. In this scenario, you **must** implement `TypeDescriberInterface`_
     instead of the `PropertyDescriberInterface`_ for custom type descriptions.
-    The `PropertyDescriberInterface`_  will **not** be used when ``type_info`` is enabled.
+    The `PropertyDescriberInterface`_ will **not** be used when ``type_info`` is enabled.
 
     The `TypeDescriberInterface`_ works similarly to the `PropertyDescriberInterface`_ but works with the
     ``Symfony\Component\TypeInfo\Type`` class.
@@ -72,14 +73,15 @@ You can create a custom type describer for this ``Currency`` class like this:
     namespace App\TypeDescriber;
 
     use App\ValueObject\Currency;
-    use Nelmio\ApiDocBundle\PropertyDescriber\TypeDescriberInterface;
+    use Nelmio\ApiDocBundle\TypeDescriber\StoppableTypeDescriberInterface;
     use OpenApi\Annotations\Schema;
     use Symfony\Component\TypeInfo\Type;
+    use Symfony\Component\TypeInfo\Type\ObjectType;
 
     /**
-     * @implements TypeDescriberInterface<ObjectType<Currency::class>>
+     * @implements StoppableTypeDescriberInterface<ObjectType>
      */
-    class CurrencyTypeDescriber implements TypeDescriberInterface
+    class CurrencyTypeDescriber implements StoppableTypeDescriberInterface
     {
         public function describe(Type $type, Schema $property, array $context = []): void
         {
@@ -90,16 +92,29 @@ You can create a custom type describer for this ``Currency`` class like this:
 
         public function supports(Type $type, array $context = []): bool
         {
-            return $type instanceof Type\ObjectType
+            return $type instanceof ObjectType
                 && Currency::class === $type->getClassName();
         }
     }
+
+This describer implements `StoppableTypeDescriberInterface`_ rather than
+`TypeDescriberInterface`_. That is deliberate: since ``Currency`` is a class,
+the built-in class describer would otherwise also run, registering a
+``Currency`` schema in ``components`` and pointing the property at it with a
+``$ref``, which conflicts with the ``type``, ``example``, and ``description``
+set above. See `Stopping the describer chain`_ below.
 
 Registering the custom Type Describer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you are using Symfony's default ``services.yaml`` configuration, your custom
 type describer will be automatically registered and tagged thanks to autoconfiguration!
+
+.. versionadded:: 5.12
+
+    Autoconfiguration of `TypeDescriberInterface`_ implementations was
+    introduced in NelmioApiDocBundle 5.12. In earlier versions, you had to tag
+    the service manually, as shown below.
 
 If you're not using ``autoconfigure`` or if you need to set a priority to make sure your describer runs before or after
 other describers, you can configure it manually in your ``services.yaml``:
@@ -118,22 +133,97 @@ other describers, you can configure it manually in your ``services.yaml``:
                     - { name: 'nelmio_api_doc.type_describer', priority: 100 }
 
     .. code-block:: php
+
         // config/services.php
         namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
         use App\TypeDescriber\CurrencyTypeDescriber;
 
-        return function(ContainerConfigurator $container) {
-            // ...
+        return function (ContainerConfigurator $container) {
+            $services = $container->services();
 
             // if you're using autoconfigure, the tag will be automatically applied
-            $services->set(App\TypeDescriber\CurrencyTypeDescriber::class)
+            $services->set(CurrencyTypeDescriber::class)
                 // register the type describer with a high priority (called earlier)
                 ->tag('nelmio_api_doc.type_describer', [
                     'priority' => 100,
                 ])
             ;
-    };
+        };
+
+Stopping the describer chain
+----------------------------
+
+.. versionadded:: 5.12
+
+    The `StoppableTypeDescriberInterface`_ was introduced in
+    NelmioApiDocBundle 5.12.
+
+By default, every describer that supports a type is executed in order of
+priority, and all of them contribute to the same ``Schema``. This is what
+allows the built-in nullable describer to add ``nullable: true`` on top of the
+schema produced by another describer.
+
+For a value object serialized as a scalar, this is usually not what you want.
+The built-in class describer supports *every* object type, so unless the
+chain is stopped it also runs after your own describer, registers a schema for
+your class in ``components``, and points the property at it with a ``$ref``.
+
+Implement `StoppableTypeDescriberInterface`_ to make your describer the last
+one to run for the types it supports:
+
+.. code-block:: php
+
+    use Nelmio\ApiDocBundle\TypeDescriber\StoppableTypeDescriberInterface;
+
+    class CurrencyTypeDescriber implements StoppableTypeDescriberInterface
+    {
+        // ...
+    }
+
+The interface extends `TypeDescriberInterface`_ and adds no methods; it only
+tells the chain to stop. Describers with a lower priority are not called for
+that type, and the property is documented inline instead of through a
+``$ref``:
+
+.. code-block:: json
+
+    {
+        "Money": {
+            "type": "object",
+            "properties": {
+                "cents": {
+                    "type": "integer"
+                },
+                "currency": {
+                    "type": "string",
+                    "example": "USD",
+                    "description": "A currency code represented as a string."
+                }
+            }
+        }
+    }
+
+.. caution::
+
+    Stopping the chain also stops the built-in nullable describer. A nullable
+    property such as ``?Currency`` resolves to a nullable type *wrapping* an
+    object type, not to an object type. A ``supports()`` method that only
+    matches ``ObjectType`` (like the example above) is therefore safe: the
+    nullable and union describers handle the wrapper first, and then call your
+    describer for the inner type.
+
+    If you broaden ``supports()`` to match the nullable wrapper as well, your
+    describer stops the chain before the nullable describer runs, and
+    ``nullable: true`` is silently lost. In that case, either set
+    ``$schema->nullable`` yourself or register your describer with a priority
+    lower than ``-950``.
+
+.. note::
+
+    Stoppable type describers only apply when the ``type_info`` option is
+    enabled. There is no equivalent for the legacy `PropertyDescriberInterface`_
+    path described below.
 
 Creating a custom Property Describer `(type_info: false)`
 ---------------------------------------------------------
@@ -222,6 +312,7 @@ other describers, you can configure it manually in your ``services.yaml``:
 
 Example Output
 --------------
+
 With the above describer examples, the generated ``components.schemas`` section
 will include the following definition for the ``Money`` model:
 
@@ -243,6 +334,7 @@ will include the following definition for the ``Money`` model:
                                 "example": "USD",
                                 "description": "A currency code represented as a string."
                             }
+                        }
                     }
                 }
             }
@@ -264,3 +356,4 @@ will include the following definition for the ``Money`` model:
 
 .. _PropertyDescriberInterface: https://github.com/nelmio/NelmioApiDocBundle/blob/5.x/src/PropertyDescriber/PropertyDescriberInterface.php
 .. _TypeDescriberInterface: https://github.com/nelmio/NelmioApiDocBundle/blob/5.x/src/TypeDescriber/TypeDescriberInterface.php
+.. _StoppableTypeDescriberInterface: https://github.com/nelmio/NelmioApiDocBundle/blob/5.x/src/TypeDescriber/StoppableTypeDescriberInterface.php

--- a/src/DependencyInjection/NelmioApiDocExtension.php
+++ b/src/DependencyInjection/NelmioApiDocExtension.php
@@ -33,6 +33,7 @@ use Nelmio\ApiDocBundle\RouteDescriber\RouteArgumentDescriber\SymfonyMapQueryStr
 use Nelmio\ApiDocBundle\RouteDescriber\RouteArgumentDescriber\SymfonyMapRequestPayloadDescriber;
 use Nelmio\ApiDocBundle\RouteDescriber\RouteArgumentDescriber\SymfonyMapUploadedFileDescriber;
 use Nelmio\ApiDocBundle\Routing\FilteredRouteCollectionBuilder;
+use Nelmio\ApiDocBundle\TypeDescriber\TypeDescriberInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -187,6 +188,10 @@ final class NelmioApiDocExtension extends Extension implements PrependExtensionI
         // Add autoconfiguration for model describer
         $container->registerForAutoconfiguration(ModelDescriberInterface::class)
             ->addTag('nelmio_api_doc.model_describer');
+
+        // Add autoconfiguration for type describer
+        $container->registerForAutoconfiguration(TypeDescriberInterface::class)
+            ->addTag('nelmio_api_doc.type_describer');
 
         // Import services needed for each library
         $loader->load('php_doc.php');

--- a/src/TypeDescriber/ChainDescriber.php
+++ b/src/TypeDescriber/ChainDescriber.php
@@ -50,6 +50,10 @@ final class ChainDescriber implements TypeDescriberInterface, ModelRegistryAware
 
             if ($describer->supports($type, $context)) {
                 $describer->describe($type, $schema, $context);
+
+                if ($describer instanceof StoppableTypeDescriberInterface) {
+                    return;
+                }
             }
         }
     }

--- a/src/TypeDescriber/StoppableTypeDescriberInterface.php
+++ b/src/TypeDescriber/StoppableTypeDescriberInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\TypeDescriber;
+
+use Symfony\Component\TypeInfo\Type;
+
+/**
+ * A type describer that stops the chain once it has described a type.
+ *
+ * @template T of Type
+ *
+ * @extends TypeDescriberInterface<T>
+ */
+interface StoppableTypeDescriberInterface extends TypeDescriberInterface
+{
+}

--- a/tests/DependencyInjection/NelmioApiDocExtensionTest.php
+++ b/tests/DependencyInjection/NelmioApiDocExtensionTest.php
@@ -12,6 +12,8 @@
 namespace Nelmio\ApiDocBundle\Tests\DependencyInjection;
 
 use Nelmio\ApiDocBundle\DependencyInjection\NelmioApiDocExtension;
+use Nelmio\ApiDocBundle\ModelDescriber\ModelDescriberInterface;
+use Nelmio\ApiDocBundle\TypeDescriber\TypeDescriberInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\TwigBundle\TwigBundle;
@@ -94,6 +96,22 @@ class NelmioApiDocExtensionTest extends TestCase
             }
         }
         self::assertTrue($foundMethodCall);
+    }
+
+    public function testDescriberInterfacesAreRegisteredForAutoconfiguration(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.bundles', []);
+        $extension = new NelmioApiDocExtension();
+        $extension->load([[]], $container);
+
+        $autoconfiguredInstanceof = $container->getAutoconfiguredInstanceof();
+
+        self::assertArrayHasKey(TypeDescriberInterface::class, $autoconfiguredInstanceof);
+        self::assertNotSame([], $autoconfiguredInstanceof[TypeDescriberInterface::class]->getTag('nelmio_api_doc.type_describer'));
+
+        self::assertArrayHasKey(ModelDescriberInterface::class, $autoconfiguredInstanceof);
+        self::assertNotSame([], $autoconfiguredInstanceof[ModelDescriberInterface::class]->getTag('nelmio_api_doc.model_describer'));
     }
 
     public function testMergesRootKeysFromMultipleConfigurations(): void

--- a/tests/Functional/ModelDescriber/Fixtures/TypeInfo/StoppableDescriberModel.json
+++ b/tests/Functional/ModelDescriber/Fixtures/TypeInfo/StoppableDescriberModel.json
@@ -1,0 +1,22 @@
+{
+    "required": [
+        "valueObject",
+        "valueObjects"
+    ],
+    "properties": {
+        "valueObject": {
+            "type": "string"
+        },
+        "nullableValueObject": {
+            "type": "string",
+            "nullable": true
+        },
+        "valueObjects": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    },
+    "type": "object"
+}

--- a/tests/Functional/ModelDescriber/Fixtures/TypeInfo/StoppableDescriberModel.php
+++ b/tests/Functional/ModelDescriber/Fixtures/TypeInfo/StoppableDescriberModel.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\ModelDescriber\Fixtures\TypeInfo;
+
+final class StoppableDescriberValueObject
+{
+    public function __construct(
+        public string $value,
+    ) {
+    }
+}
+
+final class StoppableDescriberModel
+{
+    public StoppableDescriberValueObject $valueObject;
+
+    public ?StoppableDescriberValueObject $nullableValueObject;
+
+    /**
+     * @var list<StoppableDescriberValueObject>
+     */
+    public array $valueObjects;
+}

--- a/tests/Functional/ModelDescriber/ObjectModelDescriberTest.php
+++ b/tests/Functional/ModelDescriber/ObjectModelDescriberTest.php
@@ -67,9 +67,12 @@ class ObjectModelDescriberTest extends WebTestCase
 
     public static function provideFixtures(): \Generator
     {
+        // Fixtures in Fixtures/TypeInfo only describe correctly through the TypeInfo
+        // component, they are provided by ObjectModelDescriberTypeInfoTest instead.
         $finder = new Finder();
         $entityFiles = $finder->files()
             ->in(__DIR__.'/Fixtures')
+            ->exclude('TypeInfo')
             ->name('*.php')
             ->sortByCaseInsensitiveName();
 

--- a/tests/Functional/ModelDescriber/StoppableValueObjectDescriber.php
+++ b/tests/Functional/ModelDescriber/StoppableValueObjectDescriber.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\ModelDescriber;
+
+use Nelmio\ApiDocBundle\Tests\Functional\ModelDescriber\Fixtures\TypeInfo\StoppableDescriberValueObject;
+use Nelmio\ApiDocBundle\TypeDescriber\StoppableTypeDescriberInterface;
+use OpenApi\Annotations\Schema;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\ObjectType;
+
+/**
+ * @implements StoppableTypeDescriberInterface<ObjectType>
+ */
+class StoppableValueObjectDescriber implements StoppableTypeDescriberInterface
+{
+    public function describe(Type $type, Schema $schema, array $context = []): void
+    {
+        $schema->type = 'string';
+    }
+
+    public function supports(Type $type, array $context = []): bool
+    {
+        return $type instanceof ObjectType
+            && StoppableDescriberValueObject::class === $type->getClassName();
+    }
+}

--- a/tests/Functional/TestKernel.php
+++ b/tests/Functional/TestKernel.php
@@ -23,6 +23,7 @@ use Nelmio\ApiDocBundle\Tests\Functional\Entity\NestedGroup\JMSPicture;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\PrivateProtectedExposure;
 use Nelmio\ApiDocBundle\Tests\Functional\Entity\SymfonyConstraintsWithValidationGroups;
 use Nelmio\ApiDocBundle\Tests\Functional\ModelDescriber\NameConverter;
+use Nelmio\ApiDocBundle\Tests\Functional\ModelDescriber\StoppableValueObjectDescriber;
 use Nelmio\ApiDocBundle\Tests\Functional\ModelDescriber\VirtualTypeClassDoesNotExistsHandlerDefinedDescriber;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
@@ -306,6 +307,10 @@ class TestKernel extends Kernel
         $def = new Definition(VirtualTypeClassDoesNotExistsHandlerDefinedDescriber::class);
         $def->addTag('nelmio_api_doc.model_describer');
         $c->setDefinition('nelmio.test.jms.virtual_type.describer', $def);
+
+        $def = new Definition(StoppableValueObjectDescriber::class);
+        $def->addTag('nelmio_api_doc.type_describer');
+        $c->setDefinition('nelmio.test.stoppable_value_object.type_describer', $def);
 
         $c->register('serializer.name_converter.custom', NameConverter::class)
             ->setDecoratedService('serializer.name_converter.metadata_aware')

--- a/tests/TypeDescriber/ChainDescriberTest.php
+++ b/tests/TypeDescriber/ChainDescriberTest.php
@@ -1,0 +1,226 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\TypeDescriber;
+
+use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
+use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareTrait;
+use Nelmio\ApiDocBundle\Model\ModelRegistry;
+use Nelmio\ApiDocBundle\OpenApiPhp\Util;
+use Nelmio\ApiDocBundle\TypeDescriber\ChainDescriber;
+use Nelmio\ApiDocBundle\TypeDescriber\NullableDescriber;
+use Nelmio\ApiDocBundle\TypeDescriber\StoppableTypeDescriberInterface;
+use Nelmio\ApiDocBundle\TypeDescriber\TypeDescriberAwareInterface;
+use Nelmio\ApiDocBundle\TypeDescriber\TypeDescriberAwareTrait;
+use Nelmio\ApiDocBundle\TypeDescriber\TypeDescriberInterface;
+use OpenApi\Annotations\OpenApi;
+use OpenApi\Annotations\Schema;
+use OpenApi\Generator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Type;
+
+class ChainDescriberTest extends TestCase
+{
+    /**
+     * Records the names of the describers that were invoked, in order.
+     *
+     * @var \ArrayObject<int, string>
+     */
+    private \ArrayObject $log;
+
+    protected function setUp(): void
+    {
+        $this->log = new \ArrayObject();
+    }
+
+    public function testDescribeRunsEveryMatchingDescriber(): void
+    {
+        $chain = new ChainDescriber([
+            $this->createDescriber('first'),
+            $this->createDescriber('notMatching', false),
+            $this->createDescriber('second'),
+        ]);
+
+        $chain->describe(Type::string(), new Schema([]));
+
+        self::assertSame(['first', 'second'], $this->log->getArrayCopy());
+    }
+
+    public function testDescribeStopsAfterAMatchingStoppableDescriber(): void
+    {
+        $chain = new ChainDescriber([
+            $this->createStoppableDescriber('stoppable'),
+            $this->createDescriber('later'),
+        ]);
+
+        $chain->describe(Type::string(), new Schema([]));
+
+        self::assertSame(['stoppable'], $this->log->getArrayCopy());
+    }
+
+    public function testDescribeDoesNotStopForANonMatchingStoppableDescriber(): void
+    {
+        $chain = new ChainDescriber([
+            $this->createStoppableDescriber('stoppable', false),
+            $this->createDescriber('later'),
+        ]);
+
+        $chain->describe(Type::string(), new Schema([]));
+
+        self::assertSame(['later'], $this->log->getArrayCopy());
+    }
+
+    public function testDescribeWithAStoppableDescriberLastBehavesLikeANonStoppableOne(): void
+    {
+        $chain = new ChainDescriber([
+            $this->createDescriber('first'),
+            $this->createStoppableDescriber('stoppable'),
+        ]);
+
+        $chain->describe(Type::string(), new Schema([]));
+
+        self::assertSame(['first', 'stoppable'], $this->log->getArrayCopy());
+    }
+
+    public function testDescribeCombinesANonStoppableDescriberWithTheNullableDescriber(): void
+    {
+        $chain = new ChainDescriber([
+            $this->createDescriber('describer'),
+            new NullableDescriber(),
+        ]);
+
+        $schema = new Schema([]);
+        $chain->describe(Type::nullable(Type::string()), $schema);
+
+        self::assertSame(['describer'], $this->log->getArrayCopy());
+        self::assertTrue($schema->nullable);
+    }
+
+    public function testDescribeWithAStoppableDescriberMatchingANullableTypeLosesNullable(): void
+    {
+        $chain = new ChainDescriber([
+            $this->createStoppableDescriber('stoppable'),
+            new NullableDescriber(),
+        ]);
+
+        $schema = new Schema([]);
+        $chain->describe(Type::nullable(Type::string()), $schema);
+
+        self::assertSame(['stoppable'], $this->log->getArrayCopy());
+        self::assertSame(Generator::UNDEFINED, $schema->nullable);
+    }
+
+    public function testSupportsReturnsTrueWhenOnlyALaterDescriberMatches(): void
+    {
+        $chain = new ChainDescriber([
+            $this->createDescriber('notMatching', false),
+            $this->createStoppableDescriber('matching'),
+        ]);
+
+        self::assertTrue($chain->supports(Type::string()));
+    }
+
+    public function testSupportsReturnsFalseWhenNoDescriberMatches(): void
+    {
+        $chain = new ChainDescriber([
+            $this->createDescriber('notMatching', false),
+            $this->createStoppableDescriber('alsoNotMatching', false),
+        ]);
+
+        self::assertFalse($chain->supports(Type::string()));
+    }
+
+    public function testSupportsReturnsFalseWithoutDescribers(): void
+    {
+        self::assertFalse((new ChainDescriber([]))->supports(Type::string()));
+    }
+
+    public function testDescribePropagatesTheModelRegistryAndTheChainItself(): void
+    {
+        $describer = new class implements TypeDescriberInterface, ModelRegistryAwareInterface, TypeDescriberAwareInterface {
+            use ModelRegistryAwareTrait;
+            use TypeDescriberAwareTrait;
+
+            public ?ModelRegistry $injectedModelRegistry = null;
+            public ?TypeDescriberInterface $injectedDescriber = null;
+
+            public function describe(Type $type, Schema $schema, array $context = []): void
+            {
+                $this->injectedModelRegistry = $this->modelRegistry;
+                $this->injectedDescriber = $this->describer;
+            }
+
+            public function supports(Type $type, array $context = []): bool
+            {
+                return true;
+            }
+        };
+
+        $modelRegistry = new ModelRegistry([], new OpenApi(['_context' => Util::createContext()]));
+
+        $chain = new ChainDescriber([$describer]);
+        $chain->setModelRegistry($modelRegistry);
+        $chain->describe(Type::string(), new Schema([]));
+
+        self::assertSame($modelRegistry, $describer->injectedModelRegistry);
+        self::assertSame($chain, $describer->injectedDescriber);
+    }
+
+    private function createDescriber(string $name, bool $supports = true): TypeDescriberInterface
+    {
+        return new class($this->log, $name, $supports) implements TypeDescriberInterface {
+            /**
+             * @param \ArrayObject<int, string> $log
+             */
+            public function __construct(
+                private \ArrayObject $log,
+                private string $name,
+                private bool $supports,
+            ) {
+            }
+
+            public function describe(Type $type, Schema $schema, array $context = []): void
+            {
+                $this->log[] = $this->name;
+            }
+
+            public function supports(Type $type, array $context = []): bool
+            {
+                return $this->supports;
+            }
+        };
+    }
+
+    private function createStoppableDescriber(string $name, bool $supports = true): StoppableTypeDescriberInterface
+    {
+        return new class($this->log, $name, $supports) implements StoppableTypeDescriberInterface {
+            /**
+             * @param \ArrayObject<int, string> $log
+             */
+            public function __construct(
+                private \ArrayObject $log,
+                private string $name,
+                private bool $supports,
+            ) {
+            }
+
+            public function describe(Type $type, Schema $schema, array $context = []): void
+            {
+                $this->log[] = $this->name;
+            }
+
+            public function supports(Type $type, array $context = []): bool
+            {
+                return $this->supports;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Description

`ChainDescriber` runs every describer that supports a type. Since the built-in `ClassDescriber` supports *every* object type, a custom describer for a value object can never be authoritative, `ClassDescriber` still adds a `$ref` afterwards, discarding the custom schema and leaking an internal class into `components`.

This adds a new interface `StoppableTypeDescriberInterface`. `ChainDescriber` stops iterating after invoking a describer that implements it, so the property is documented inline instead of through a `$ref`.

Also included:
- Autoconfiguration for `TypeDescriberInterface`, which the docs already claimed but was
  never registered.
- The `CurrencyTypeDescriber` docs example taught this exact broken pattern and imported
  from the wrong namespace; it now implements the marker interface and works as written.

Closes https://github.com/nelmio/NelmioApiDocBundle/issues/2768

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [x] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [x] Documentation Update
- [ ] CI

## Checklist
- [x] I have made corresponding changes to the documentation (`docs/`)