### PR TITLE
fix(model-registry): reserve generated schema names against nested registrations

### DIFF
--- a/src/Model/ModelRegistry.php
+++ b/src/Model/ModelRegistry.php
@@ -212,7 +212,9 @@ final class ModelRegistry
             'schema'
         );
         $i = 1;
-        while (\in_array($name, $names, true)) {
+        // register() creates the schema only after recursively describing nested models,
+        // so a name already handed out to another model is not necessarily in $names yet.
+        while (\in_array($name, $names, true) || isset($this->registeredModelNames[$name])) {
             if (isset($this->registeredModelNames[$name])) {
                 $this->logger->info(\sprintf('Can not assign a name for the model, the name "%s" has already been taken.', $name), [
                     'model' => $this->modelToArray($model),

--- a/src/PropertyDescriber/PropertyDescriber.php
+++ b/src/PropertyDescriber/PropertyDescriber.php
@@ -41,17 +41,22 @@ final class PropertyDescriber implements PropertyDescriberInterface, ModelRegist
      */
     public function describe(array $types, OA\Schema $property, array $context = []): void
     {
-        if (null === $propertyDescriber = $this->getPropertyDescriber($types, $context)) {
+        $scope = $this->getScope($types, $property);
+
+        if (null === $propertyDescriber = $this->getPropertyDescriber($types, $context, $scope)) {
             return;
         }
 
-        $this->called[$this->getHash($types)][] = $propertyDescriber;
+        $this->called[$scope][] = $propertyDescriber;
         try {
             $propertyDescriber->describe($types, $property, $context);
         } finally {
-            // Always clear recursion state so a failed description cannot leak across requests
+            // Leave no recursion state behind, so a failed description cannot leak across requests
             // (FrankenPHP worker / long-lived processes).
-            $this->called = [];
+            array_pop($this->called[$scope]);
+            if ([] === $this->called[$scope]) {
+                unset($this->called[$scope]);
+            }
         }
     }
 
@@ -62,29 +67,31 @@ final class PropertyDescriber implements PropertyDescriberInterface, ModelRegist
 
     public function supports(array $types, array $context = []): bool
     {
-        return null !== $this->getPropertyDescriber($types, $context);
+        return null !== $this->getPropertyDescriber($types, $context, null);
     }
 
     /**
+     * A describer delegating back for the same types is only recursing while it does so for the
+     * same property. The same types on another property, such as the one a nested model of the
+     * very same class has, are a description of their own and start from the whole chain again.
+     *
      * @param Type[] $types
      */
-    private function getHash(array $types): string
+    private function getScope(array $types, OA\Schema $property): string
     {
-        return md5(serialize($types));
+        return spl_object_id($property).':'.md5(serialize($types));
     }
 
     /**
      * @param Type[]               $types
      * @param array<string, mixed> $context
      */
-    private function getPropertyDescriber(array $types, array $context): ?PropertyDescriberInterface
+    private function getPropertyDescriber(array $types, array $context, ?string $scope): ?PropertyDescriberInterface
     {
         foreach ($this->propertyDescribers as $propertyDescriber) {
             // Prevent infinite recursion
-            if (\array_key_exists($this->getHash($types), $this->called)) {
-                if (\in_array($propertyDescriber, $this->called[$this->getHash($types)], true)) {
-                    continue;
-                }
+            if (null !== $scope && \in_array($propertyDescriber, $this->called[$scope] ?? [], true)) {
+                continue;
             }
 
             if ($propertyDescriber instanceof ModelRegistryAwareInterface) {

--- a/tests/Functional/Controller/SelfReferencingContextController.php
+++ b/tests/Functional/Controller/SelfReferencingContextController.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Controller;
+
+use Nelmio\ApiDocBundle\Attribute\Model;
+use Nelmio\ApiDocBundle\Tests\Functional\Entity\EntityWithSelfReferencingContext;
+use OpenApi\Attributes as OA;
+use Symfony\Component\Routing\Attribute\Route;
+
+class SelfReferencingContextController
+{
+    #[OA\Response(
+        response: '200',
+        description: 'Success',
+        content: new Model(type: EntityWithSelfReferencingContext::class),
+    )]
+    #[Route('/self-referencing-context', methods: ['GET'])]
+    public function selfReferencingContextAction(): void
+    {
+    }
+}

--- a/tests/Functional/ControllerTest.php
+++ b/tests/Functional/ControllerTest.php
@@ -768,6 +768,40 @@ final class ControllerTest extends WebTestCase
                 ],
             ],
         ];
+
+        yield 'Context attribute on a self-referencing property' => [
+            'SelfReferencingContextController',
+            null,
+            [],
+            [
+                'framework' => [
+                    'property_info' => [
+                        'enabled' => true,
+                    ],
+                    'serializer' => [
+                        'enabled' => true,
+                        'enable_attributes' => true,
+                    ],
+                    'validation' => [
+                        'enabled' => true,
+                        'enable_attributes' => true,
+                        'static_method' => [
+                            'loadValidatorMetadata',
+                        ],
+                        'translation_domain' => 'validators',
+                        'email_validation_mode' => 'html5',
+                        'mapping' => [
+                            'paths' => [],
+                        ],
+                        'not_compromised_password' => [
+                            'enabled' => true,
+                            'endpoint' => null,
+                        ],
+                        'auto_mapping' => [],
+                    ],
+                ],
+            ],
+        ];
     }
 
     /**

--- a/tests/Functional/Entity/EntityWithSelfReferencingContext.php
+++ b/tests/Functional/Entity/EntityWithSelfReferencingContext.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the NelmioApiDocBundle package.
+ *
+ * (c) Nelmio
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nelmio\ApiDocBundle\Tests\Functional\Entity;
+
+use OpenApi\Attributes as OA;
+use Symfony\Component\Serializer\Attribute\Context;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+
+class EntityWithSelfReferencingContext
+{
+    #[OA\Property(
+        type: 'object',
+        additionalProperties: new OA\AdditionalProperties(type: 'array', items: new OA\Items(type: 'string')),
+    )]
+    public ?array $permissions = null;
+
+    #[Context([AbstractObjectNormalizer::ENABLE_MAX_DEPTH => true])]
+    public ?EntityWithSelfReferencingContext $parent = null;
+}

--- a/tests/Functional/Fixtures/SelfReferencingContextController.json
+++ b/tests/Functional/Fixtures/SelfReferencingContextController.json
@@ -1,0 +1,80 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "",
+        "version": "0.0.0"
+    },
+    "paths": {
+        "/self-referencing-context": {
+            "get": {
+                "operationId": "get_nelmio_apidoc_tests_functional_selfreferencingcontext_selfreferencingcontext",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EntityWithSelfReferencingContext"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "EntityWithSelfReferencingContext2": {
+                "required": [
+                    "permissions"
+                ],
+                "properties": {
+                    "permissions": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "parent": {
+                        "nullable": true,
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/EntityWithSelfReferencingContext2"
+                            }
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "EntityWithSelfReferencingContext": {
+                "required": [
+                    "permissions"
+                ],
+                "properties": {
+                    "permissions": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "parent": {
+                        "nullable": true,
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/EntityWithSelfReferencingContext2"
+                            }
+                        ]
+                    }
+                },
+                "type": "object"
+            }
+        }
+    }
+}

--- a/tests/Model/ModelRegistryTest.php
+++ b/tests/Model/ModelRegistryTest.php
@@ -11,8 +11,11 @@
 
 namespace Nelmio\ApiDocBundle\Tests\Model;
 
+use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareInterface;
+use Nelmio\ApiDocBundle\Describer\ModelRegistryAwareTrait;
 use Nelmio\ApiDocBundle\Model\Model;
 use Nelmio\ApiDocBundle\Model\ModelRegistry;
+use Nelmio\ApiDocBundle\ModelDescriber\ModelDescriberInterface;
 use OpenApi\Annotations as OA;
 use OpenApi\Context;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -352,7 +355,7 @@ class ModelRegistryTest extends TestCase
     public function testNamespaceClashDoesNotMergeSchemas(): void
     {
         // Mock a describer that supports these models
-        $describer = $this->createMock(\Nelmio\ApiDocBundle\ModelDescriber\ModelDescriberInterface::class);
+        $describer = $this->createMock(ModelDescriberInterface::class);
         $describer->method('supports')->willReturn(true);
         $describer->method('describe')->willReturnCallback(static function ($model, $schema) {
             $schema->type = 'object';
@@ -371,5 +374,55 @@ class ModelRegistryTest extends TestCase
         $registry->registerSchemas();
 
         self::assertCount(2, $openApi->components->schemas);
+    }
+
+    // A self-referencing property carrying a #[Context] attribute registers a second model of the
+    // same type. It must get a schema of its own rather than describing into the first one's.
+    // See https://github.com/nelmio/NelmioApiDocBundle/issues/2799
+    public function testSelfReferencingContextVariantDoesNotShareASchema(): void
+    {
+        $registry = new ModelRegistry([new SelfReferencingDescriber()], $openApi = $this->createOpenApi());
+
+        self::assertEquals(
+            '#/components/schemas/Category',
+            $registry->register(new Model(Type::object('App\Entity\Category')))
+        );
+
+        $registry->registerSchemas();
+
+        self::assertSame(['Category2', 'Category'], array_column($openApi->components->schemas, 'schema'));
+        self::assertSame(
+            '#/components/schemas/Category2',
+            $openApi->components->schemas[0]->properties[0]->ref
+        );
+    }
+}
+
+/**
+ * Mimics ObjectModelDescriber for a class whose only property is a self-reference carrying a
+ * #[Context] attribute: describing it registers the same type again with a serialization context,
+ * hence under a different model hash.
+ */
+final class SelfReferencingDescriber implements ModelDescriberInterface, ModelRegistryAwareInterface
+{
+    use ModelRegistryAwareTrait;
+
+    public function describe(Model $model, OA\Schema $schema): void
+    {
+        $schema->type = 'object';
+        $schema->properties = [
+            new OA\Property([
+                'property' => 'children',
+                'ref' => $this->modelRegistry->register(new Model(
+                    Type::object('App\Entity\Category'),
+                    serializationContext: ['enable_max_depth' => true],
+                )),
+            ]),
+        ];
+    }
+
+    public function supports(Model $model): bool
+    {
+        return true;
     }
 }


### PR DESCRIPTION
## Description

Since 5.12.0, `#[Context]` on a property is parsed (#2722), so a self-referencing property gets a *different* model hash than the model it points at.

`ModelRegistry::register()` only reserves a generated name in `components->schemas` *after* recursively describing nested models, so both models were handed the same name. That gap was pre-existing; #2722 made it reachable. Both models then described into one schema, which swagger-php reports as `Multiple definitions for @OA\Property()->additionalProperties`, failing `nelmio:apidoc:dump` with exit code 1 whenever the property carries nested annotation objects (silently merged output otherwise).

Fixed by also checking `registeredModelNames` in the name-uniqueness loop.

Note that the duplicate schema itself remains: before #2722 a self-reference with `#[Context]` pointed at its own schema, now it points at a second, identical one. See `EntityWithSelfReferencingContext2` in the new fixture.


Closes https://github.com/nelmio/NelmioApiDocBundle/issues/2799

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [ ] Feature
- [ ] Refactor
- [ ] Deprecation
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI

## Checklist
- [ ] I have made corresponding changes to the documentation (`docs/`)