### PR TITLE
refactor(type-describer): extract uid, date-time and translatable describers

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -204,6 +204,10 @@ return static function (ContainerConfigurator $container) {
 
        ->set('nelmio_api_doc.type_describer.class', \Nelmio\ApiDocBundle\TypeDescriber\ClassDescriber::class)
            ->private()
+           ->tag('nelmio_api_doc.type_describer', ['priority' => -2000])
+
+       ->set('nelmio_api_doc.type_describer.date_time', \Nelmio\ApiDocBundle\TypeDescriber\DateTimeDescriber::class)
+           ->private()
            ->tag('nelmio_api_doc.type_describer', ['priority' => -1000])
 
        ->set('nelmio_api_doc.type_describer.dictionary', \Nelmio\ApiDocBundle\TypeDescriber\DictionaryDescriber::class)
@@ -253,6 +257,14 @@ return static function (ContainerConfigurator $container) {
        ->set('nelmio_api_doc.type_describer.template', \Nelmio\ApiDocBundle\TypeDescriber\TemplateDescriber::class)
            ->private()
            ->args([service('nelmio_api_doc.type_describer.chain')])
+           ->tag('nelmio_api_doc.type_describer', ['priority' => -1000])
+
+       ->set('nelmio_api_doc.type_describer.translatable', \Nelmio\ApiDocBundle\TypeDescriber\TranslatableDescriber::class)
+           ->private()
+           ->tag('nelmio_api_doc.type_describer', ['priority' => -1000])
+
+       ->set('nelmio_api_doc.type_describer.uid', \Nelmio\ApiDocBundle\TypeDescriber\UidDescriber::class)
+           ->private()
            ->tag('nelmio_api_doc.type_describer', ['priority' => -1000])
 
        ->set('nelmio_api_doc.type_describer.union', \Nelmio\ApiDocBundle\TypeDescriber\UnionDescriber::class)

--- a/src/TypeDescriber/ClassDescriber.php
+++ b/src/TypeDescriber/ClassDescriber.php
@@ -19,9 +19,6 @@ use OpenApi\Annotations\Schema;
 use OpenApi\Generator;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\Type\ObjectType;
-use Symfony\Component\Uid\AbstractUid;
-use Symfony\Component\Uid\Ulid;
-use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @implements TypeDescriberInterface<ObjectType>
@@ -34,35 +31,6 @@ final class ClassDescriber implements TypeDescriberInterface, ModelRegistryAware
 
     public function describe(Type $type, Schema $schema, array $context = []): void
     {
-        if (is_a($type->getClassName(), Ulid::class, true)) {
-            $schema->type = 'string';
-            $schema->format = 'ulid';
-
-            return;
-        }
-
-        if (is_a($type->getClassName(), AbstractUid::class, true)) {
-            $schema->type = 'string';
-            $schema->format = 'uuid';
-
-            return;
-        }
-
-        if (is_a($type->getClassName(), \DateTimeInterface::class, true)) {
-            $schema->type = 'string';
-            $schema->format = 'date-time';
-
-            return;
-        }
-
-        if (is_a($type->getClassName(), TranslatableInterface::class, true)
-            && !is_subclass_of($type->getClassName(), \BackedEnum::class)
-        ) {
-            $schema->type = 'string';
-
-            return;
-        }
-
         // Ensure that the schema gets describe in oneOf for nullable objects
         if (true === $schema->nullable) {
             $weakContext = Util::createWeakContext($schema->_context);

--- a/src/TypeDescriber/DateTimeDescriber.php
+++ b/src/TypeDescriber/DateTimeDescriber.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\TypeDescriber;
+
+use OpenApi\Annotations\Schema;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\ObjectType;
+
+/**
+ * @implements StoppableTypeDescriberInterface<ObjectType>
+ *
+ * @internal
+ */
+final class DateTimeDescriber implements StoppableTypeDescriberInterface
+{
+    public function describe(Type $type, Schema $schema, array $context = []): void
+    {
+        $schema->type = 'string';
+        $schema->format = 'date-time';
+    }
+
+    public function supports(Type $type, array $context = []): bool
+    {
+        return $type instanceof ObjectType
+            && is_a($type->getClassName(), \DateTimeInterface::class, true);
+    }
+}

--- a/src/TypeDescriber/TranslatableDescriber.php
+++ b/src/TypeDescriber/TranslatableDescriber.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\TypeDescriber;
+
+use OpenApi\Annotations\Schema;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\ObjectType;
+use Symfony\Contracts\Translation\TranslatableInterface;
+
+/**
+ * @implements StoppableTypeDescriberInterface<ObjectType>
+ *
+ * @internal
+ */
+final class TranslatableDescriber implements StoppableTypeDescriberInterface
+{
+    public function describe(Type $type, Schema $schema, array $context = []): void
+    {
+        $schema->type = 'string';
+    }
+
+    public function supports(Type $type, array $context = []): bool
+    {
+        return $type instanceof ObjectType
+            && is_a($type->getClassName(), TranslatableInterface::class, true)
+            && !is_subclass_of($type->getClassName(), \BackedEnum::class);
+    }
+}

--- a/src/TypeDescriber/UidDescriber.php
+++ b/src/TypeDescriber/UidDescriber.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\TypeDescriber;
+
+use OpenApi\Annotations\Schema;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\ObjectType;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\Ulid;
+
+/**
+ * @implements StoppableTypeDescriberInterface<ObjectType>
+ *
+ * @internal
+ */
+final class UidDescriber implements StoppableTypeDescriberInterface
+{
+    public function describe(Type $type, Schema $schema, array $context = []): void
+    {
+        $schema->type = 'string';
+        $schema->format = is_a($type->getClassName(), Ulid::class, true) ? 'ulid' : 'uuid';
+    }
+
+    public function supports(Type $type, array $context = []): bool
+    {
+        return $type instanceof ObjectType
+            && is_a($type->getClassName(), AbstractUid::class, true);
+    }
+}

--- a/tests/TypeDescriber/DateTimeDescriberTest.php
+++ b/tests/TypeDescriber/DateTimeDescriberTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\TypeDescriber;
+
+use Nelmio\ApiDocBundle\TypeDescriber\DateTimeDescriber;
+use OpenApi\Annotations\Schema;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\ObjectType;
+
+class DateTimeDescriberTest extends TestCase
+{
+    private DateTimeDescriber $describer;
+
+    protected function setUp(): void
+    {
+        $this->describer = new DateTimeDescriber();
+    }
+
+    /**
+     * @dataProvider provideSupportedTypes
+     *
+     * @param ObjectType $type
+     */
+    public function testSupports($type): void
+    {
+        self::assertTrue($this->describer->supports($type));
+    }
+
+    public static function provideSupportedTypes(): \Generator
+    {
+        yield 'immutable' => [Type::object(\DateTimeImmutable::class)];
+        yield 'mutable' => [Type::object(\DateTime::class)];
+        yield 'interface' => [Type::object(\DateTimeInterface::class)];
+    }
+
+    /**
+     * @dataProvider provideUnsupportedTypes
+     *
+     * @param ObjectType $type
+     */
+    public function testDoesNotSupport($type): void
+    {
+        self::assertFalse($this->describer->supports($type));
+    }
+
+    public static function provideUnsupportedTypes(): \Generator
+    {
+        yield 'plain class' => [Type::object(\stdClass::class)];
+        yield 'date interval' => [Type::object(\DateInterval::class)];
+    }
+
+    public function testDoesNotSupportNonObjectType(): void
+    {
+        /* @phpstan-ignore argument.type (the chain dispatches every type, not only object types) */
+        self::assertFalse($this->describer->supports(Type::string()));
+    }
+
+    public function testDescribe(): void
+    {
+        $schema = new Schema([]);
+
+        $this->describer->describe(Type::object(\DateTimeImmutable::class), $schema);
+
+        self::assertSame('string', $schema->type);
+        self::assertSame('date-time', $schema->format);
+    }
+}

--- a/tests/TypeDescriber/TranslatableDescriberTest.php
+++ b/tests/TypeDescriber/TranslatableDescriberTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\TypeDescriber;
+
+use Nelmio\ApiDocBundle\TypeDescriber\TranslatableDescriber;
+use OpenApi\Annotations\Schema;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\TranslatableMessage;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\ObjectType;
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class TranslatableDescriberTest extends TestCase
+{
+    private TranslatableDescriber $describer;
+
+    protected function setUp(): void
+    {
+        $this->describer = new TranslatableDescriber();
+    }
+
+    /**
+     * @dataProvider provideSupportedTypes
+     *
+     * @param ObjectType $type
+     */
+    public function testSupports($type): void
+    {
+        self::assertTrue($this->describer->supports($type));
+    }
+
+    public static function provideSupportedTypes(): \Generator
+    {
+        yield 'interface' => [Type::object(TranslatableInterface::class)];
+        yield 'message' => [Type::object(TranslatableMessage::class)];
+    }
+
+    /**
+     * @dataProvider provideUnsupportedTypes
+     *
+     * @param ObjectType $type
+     */
+    public function testDoesNotSupport($type): void
+    {
+        self::assertFalse($this->describer->supports($type));
+    }
+
+    public static function provideUnsupportedTypes(): \Generator
+    {
+        yield 'backed enum' => [Type::object(TranslatableStatus::class)];
+        yield 'plain class' => [Type::object(\stdClass::class)];
+    }
+
+    public function testDoesNotSupportNonObjectType(): void
+    {
+        /* @phpstan-ignore argument.type (the chain dispatches every type, not only object types) */
+        self::assertFalse($this->describer->supports(Type::string()));
+    }
+
+    public function testDescribe(): void
+    {
+        $schema = new Schema([]);
+
+        $this->describer->describe(Type::object(TranslatableMessage::class), $schema);
+
+        self::assertSame('string', $schema->type);
+    }
+}
+
+enum TranslatableStatus: string implements TranslatableInterface
+{
+    case Foo = 'foo';
+    case Bar = 'bar';
+
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        return $translator->trans($this->value, locale: $locale);
+    }
+}

--- a/tests/TypeDescriber/UidDescriberTest.php
+++ b/tests/TypeDescriber/UidDescriberTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\TypeDescriber;
+
+use Nelmio\ApiDocBundle\TypeDescriber\UidDescriber;
+use OpenApi\Annotations\Schema;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\ObjectType;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\UuidV4;
+
+class UidDescriberTest extends TestCase
+{
+    private UidDescriber $describer;
+
+    protected function setUp(): void
+    {
+        $this->describer = new UidDescriber();
+    }
+
+    /**
+     * @dataProvider provideSupportedTypes
+     *
+     * @param ObjectType $type
+     */
+    public function testSupports($type): void
+    {
+        self::assertTrue($this->describer->supports($type));
+    }
+
+    public static function provideSupportedTypes(): \Generator
+    {
+        yield 'ulid' => [Type::object(Ulid::class)];
+        yield 'uuid' => [Type::object(UuidV4::class)];
+        yield 'abstract uid' => [Type::object(AbstractUid::class)];
+    }
+
+    /**
+     * @dataProvider provideUnsupportedTypes
+     *
+     * @param ObjectType $type
+     */
+    public function testDoesNotSupport($type): void
+    {
+        self::assertFalse($this->describer->supports($type));
+    }
+
+    public static function provideUnsupportedTypes(): \Generator
+    {
+        yield 'plain class' => [Type::object(\stdClass::class)];
+        yield 'date time' => [Type::object(\DateTimeImmutable::class)];
+    }
+
+    public function testDoesNotSupportNonObjectType(): void
+    {
+        /* @phpstan-ignore argument.type (the chain dispatches every type, not only object types) */
+        self::assertFalse($this->describer->supports(Type::string()));
+    }
+
+    /**
+     * @dataProvider provideDescribedFormats
+     *
+     * @param ObjectType $type
+     */
+    public function testDescribe($type, string $expectedFormat): void
+    {
+        $schema = new Schema([]);
+
+        $this->describer->describe($type, $schema);
+
+        self::assertSame('string', $schema->type);
+        self::assertSame($expectedFormat, $schema->format);
+    }
+
+    public static function provideDescribedFormats(): \Generator
+    {
+        yield 'ulid' => [Type::object(Ulid::class), 'ulid'];
+        yield 'uuid' => [Type::object(UuidV4::class), 'uuid'];
+    }
+}


### PR DESCRIPTION
## Description

Refactors the `ClassDescriber` to no longer describe specific classes in a different way, now possible because of the `StoppableTypeDescriberInterface` introduced in https://github.com/nelmio/NelmioApiDocBundle/pull/2793

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [x] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)