### PR TITLE
ci(dependabot): fix missing commit prefix for releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,10 +15,16 @@ updates:
     schedule:
       interval: "weekly"
     versioning-strategy: increase
+    commit-message:
+      prefix: "chore"
+      include: "scope"
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
     groups:
       symfony:
         patterns:


### PR DESCRIPTION
## Description

Dependabot stopped making update PR's prefixed with `chore` causing them to not trigger `release-please` or mention them in changelog

https://github.com/nelmio/NelmioApiDocBundle/pull/2795

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [x] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)